### PR TITLE
Add GitHub Actions CI for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel superseded runs on the same branch/PR
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Enable Corepack before setup-node so the pinned Yarn (packageManager
+      # field) is active when the yarn cache is resolved.
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn lint
+
+  test:
+    name: Tests (bun)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.16
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+      # Tests import from node_modules (React, happy-dom); install with the
+      # locked, node-modules linker Yarn is configured for.
+      - run: yarn install --immutable
+      - run: bun test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,13 @@ export default defineConfig([
     settings: { react: { version: "detect" } },
   },
   {
+    // Ambient declaration files legitimately use triple-slash directives
+    files: ["**/*.d.ts"],
+    rules: {
+      "@typescript-eslint/triple-slash-reference": "off",
+    },
+  },
+  {
     // react-three-fiber JSX elements take three.js properties (args,
     // intensity, decay, ...) that the DOM-oriented rule doesn't know
     files: ["src/space3d/**/*.{ts,tsx}"],

--- a/src/Stars.tsx
+++ b/src/Stars.tsx
@@ -212,6 +212,9 @@ const useStars = (
 };
 
 function Stars({ isLanding }: { isLanding: boolean }) {
+  // setCursorGravityRadiusPx drives the (currently commented-out) dev slider
+  // below; kept so the control can be re-enabled without rewiring state.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
   const [cursorGravityRadiusPx, setCursorGravityRadiusPx] = useState(
     DEFAULT_CURSOR_GRAVITY_RADIUS_PX,
   );

--- a/src/SvgGenerator.tsx
+++ b/src/SvgGenerator.tsx
@@ -198,8 +198,8 @@ const SvgGenerator = () => {
       }
 
       setSvgContent(svg);
-    } catch (err: any) {
-      setError(err.message || "Failed to generate SVG");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate SVG");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` with two parallel jobs, triggered on push to `master` and on all PRs:

- **ESLint** — `yarn lint` (Corepack → Yarn 4.6.0, Node 24, `yarn install --immutable`)
- **Tests (bun)** — `bun test`, the actual runner (`bunfig.toml` preloads happy-dom; `App.test.js` imports `bun:test`). The `"test": "jest"` script is stale and would fail on that import, so CI calls bun directly.

## Lint fixes (so the ESLint job is green on first run)
`yarn lint` had 4 pre-existing errors; fixed them:
- `SvgGenerator.tsx` — `catch (err: any)` → `catch (err)` with an `instanceof Error` guard
- `eslint.config.mjs` — disable `@typescript-eslint/triple-slash-reference` for ambient `**/*.d.ts` files (was flagging generated `react-app-env.d.ts`)
- `Stars.tsx` — the unused `setCursorGravityRadiusPx` drives a commented-out dev slider; kept it with a documented `eslint-disable` rather than deleting the control

## Verification
- `yarn lint` → exit 0
- `bun test` → 1 pass, exit 0
- `yarn install --immutable` → exit 0 (lockfile in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)