### PR TITLE
Focus swap: home rides the sun, about rides Earth + link asteroids & polish

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -627,14 +627,24 @@ li > ul > li {
   margin: auto;
   margin-top: 80px;
   max-width: 800px;
-  padding-left: 32px;
-  padding-right: 32px;
-  padding-bottom: 160px;
+  padding: 32px 32px 64px;
+  margin-bottom: 96px;
+
+  // Translucent, blurred panel so the text stays legible over whatever
+  // the 3D scene puts behind it (Earth's bright limb, the drifting moon)
+  background: rgba(8, 6, 28, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 16px;
 
   @media (min-width: 1280px) {
     max-width: 980px;
     margin-top: 200px;
   }
+}
+
+.App.day .resume-inner-container {
+  background: rgba(255, 255, 255, 0.55);
 }
 
 .splitRow {

--- a/src/App.scss
+++ b/src/App.scss
@@ -977,6 +977,28 @@ a:hover {
   pointer-events: none;
 }
 
+// Clickable overlays glued to projected 3D bodies (BodyAnchors positions
+// them each frame). Hidden until the first frame places them.
+.asteroid-link {
+  position: fixed;
+  visibility: hidden;
+  z-index: 3;
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.45);
+  }
+}
+
+.App.day .asteroid-link:hover,
+.App.day .asteroid-link:focus-visible {
+  box-shadow: 0 0 0 2px rgba(65, 37, 150, 0.45);
+}
+
 .App-background_day {
   background: linear-gradient(
     168deg,

--- a/src/App.scss
+++ b/src/App.scss
@@ -999,6 +999,37 @@ a:hover {
   box-shadow: 0 0 0 2px rgba(65, 37, 150, 0.45);
 }
 
+// Earth's /about ring: "About Andrew" curved over the projected Earth,
+// styled after the landing "enter" arc. The whole circle is the link.
+.earth-about-ring {
+  position: fixed;
+  visibility: hidden;
+  z-index: 3;
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: pointer;
+
+  .svg-link-tspan {
+    fill: #fff;
+  }
+
+  &:hover .svg-link-tspan,
+  &:focus-visible .svg-link-tspan {
+    fill: $purp-light;
+  }
+}
+
+.App.day .earth-about-ring {
+  .svg-link-tspan {
+    fill: $purp;
+  }
+
+  &:hover .svg-link-tspan,
+  &:focus-visible .svg-link-tspan {
+    fill: $purp-light;
+  }
+}
+
 .App-background_day {
   background: linear-gradient(
     168deg,

--- a/src/DayNightSwitch.tsx
+++ b/src/DayNightSwitch.tsx
@@ -13,7 +13,7 @@ const DayNightSwitch = ({
   onCheckedChange: (isNight: boolean) => void;
 }) => (
   <Switch.Root
-    className="day-night-switch fixed right-4 top-4 z-[5000]"
+    className="day-night-switch fixed right-12 top-4 z-[5000]"
     checked={isNightMode}
     onCheckedChange={onCheckedChange}
     aria-label={isNightMode ? "Switch to day mode" : "Switch to night mode"}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 import { GitHub, Linkedin, Mail } from "react-feather";
 import { ArrowLeftIcon, Wand2 } from "lucide-react";
 import useWindowSize from "./useWindowSize";
+import SolarOverlays from "./SolarOverlays";
 
 import {
   Tooltip,
@@ -64,6 +65,7 @@ const Home = () => {
 
   return (
     <>
+      <SolarOverlays />
       <div className="homePageBackLink">
         <Link
           className={cx("mt-4 flex items-center gap-1 transition-transform")}

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 import {
   Tooltip,
@@ -6,7 +7,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./ui/tooltip";
-import { asteroidAnchorId } from "./space3d/solar/BodyAnchors";
+import {
+  asteroidAnchorId,
+  EARTH_ABOUT_RING_ID,
+} from "./space3d/solar/BodyAnchors";
 
 /**
  * DOM overlays for the home page's 3D bodies. The canvases never take
@@ -31,6 +35,37 @@ const ASTEROID_LINKS = [
 
 const SolarOverlays = () => (
   <>
+    {/* Earth is the /about link: a ring glued around its projection with
+        "About Andrew" curved over the top, styled like the landing
+        "enter" ring. The whole circle (Earth included) is clickable. */}
+    <Link
+      to="/about"
+      id={EARTH_ABOUT_RING_ID}
+      className="earth-about-ring"
+      aria-label="About Andrew"
+    >
+      <svg viewBox="0 0 100 100" width="100%" height="100%">
+        <path
+          id="earth-about-ring-path"
+          fill="none"
+          d="
+            M 9,50
+            a 41,41 0 1,1 82,0
+            a 41,41 0 1,1 -82,0
+          "
+        />
+        <text fontFamily="'Inconsolata', monospace" textAnchor="middle">
+          <textPath
+            href="#earth-about-ring-path"
+            startOffset="25%"
+            className="svg-link-tspan"
+            fontSize="13px"
+          >
+            About Andrew
+          </textPath>
+        </text>
+      </svg>
+    </Link>
     {ASTEROID_LINKS.map((link) => (
       <TooltipProvider key={link.name} delayDuration={100}>
         <Tooltip disableHoverableContent>

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+import { asteroidAnchorId } from "./space3d/solar/BodyAnchors";
+
+/**
+ * DOM overlays for the home page's 3D bodies. The canvases never take
+ * pointer input, so every clickable body gets an invisible fixed-position
+ * element here that BodyAnchors glues to the body's projection each
+ * frame. Everything starts `visibility: hidden` (App.scss) and is
+ * revealed once positioned.
+ */
+
+const ASTEROID_LINKS = [
+  {
+    name: "recent",
+    label: "Recent blog post",
+    href: "https://engineering.ziphq.com/material-ui/",
+  },
+  {
+    name: "old",
+    label: "Old personal blog",
+    href: "https://andrew-hunt.medium.com/",
+  },
+];
+
+const SolarOverlays = () => (
+  <>
+    {ASTEROID_LINKS.map((link) => (
+      <TooltipProvider key={link.name} delayDuration={100}>
+        <Tooltip disableHoverableContent>
+          <TooltipTrigger asChild>
+            <a
+              id={asteroidAnchorId(link.name)}
+              className="asteroid-link"
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={link.label}
+            />
+          </TooltipTrigger>
+          <TooltipContent updatePositionStrategy="always">
+            <p>{link.label}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    ))}
+  </>
+);
+
+export default SolarOverlays;

--- a/src/SunSvg.tsx
+++ b/src/SunSvg.tsx
@@ -12,6 +12,11 @@ export const HOME_SUN_CX = 275;
 export const HOME_SUN_CY = 276;
 export const HOME_SUN_RADIUS = 175;
 
+// The orbiting text links are retired for now (replaced by the asteroid
+// links + the Earth "About Andrew" ring in the 3D scene) but kept
+// compiled behind this flag in case they come back.
+const SHOW_ORBITING_LINKS = false;
+
 const isSafari =
   navigator.userAgent.includes("Safari") &&
   // Chrome also has "Safari" in its user-agent string
@@ -212,7 +217,7 @@ export default function SunSvg({
           xmlnsXlink="http://www.w3.org/1999/xlink"
           xlinkHref="#circle2"
         >
-          {isHome && (
+          {SHOW_ORBITING_LINKS && isHome && (
             <>
               <Link className="planet-emoji" to="/about">
                 <tspan

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+import { planetPosition, type SolarPlanetConfig } from "./constants";
+import { createPlanetTexture } from "../textures";
+
+/**
+ * A small rocky link-asteroid: a jittered icosahedron (lumpy, flat-shaded)
+ * that slowly orbits the sun. No orbit ring — these are meant to read as
+ * floating debris, and rings would clutter the zoomed landing view. The
+ * matching DOM link overlay is glued to it by BodyAnchors via the same
+ * planetPosition() the mesh uses, so the two can't drift apart.
+ */
+export default function Asteroid({ config }: { config: SolarPlanetConfig }) {
+  const group = useRef<THREE.Group>(null);
+  const mesh = useRef<THREE.Mesh>(null);
+
+  const texture = useMemo(() => createPlanetTexture(config.kind), [config]);
+  useEffect(() => () => texture.dispose(), [texture]);
+
+  const geometry = useMemo(() => {
+    const geo = new THREE.IcosahedronGeometry(config.radius, 1);
+    // One-time deterministic radial jitter so it reads as a lumpy rock
+    // (seeded per-vertex from the position, not Math.random, so the two
+    // asteroids differ via their radii/phases but stay stable per mount)
+    const pos = geo.getAttribute("position") as THREE.BufferAttribute;
+    const v = new THREE.Vector3();
+    for (let i = 0; i < pos.count; i++) {
+      v.fromBufferAttribute(pos, i);
+      const seed = Math.sin(v.x * 91.7 + v.y * 47.3 + v.z * 13.1) * 43758.5;
+      const jitter = 1 + (seed - Math.floor(seed) - 0.5) * 0.4; // ±20%
+      v.multiplyScalar(jitter);
+      pos.setXYZ(i, v.x, v.y, v.z);
+    }
+    pos.needsUpdate = true;
+    geo.computeVertexNormals();
+    return geo;
+  }, [config.radius]);
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  useFrame(({ clock }, delta) => {
+    if (group.current) {
+      planetPosition(config, clock.elapsedTime, group.current.position);
+    }
+    if (mesh.current) {
+      mesh.current.rotation.y += delta * config.spinSpeed;
+      mesh.current.rotation.x += delta * config.spinSpeed * 0.3;
+    }
+  });
+
+  return (
+    <group ref={group}>
+      <mesh ref={mesh} geometry={geometry}>
+        <meshStandardMaterial
+          map={texture}
+          roughness={1}
+          metalness={0}
+          flatShading
+        />
+      </mesh>
+    </group>
+  );
+}

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -1,0 +1,99 @@
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+import {
+  ASTEROIDS,
+  EARTH,
+  planetPosition,
+  type SolarPlanetConfig,
+} from "./constants";
+import { projectBody, type ProjectedBody } from "./projection";
+import { liveElementById } from "../svgTracking";
+
+/**
+ * Glues DOM overlay elements to projected 3D bodies (the inverse-gluing
+ * pattern SunSvgAnchor established, generalized): every frame each
+ * configured body is projected through the camera and its overlay —
+ * looked up by id — is positioned and sized around it. Absent elements
+ * are skipped, so route scoping comes for free: the overlays are
+ * rendered by home-page components and simply don't exist elsewhere.
+ *
+ * Overlays should default to `visibility: hidden` in CSS; the anchor
+ * reveals them once positioned (and hides them again while the body is
+ * behind the camera mid-swoop).
+ */
+
+export const EARTH_ABOUT_RING_ID = "earth-about-ring";
+export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;
+
+interface BodyAnchorConfig {
+  domId: string;
+  position: (t: number, out: THREE.Vector3) => THREE.Vector3;
+  radius: number;
+  /** Overlay diameter as a multiple of the body's projected diameter */
+  ringScale: number;
+  /** Floor on the overlay's CSS size, px (legibility / hit target) */
+  minSizePx: number;
+}
+
+const asteroidConfig = (asteroid: SolarPlanetConfig): BodyAnchorConfig => ({
+  domId: asteroidAnchorId(asteroid.name),
+  position: (t, out) => planetPosition(asteroid, t, out),
+  radius: asteroid.radius,
+  ringScale: 1.4,
+  minSizePx: 36,
+});
+
+const ANCHORS: BodyAnchorConfig[] = [
+  {
+    domId: EARTH_ABOUT_RING_ID,
+    position: (t, out) => planetPosition(EARTH, t, out),
+    radius: EARTH.radius,
+    ringScale: 1.3,
+    minSizePx: 140,
+  },
+  ...ASTEROIDS.map(asteroidConfig),
+];
+
+const worldPos = new THREE.Vector3();
+const projected: ProjectedBody = { x: 0, y: 0, projR: 0, inFront: false };
+
+const BodyAnchors = () => {
+  const size = useThree((s) => s.size);
+
+  useFrame(({ camera, clock }) => {
+    const persp = camera as THREE.PerspectiveCamera;
+    // CameraRig moved the camera earlier this frame; refresh its inverse
+    // matrix so projections don't lag a frame behind during swoops
+    persp.updateMatrixWorld();
+    const t = clock.elapsedTime;
+
+    for (const anchor of ANCHORS) {
+      const el = liveElementById(anchor.domId) as HTMLElement | null;
+      if (!el) continue;
+
+      anchor.position(t, worldPos);
+      projectBody(persp, size, worldPos, anchor.radius, projected);
+
+      if (!projected.inFront) {
+        el.style.visibility = "hidden";
+        continue;
+      }
+      const sizePx = Math.max(
+        2 * projected.projR * anchor.ringScale,
+        anchor.minSizePx,
+      );
+      el.style.position = "fixed";
+      el.style.margin = "0";
+      el.style.left = `${projected.x - sizePx / 2}px`;
+      el.style.top = `${projected.y - sizePx / 2}px`;
+      el.style.width = `${sizePx}px`;
+      el.style.height = `${sizePx}px`;
+      el.style.visibility = "visible";
+    }
+  });
+
+  return null;
+};
+
+export default BodyAnchors;

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -18,7 +18,10 @@ import { EARTH, moonPosition, planetPosition } from "./constants";
 
 export type SolarView = "landing" | "home" | "about";
 
-const LANDING_POS = new THREE.Vector3(0, 58, 0.01);
+// Height tuned so Earth's orbit (r 17.5) nearly reaches the bottom edge
+// (~16px margin on a laptop): visible half-height = tan(fov/2)·y ≈ .52·35.
+// Mars' orbit clips top/bottom at this zoom — intentional.
+const LANDING_POS = new THREE.Vector3(0, 35, 0.01);
 const ORIGIN = new THREE.Vector3(0, 0, 0);
 const UP = new THREE.Vector3(0, 1, 0);
 const TRANSITION_SECONDS = 3.2;

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -2,17 +2,17 @@ import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
-import { EARTH, moonPosition, planetPosition } from "./constants";
+import { EARTH, MOON, planetPosition } from "./constants";
 
 /**
  * Camera choreography, ported from hunt-codes-3. Landing hovers straight
- * above the sun (the system reads as a flat orbital diagram); home
- * perches just behind/above Earth on the far side from the sun, so
- * Earth's limb fills the bottom of the frame with the sun hanging above
- * the horizon while the other planets keep orbiting it. About perches
- * over the moon's far side looking back at Earth, so the moon's top curve
- * fills the foreground and Earth hangs in the background as the moon
- * orbits — carrying the camera with it. View changes swoop between the
+ * above the sun (the system reads as a flat orbital diagram). Home
+ * perches just over the SUN's limb looking out toward Earth, so the
+ * sun's top curve fills the bottom of the frame with mostly stars above
+ * and Earth (moon alongside) hanging small in the middle distance. About
+ * perches over EARTH's limb looking anti-sunward at the moon's orbit
+ * band, so Earth's top curve fills the foreground and the moon drifts
+ * through the background as it circles. View changes swoop between the
  * views over a few seconds; once arrived the camera rides the moving goal.
  */
 
@@ -26,79 +26,72 @@ const ORIGIN = new THREE.Vector3(0, 0, 0);
 const UP = new THREE.Vector3(0, 1, 0);
 const TRANSITION_SECONDS = 3.2;
 
-// Home-view framing. The camera hugs Earth so closely that its limb
-// spans the whole bottom of the frame (Earth reads ~2x the viewport
-// wide), drifted slightly left; the sun is pinned a fixed fraction of
-// the viewport right of center.
-const HOME_CAM_BEHIND = 0.85; // from Earth's center, away from the sun
-const HOME_CAM_ABOVE = 1.8;
-const HOME_CAM_SIDE = 0.55; // camera right => Earth drifts screen-left
-const HOME_LOOK_HEIGHT = 2.1;
-/** Sun's horizontal screen position: +0.4 of the half-width = ~20vw right */
-const HOME_SUN_SCREEN_X = 0.4;
+// Home-view framing: the sun-perch. Offsets from the SUN's center (r 3),
+// on the far side from Earth, elevated — camera ends up ~0.9 above the
+// surface (well clear of the 0.1 near plane) with the sun's limb filling
+// the bottom third and Earth ~9deg wide in the middle distance.
+const HOME_CAM_BEHIND = 1.6; // away from Earth
+const HOME_CAM_ABOVE = 3.4;
+const HOME_CAM_SIDE = 1; // camera right => sun apex drifts screen-left
+const HOME_LOOK_HEIGHT = 3; // raise the aim so Earth sits below center
 
-// About-view framing: hug the moon (offsets from its center, not its
-// surface) on the side facing away from Earth, so the moon's top curve
-// fills the foreground and Earth hangs beyond it. Camera ends up ~1.5
-// moon-radii out — clear of the 0.1 near-plane, tight enough that the
-// moon over-fills the frame like Earth does on home.
-const ABOUT_CAM_BEHIND = 0.38; // away from Earth
-const ABOUT_CAM_ABOVE = 0.46;
-const ABOUT_CAM_SIDE = 0.2;
-const ABOUT_LOOK_HEIGHT = 0.35; // aim a touch above Earth's center
+// About-view framing: the Earth-perch (same proven offsets the old home
+// view used), now placed on the SUNWARD side of Earth because the camera
+// looks anti-sunward at the moon's orbit band. The aim is a stable point
+// on that band — NOT the moon itself, whose closest approach would slew
+// the camera ~20deg/s — so the moon drifts through frame twice per orbit,
+// growing as it passes near the camera.
+const ABOUT_CAM_BEHIND = 0.85; // from Earth's center, toward the sun
+const ABOUT_CAM_ABOVE = 1.8;
+const ABOUT_CAM_SIDE = 0.55;
+const ABOUT_LOOK_HEIGHT = 1.2;
 
 // scratch vectors, reused every frame
 const goalPos = new THREE.Vector3();
 const goalLook = new THREE.Vector3();
-const planetPos = new THREE.Vector3();
-const moonPos = new THREE.Vector3();
 const earthPos = new THREE.Vector3();
-const toSun = new THREE.Vector3();
 const toEarth = new THREE.Vector3();
+const antiSun = new THREE.Vector3();
+const viewDir = new THREE.Vector3();
 const side = new THREE.Vector3();
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
 
 /** Camera pos/look for a view at elapsed time t, written into goalPos/goalLook. */
-function computeGoal(view: SolarView, t: number, camera: THREE.Camera) {
+function computeGoal(view: SolarView, t: number) {
   if (view === "landing") {
     goalPos.copy(LANDING_POS);
     goalLook.copy(ORIGIN);
   } else if (view === "about") {
-    // Perch over the moon's limb on the far side from Earth, looking back
-    // at Earth: the moon's top curve fills the foreground, Earth sits in
-    // the background, and both drift as the moon orbits.
-    moonPosition(t, moonPos);
+    // Perch over Earth's limb on the sunward side, looking anti-sunward:
+    // Earth's top curve fills the bottom of the frame and the moon drifts
+    // through the background as it orbits.
     planetPosition(EARTH, t, earthPos);
-    toEarth.copy(earthPos).sub(moonPos).normalize();
-    side.crossVectors(toEarth, UP).normalize();
+    antiSun.copy(earthPos).normalize(); // away from the sun (origin)
+    side.crossVectors(antiSun, UP).normalize();
     goalPos
-      .copy(moonPos)
-      .addScaledVector(toEarth, -ABOUT_CAM_BEHIND)
+      .copy(earthPos)
+      .addScaledVector(antiSun, -ABOUT_CAM_BEHIND)
       .addScaledVector(side, ABOUT_CAM_SIDE);
     goalPos.y += ABOUT_CAM_ABOVE;
-    goalLook.copy(earthPos);
+    // Stable aim at the moon's orbit band (not the moon itself)
+    goalLook.copy(earthPos).addScaledVector(antiSun, MOON.orbitRadius);
     goalLook.y += ABOUT_LOOK_HEIGHT;
   } else {
-    // Perch just over Earth's limb on the far side from the sun, looking
-    // sunward: Earth's top curve fills the bottom of the frame.
-    planetPosition(EARTH, t, planetPos);
-    toSun.copy(planetPos).negate().normalize();
-    side.crossVectors(toSun, UP).normalize(); // screen-right, looking sunward
+    // Perch just over the sun's limb on the far side from Earth, looking
+    // out at the stars: the sun's top curve fills the bottom of the frame
+    // and Earth (with its moon) hangs small in the middle distance.
+    planetPosition(EARTH, t, earthPos);
+    toEarth.copy(earthPos).normalize();
+    side.crossVectors(toEarth, UP).normalize();
     goalPos
-      .copy(planetPos)
-      .addScaledVector(toSun, -HOME_CAM_BEHIND)
+      .set(0, 0, 0)
+      .addScaledVector(toEarth, -HOME_CAM_BEHIND)
       .addScaledVector(side, HOME_CAM_SIDE);
     goalPos.y += HOME_CAM_ABOVE;
-
-    // Aim left of the sun by the angle that lands it HOME_SUN_SCREEN_X of
-    // the half-width right of center, whatever the viewport aspect
-    const persp = camera as THREE.PerspectiveCamera;
-    const halfFovH =
-      Math.tan((persp.fov * Math.PI) / 360) * (persp.aspect || 1);
-    const lateral = goalPos.length() * HOME_SUN_SCREEN_X * halfFovH;
-    goalLook.set(0, HOME_LOOK_HEIGHT, 0).addScaledVector(side, -lateral);
+    goalLook.copy(earthPos);
+    goalLook.y += HOME_LOOK_HEIGHT;
   }
 }
 
@@ -116,11 +109,11 @@ export default function CameraRig({ view }: { view: SolarView }) {
       activeView.current = view;
       transitionStart.current = t;
       fromPos.current.copy(camera.position);
-      camera.getWorldDirection(toSun);
-      fromLook.current.copy(camera.position).addScaledVector(toSun, 20);
+      camera.getWorldDirection(viewDir);
+      fromLook.current.copy(camera.position).addScaledVector(viewDir, 20);
     }
 
-    computeGoal(view, t, camera);
+    computeGoal(view, t);
 
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
     if (p < 1) {

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -40,7 +40,10 @@ const SolarScene = ({
       <ambientLight intensity={0.14} />
       {/* From the home sun-perch the full glow would fill the frame and
           wash out the stars — shrink it to hug the limb there */}
-      <Sun targetGlowScale={view === "home" ? 2.5 : 6} />
+      <Sun
+        targetGlowScale={view === "home" ? 2.5 : 6}
+        isNightMode={isNightMode}
+      />
       {PLANETS.map((planet) => (
         <Planet
           key={planet.name}

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -5,8 +5,10 @@ import CameraRig, { type SolarView } from "./CameraRig";
 import Planet from "./Planet";
 import Moon from "./Moon";
 import Sun from "./Sun";
+import Asteroid from "./Asteroid";
 import SunSvgAnchor from "./SunSvgAnchor";
-import { PLANETS } from "./constants";
+import BodyAnchors from "./BodyAnchors";
+import { ASTEROIDS, PLANETS } from "./constants";
 
 /**
  * The perspective solar-system canvas (hunt-codes-3's scene), layered
@@ -57,8 +59,12 @@ const SolarScene = ({
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.08 : 0.2}
       />
+      {ASTEROIDS.map((asteroid) => (
+        <Asteroid key={asteroid.name} config={asteroid} />
+      ))}
       <CameraRig view={view} />
       <SunSvgAnchor />
+      <BodyAnchors />
     </Canvas>
   );
 };

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -38,8 +38,9 @@ const SolarScene = ({
       gl={{ alpha: true, antialias: true }}
     >
       <ambientLight intensity={0.14} />
-      {/* The sun reads a bit larger on the home page */}
-      <Sun targetScale={view === "home" ? 1.4 : 1} />
+      {/* From the home sun-perch the full glow would fill the frame and
+          wash out the stars — shrink it to hug the limb there */}
+      <Sun targetGlowScale={view === "home" ? 2.5 : 6} />
       {PLANETS.map((planet) => (
         <Planet
           key={planet.name}

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -9,13 +9,23 @@ import { createSunGlowTexture, createSunTexture } from "../textures";
  * The sun, ported from hunt-codes-3: a slowly rotating sphere with the
  * mottled golden canvas texture, a soft glow sprite (billboarded, so the
  * corona reads from any camera angle), and the point light that lights
- * the planets. The whole group eases toward a per-view scale (the home
- * view shows it a bit larger) and publishes the rendered scale so the
- * DOM rings can track it.
+ * the planets. The whole group eases toward a per-view scale and
+ * publishes the rendered scale so the DOM rings can track it; the glow
+ * sprite eases toward a per-view size too — from the home sun-perch the
+ * full 6x glow would span the whole frame and wash out the stars, so
+ * that view shrinks it to hug the limb.
  */
-export default function Sun({ targetScale = 1 }: { targetScale?: number }) {
+export default function Sun({
+  targetScale = 1,
+  targetGlowScale = 6,
+}: {
+  targetScale?: number;
+  /** Glow sprite size as a multiple of SUN_RADIUS (eased) */
+  targetGlowScale?: number;
+}) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const glow = useRef<THREE.Sprite>(null);
   const texture = useMemo(() => createSunTexture(), []);
   const glowTexture = useMemo(() => createSunGlowTexture(), []);
 
@@ -29,12 +39,18 @@ export default function Sun({ targetScale = 1 }: { targetScale?: number }) {
 
   useFrame((_, delta) => {
     if (mesh.current) mesh.current.rotation.y += delta * 0.04;
+    const ease = Math.min(1, delta * 2.5);
     if (group.current) {
       const current = group.current.scale.x;
-      const next =
-        current + (targetScale - current) * Math.min(1, delta * 2.5);
+      const next = current + (targetScale - current) * ease;
       group.current.scale.setScalar(next);
       sunState.scale = next;
+    }
+    if (glow.current) {
+      const target = SUN_RADIUS * targetGlowScale;
+      const current = glow.current.scale.x;
+      const next = current + (target - current) * ease;
+      glow.current.scale.set(next, next, 1);
     }
   });
 
@@ -45,7 +61,7 @@ export default function Sun({ targetScale = 1 }: { targetScale?: number }) {
         <meshBasicMaterial map={texture} toneMapped={false} />
       </mesh>
       {/* soft corona billboard */}
-      <sprite scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>
+      <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>
         <spriteMaterial
           map={glowTexture}
           transparent

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -15,17 +15,27 @@ import { createSunGlowTexture, createSunTexture } from "../textures";
  * full 6x glow would span the whole frame and wash out the stars, so
  * that view shrinks it to hug the limb.
  */
+// Surface brightness multipliers (meshBasicMaterial.color, toneMapped
+// off, so components >1 push the texture toward white). Day mode reads
+// noticeably brighter/whiter against the light gradient; night gets a
+// subtler lift.
+const DAY_TINT = new THREE.Color(1.55, 1.55, 1.7);
+const NIGHT_TINT = new THREE.Color(1.12, 1.12, 1.15);
+
 export default function Sun({
   targetScale = 1,
   targetGlowScale = 6,
+  isNightMode,
 }: {
   targetScale?: number;
   /** Glow sprite size as a multiple of SUN_RADIUS (eased) */
   targetGlowScale?: number;
+  isNightMode: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const glow = useRef<THREE.Sprite>(null);
+  const materialRef = useRef<THREE.MeshBasicMaterial>(null);
   const texture = useMemo(() => createSunTexture(), []);
   const glowTexture = useMemo(() => createSunGlowTexture(), []);
 
@@ -52,13 +62,20 @@ export default function Sun({
       const next = current + (target - current) * ease;
       glow.current.scale.set(next, next, 1);
     }
+    if (materialRef.current) {
+      // Ease the brightness so the mode toggle doesn't pop
+      materialRef.current.color.lerp(
+        isNightMode ? NIGHT_TINT : DAY_TINT,
+        ease,
+      );
+    }
   });
 
   return (
     <group ref={group}>
       <mesh ref={mesh}>
         <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
-        <meshBasicMaterial map={texture} toneMapped={false} />
+        <meshBasicMaterial ref={materialRef} map={texture} toneMapped={false} />
       </mesh>
       {/* soft corona billboard */}
       <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -36,19 +36,29 @@ export default function Sun({
   const mesh = useRef<THREE.Mesh>(null);
   const glow = useRef<THREE.Sprite>(null);
   const materialRef = useRef<THREE.MeshBasicMaterial>(null);
+  const spotsMaterialRef = useRef<THREE.MeshBasicMaterial>(null);
   const texture = useMemo(() => createSunTexture(), []);
+  // A second, independently-random blotch layer: crossfading it in and
+  // out over the base makes the surface spots slowly shift
+  const spotsTexture = useMemo(() => createSunTexture(), []);
   const glowTexture = useMemo(() => createSunGlowTexture(), []);
 
   useEffect(
     () => () => {
       texture.dispose();
+      spotsTexture.dispose();
       glowTexture.dispose();
     },
-    [texture, glowTexture],
+    [texture, spotsTexture, glowTexture],
   );
 
-  useFrame((_, delta) => {
+  useFrame(({ clock }, delta) => {
     if (mesh.current) mesh.current.rotation.y += delta * 0.04;
+    if (spotsMaterialRef.current) {
+      // Slow morph between the two blotch patterns (~30s round trip)
+      spotsMaterialRef.current.opacity =
+        0.5 + 0.5 * Math.sin((clock.elapsedTime * Math.PI * 2) / 30);
+    }
     const ease = Math.min(1, delta * 2.5);
     if (group.current) {
       const current = group.current.scale.x;
@@ -63,11 +73,15 @@ export default function Sun({
       glow.current.scale.set(next, next, 1);
     }
     if (materialRef.current) {
-      // Ease the brightness so the mode toggle doesn't pop
+      // Ease the brightness so the mode toggle doesn't pop; the spot
+      // layer follows the same tint or the crossfade would pulse dark
       materialRef.current.color.lerp(
         isNightMode ? NIGHT_TINT : DAY_TINT,
         ease,
       );
+      if (spotsMaterialRef.current) {
+        spotsMaterialRef.current.color.copy(materialRef.current.color);
+      }
     }
   });
 
@@ -76,6 +90,18 @@ export default function Sun({
       <mesh ref={mesh}>
         <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
         <meshBasicMaterial ref={materialRef} map={texture} toneMapped={false} />
+        {/* Crossfading spot layer, drawn just over the base surface */}
+        <mesh scale={1.001} renderOrder={1}>
+          <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
+          <meshBasicMaterial
+            ref={spotsMaterialRef}
+            map={spotsTexture}
+            toneMapped={false}
+            transparent
+            opacity={0}
+            depthWrite={false}
+          />
+        </mesh>
       </mesh>
       {/* soft corona billboard */}
       <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>

--- a/src/space3d/solar/SunSvgAnchor.tsx
+++ b/src/space3d/solar/SunSvgAnchor.tsx
@@ -80,9 +80,15 @@ const SunSvgAnchor = () => {
         const el = svg.querySelector<SVGElement>(`#${id}`);
         if (el) el.style.fill = "";
       });
-      ["position", "left", "top", "width", "height", "margin"].forEach(
-        (prop) => svg.style.removeProperty(prop),
-      );
+      [
+        "position",
+        "left",
+        "top",
+        "width",
+        "height",
+        "margin",
+        "visibility",
+      ].forEach((prop) => svg.style.removeProperty(prop));
     };
 
     const adopt = (svg: SVGSVGElement) => {
@@ -120,6 +126,16 @@ const SunSvgAnchor = () => {
       return;
     }
     if (el !== adoptedRef.current) helpers.adopt(el);
+
+    // The home view now perches ON the sun, so gluing the home links svg
+    // to the projected disc would create a viewport-dwarfing element.
+    // Adopt it (blank the disc, keep the no-WebGL fallback hand-off) but
+    // hide it instead of sizing it; its links live elsewhere now.
+    if (!landing) {
+      el.style.visibility = "hidden";
+      return;
+    }
+    el.style.visibility = "";
 
     // Project the sun's center (world origin) to CSS pixels
     projected.set(0, 0, 0).project(camera);

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -73,6 +73,34 @@ export const PLANETS: SolarPlanetConfig[] = [
 
 export const EARTH = PLANETS.find((p) => p.name === "Earth")!;
 
+/**
+ * Link asteroids: small rocks that float near the sun in the home view.
+ * They're near-co-orbital with Earth on purpose — the home camera's look
+ * direction sweeps around with Earth, so a truly slow asteroid would be
+ * out of frame most of the time. With orbit speeds close to Earth's,
+ * they drift across the view VERY slowly (relative ~0.01 rad/s).
+ */
+export const ASTEROIDS: SolarPlanetConfig[] = [
+  {
+    name: "recent",
+    kind: "mercury",
+    radius: 0.28,
+    orbitRadius: 5.2,
+    orbitSpeed: 0.082,
+    orbitPhase: EARTH.orbitPhase + 0.35,
+    spinSpeed: 0.6,
+  },
+  {
+    name: "old",
+    kind: "mercury",
+    radius: 0.22,
+    orbitRadius: 9.8,
+    orbitSpeed: 0.098,
+    orbitPhase: EARTH.orbitPhase - 0.3,
+    spinSpeed: -0.45,
+  },
+];
+
 /** Earth's moon — orbits Earth (not the sun), in the same XZ plane. */
 export const MOON = {
   radius: 0.42,

--- a/src/space3d/solar/projection.ts
+++ b/src/space3d/solar/projection.ts
@@ -1,0 +1,44 @@
+import * as THREE from "three";
+
+/**
+ * Shared camera->screen projection for the DOM overlays that ride 3D
+ * bodies (the sun rings, the Earth "About Andrew" ring, the asteroid
+ * links). Positions come out in CSS pixels; projR is the body's apparent
+ * radius on screen.
+ */
+
+export interface ProjectedBody {
+  /** CSS px of the body's center */
+  x: number;
+  y: number;
+  /** Apparent radius of the body, CSS px */
+  projR: number;
+  /** False when the body is behind the camera (project() mirrors those
+   *  coordinates, which would teleport overlays during swoops) */
+  inFront: boolean;
+}
+
+const camSpace = new THREE.Vector3();
+const ndc = new THREE.Vector3();
+
+export function projectBody(
+  camera: THREE.PerspectiveCamera,
+  size: { width: number; height: number },
+  worldPos: THREE.Vector3,
+  worldRadius: number,
+  out: ProjectedBody,
+): ProjectedBody {
+  camSpace.copy(worldPos).applyMatrix4(camera.matrixWorldInverse);
+  out.inFront = camSpace.z < -camera.near;
+
+  ndc.copy(worldPos).project(camera);
+  out.x = (ndc.x * 0.5 + 0.5) * size.width;
+  out.y = (0.5 - ndc.y * 0.5) * size.height;
+
+  const distance = camera.position.distanceTo(worldPos);
+  out.projR =
+    (worldRadius / Math.max(distance, 1e-6) /
+      Math.tan((camera.fov * Math.PI) / 360)) *
+    (size.height / 2);
+  return out;
+}


### PR DESCRIPTION
## What changed

Eight features, one commit each:

### Camera / staging
- **Landing zoomed in** — camera height 58 → 35: the sun and "enter" are much larger, Earth's orbit sits ~16px from the bottom edge on a laptop. (Mars' orbit clips top/bottom at this zoom — intentional.)
- **View focus swap**:
  - **Home** now perches just over the **sun's** limb looking out at the stars — the sun's top curve fills the bottom of the frame, Earth (with its moon alongside) hangs small in the middle distance.
  - **About** perches over **Earth's** limb on the sunward side looking anti-sunward: Earth's lit curve fills the foreground and the moon drifts through the background twice per orbit (the aim is a stable point on the moon's orbit band, not the moon itself, whose closest approach would slew the camera ~20°/s).
  - Supporting: the sun's home `targetScale` (1.4) is gone (it would swallow the new perch), the glow sprite eases to 2.5× radius on home (the full 6× glow spanned the whole frame), and the old home links ring is hidden rather than glued (it would now be a ~4000px DOM element).

### Links
- **Sun's orbiting text links retired** (kept compiled behind a `SHOW_ORBITING_LINKS` flag). Replaced by:
  - **Two clickable asteroids** — lumpy jittered icosahedrons orbiting the sun near-co-orbitally with Earth so they drift across the home view very slowly. Each carries an invisible circular `<a>` glued to its projection with a Radix tooltip ("Recent blog post" / "Old personal blog").
  - **Earth is the /about link** — an "About Andrew" ring curved over Earth's projection, styled like the landing "enter" arc, with a 140px minimum size for legibility. The whole circle (Earth included) is clickable.
  - Infrastructure: a shared `projectBody()` helper (with a behind-camera check so overlays don't teleport mid-swoop) + a config-driven `BodyAnchors` that generalizes SunSvgAnchor's inverse-gluing; DOM overlays live in `SolarOverlays` (home route only).

### Visual polish
- **Sun brighter per mode** — day mode pushes the surface toward white (reads clearly as a sun against the light gradient); night gets a subtler lift. Eased so the toggle doesn't pop.
- **Animated sun spots** — a second random blotch texture crossfades over the surface (~30s period) so the spots slowly shift.
- **Day/night switch moved 32px left** (`right-4` → `right-12`).
- **Resume text panel** — `.resume-inner-container` is now a frosted panel (dark translucent + backdrop blur at night, light by day); the scene reads through the blur while the words stay legible.

## Verified (≤2 min per feature)
- Landing zoom/framing, both new camera views + the home↔about swoop endpoints, day-mode sun brightness, toggle at 48px, asteroid hrefs + a live tooltip open, "About Andrew" ring glued to Earth + click navigates to /about, resume panel in both modes. Lint (0), tsc, bun test, and production build all pass.

## Please test manually (limited-budget items)
- **Sun spot morphing** (F8): verified by code/typecheck only — watch the sun ~30s to confirm spots visibly shift and nothing flickers.
- **Real-time swoop smoothness** for landing↔home↔about (my environment steps frames; endpoints verified, motion not).
- **Asteroid drift + hover feel** over minutes: rocks stay near-frame, tooltips track the drifting rocks, hover ring reads OK in both modes.
- **Moon pass-through on /about** in real time (it grows dramatically as it passes near the camera — check it doesn't feel too fast).
- **Mobile/small viewports** for all of the above, especially the landing zoom (Mars orbit clipping) and the Earth ring size.
- **Day-mode home**: sun brightness + asteroid hover ring against the light gradient.

🤖 Generated with Claude Code