### PR TITLE
Slow sun spin, reframe home Earth, static asteroids, hover glow

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -116,7 +116,6 @@ $breakpoint-lg: 1280px;
       fill: white;
       font-weight: 400;
       transition: fill 0.1s;
-      text-decoration: underline;
     }
   }
 }
@@ -867,6 +866,13 @@ a:hover {
   //   url(./cursor_pointer.png) 16 0,
   //   auto;
   cursor: pointer;
+}
+
+// Planet ring links ("ENTER", "ABOUT ANDREW"): no underline — the planet
+// glows on hover instead
+#solar-system a:hover,
+.earth-about-ring:hover {
+  text-decoration: none;
 }
 
 @keyframes spin {

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { SunInternals } from "SunSvg";
+import { hoverState } from "./solarHover";
 import { useOrbitalAnimation } from "./hooks/useOrbitalAnimation";
 import {
   PLANET_CONFIGS,
@@ -57,6 +58,15 @@ const Landing = () => {
     hasPlayedIntro = true;
   }, []);
 
+  // Clicking ENTER navigates away without a pointerleave — don't leave
+  // the sun's hover glow stuck on
+  useEffect(
+    () => () => {
+      hoverState.sun = false;
+    },
+    [],
+  );
+
   return (
     <div className="landing-page">
       <svg
@@ -95,7 +105,15 @@ const Landing = () => {
           </radialGradient>
         </defs>
 
-        <Link to="/home">
+        <Link
+          to="/home"
+          onPointerEnter={() => {
+            hoverState.sun = true;
+          }}
+          onPointerLeave={() => {
+            hoverState.sun = false;
+          }}
+        >
           <SunInternals size={SUN_SIZE} radiusOffset={SUN_RADIUS_OFFSET} />
           <text fontFamily="'Retro Floral', 'Inconsolata', monospace">
             <textPath

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -11,6 +11,7 @@ import {
   asteroidAnchorId,
   EARTH_ABOUT_RING_ID,
 } from "./space3d/solar/BodyAnchors";
+import { hoverState } from "./solarHover";
 
 /**
  * DOM overlays for the home page's 3D bodies. The canvases never take
@@ -33,59 +34,79 @@ const ASTEROID_LINKS = [
   },
 ];
 
-const SolarOverlays = () => (
-  <>
-    {/* Earth is the /about link: a ring glued around its projection with
+const SolarOverlays = () => {
+  // Clicking the ring navigates away without a pointerleave — don't
+  // leave Earth's hover glow stuck on
+  React.useEffect(
+    () => () => {
+      hoverState.earth = false;
+    },
+    [],
+  );
+
+  return (
+    <>
+      {/* Earth is the /about link: a ring glued around its projection with
         "About Andrew" curved over the top, styled like the landing
         "enter" ring. The whole circle (Earth included) is clickable. */}
-    <Link
-      to="/about"
-      id={EARTH_ABOUT_RING_ID}
-      className="earth-about-ring"
-      aria-label="About Andrew"
-    >
-      <svg viewBox="0 0 100 100" width="100%" height="100%">
-        <path
-          id="earth-about-ring-path"
-          fill="none"
-          d="
+      <Link
+        to="/about"
+        id={EARTH_ABOUT_RING_ID}
+        className="earth-about-ring"
+        aria-label="About Andrew"
+        onPointerEnter={() => {
+          hoverState.earth = true;
+        }}
+        onPointerLeave={() => {
+          hoverState.earth = false;
+        }}
+      >
+        <svg viewBox="0 0 100 100" width="100%" height="100%">
+          <path
+            id="earth-about-ring-path"
+            fill="none"
+            d="
             M 9,50
             a 41,41 0 1,1 82,0
             a 41,41 0 1,1 -82,0
           "
-        />
-        <text fontFamily="'Retro Floral', 'Inconsolata', monospace" textAnchor="middle">
-          <textPath
-            href="#earth-about-ring-path"
-            startOffset="25%"
-            className="svg-link-tspan"
-            fontSize="13px"
+          />
+          <text
+            fontFamily="'Retro Floral', 'Inconsolata', monospace"
+            textAnchor="middle"
           >
-            ABOUT ANDREW
-          </textPath>
-        </text>
-      </svg>
-    </Link>
-    {ASTEROID_LINKS.map((link) => (
-      <TooltipProvider key={link.name} delayDuration={100}>
-        <Tooltip disableHoverableContent>
-          <TooltipTrigger asChild>
-            <a
-              id={asteroidAnchorId(link.name)}
-              className="asteroid-link"
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={link.label}
-            />
-          </TooltipTrigger>
-          <TooltipContent updatePositionStrategy="always">
-            <p>{link.label}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    ))}
-  </>
-);
+            <textPath
+              href="#earth-about-ring-path"
+              startOffset="25%"
+              className="svg-link-tspan"
+              fontSize="13px"
+            >
+              ABOUT ANDREW
+            </textPath>
+          </text>
+        </svg>
+      </Link>
+      {ASTEROID_LINKS.map((link) => (
+        <TooltipProvider key={link.name} delayDuration={100}>
+          <Tooltip disableHoverableContent>
+            <TooltipTrigger asChild>
+              <a
+                id={asteroidAnchorId(link.name)}
+                className="asteroid-link"
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={link.label}
+              />
+            </TooltipTrigger>
+            <TooltipContent updatePositionStrategy="always">
+              <p>{link.label}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ))}
+    </>
+  );
+};
 
 export default SolarOverlays;

--- a/src/SunSvg.tsx
+++ b/src/SunSvg.tsx
@@ -161,7 +161,6 @@ export function SunInternals({
             fill: black;
             font-weight: 400;
             transition: fill 0.1s;
-            text-decoration: underline;
 
             &:hover {
               fill: #7400b3;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -1,0 +1,8 @@
+/**
+ * Hover flags for the planet-link overlays, bridged into the WebGL scene
+ * (the DOM sets them; Sun/Planet read them per frame to ease their glow
+ * up). Lives in its own three-free module so main-chunk components
+ * (Landing, SolarOverlays) can import it without dragging three.js out
+ * of its lazy chunk.
+ */
+export const hoverState = { sun: false, earth: false };

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -33,7 +33,12 @@ const TRANSITION_SECONDS = 3.2;
 const HOME_CAM_BEHIND = 1.6; // away from Earth
 const HOME_CAM_ABOVE = 3.4;
 const HOME_CAM_SIDE = 1; // camera right => sun apex drifts screen-left
-const HOME_LOOK_HEIGHT = 3; // raise the aim so Earth sits below center
+// Earth's screen spot: on lg+ screens, pixel offsets from the viewport
+// center; below that, fixed viewport fractions (same look, scaled down)
+const HOME_EARTH_RIGHT_PX = 300;
+const HOME_EARTH_UP_PX = 120;
+const HOME_EARTH_NDC_X_SMALL = 0.4;
+const HOME_EARTH_NDC_Y_SMALL = 0.28;
 
 // About-view framing: the Earth-perch, placed on the side of Earth
 // OPPOSITE the moon and co-rotating with the moon's orbit (the same way
@@ -71,7 +76,7 @@ function computeGoal(
   view: SolarView,
   t: number,
   camera: THREE.Camera,
-  viewportWidth: number,
+  viewport: { width: number; height: number },
 ) {
   if (view === "landing") {
     goalPos.copy(LANDING_POS);
@@ -84,7 +89,7 @@ function computeGoal(
     moonPosition(t, moonPos);
     moonDir.copy(moonPos).sub(earthPos).normalize();
     side.crossVectors(moonDir, UP).normalize();
-    const centered = viewportWidth < LG_BREAKPOINT_PX;
+    const centered = viewport.width < LG_BREAKPOINT_PX;
     goalPos
       .copy(earthPos)
       .addScaledVector(moonDir, -ABOUT_CAM_BEHIND)
@@ -100,8 +105,7 @@ function computeGoal(
       const persp = camera as THREE.PerspectiveCamera;
       const tanHalfH =
         Math.tan((persp.fov * Math.PI) / 360) * (persp.aspect || 1);
-      const lateral =
-        goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
+      const lateral = goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
       goalLook.addScaledVector(side, -lateral);
     }
   } else {
@@ -116,8 +120,21 @@ function computeGoal(
       .addScaledVector(toEarth, -HOME_CAM_BEHIND)
       .addScaledVector(side, HOME_CAM_SIDE);
     goalPos.y += HOME_CAM_ABOVE;
-    goalLook.copy(earthPos);
-    goalLook.y += HOME_LOOK_HEIGHT;
+    // Aim so Earth lands right of and above the viewport center (aiming
+    // left of / below a body pushes it right / up on screen)
+    const persp = camera as THREE.PerspectiveCamera;
+    const tanHalfV = Math.tan((persp.fov * Math.PI) / 360);
+    const tanHalfH = tanHalfV * (persp.aspect || 1);
+    const lg = viewport.width >= LG_BREAKPOINT_PX;
+    const ndcX = lg
+      ? HOME_EARTH_RIGHT_PX / (viewport.width / 2)
+      : HOME_EARTH_NDC_X_SMALL;
+    const ndcY = lg
+      ? HOME_EARTH_UP_PX / (viewport.height / 2)
+      : HOME_EARTH_NDC_Y_SMALL;
+    const d = goalPos.distanceTo(earthPos);
+    goalLook.copy(earthPos).addScaledVector(side, -ndcX * d * tanHalfH);
+    goalLook.y = earthPos.y - ndcY * d * tanHalfV;
   }
 }
 
@@ -139,7 +156,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
       fromLook.current.copy(camera.position).addScaledVector(viewDir, 20);
     }
 
-    computeGoal(view, t, camera, size.width);
+    computeGoal(view, t, camera, size);
 
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
     rigState.settled = p >= 1;

--- a/src/space3d/solar/Planet.tsx
+++ b/src/space3d/solar/Planet.tsx
@@ -4,6 +4,7 @@ import * as THREE from "three";
 
 import { planetPosition, type SolarPlanetConfig } from "./constants";
 import { createPlanetTexture } from "../textures";
+import { hoverState } from "../../solarHover";
 import earthMapUrl from "../../assets/earth.jpg";
 
 /**
@@ -23,6 +24,8 @@ export default function Planet({
 }) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
+  const atmosphereMaterial = useRef<THREE.MeshBasicMaterial>(null);
 
   const texture = useMemo(() => {
     if (config.kind === "earth") {
@@ -63,6 +66,22 @@ export default function Planet({
     if (mesh.current) {
       mesh.current.rotation.y += delta * config.spinSpeed;
     }
+    if (config.kind === "earth") {
+      // Ease the glow up while the "About Andrew" ring/planet is hovered:
+      // the atmosphere shell thickens and the earthshine brightens
+      const hovered = hoverState.earth;
+      const ease = Math.min(delta * 6, 1);
+      if (atmosphereMaterial.current) {
+        atmosphereMaterial.current.opacity +=
+          ((hovered ? 0.5 : 0.16) - atmosphereMaterial.current.opacity) * ease;
+      }
+      if (surfaceMaterial.current) {
+        surfaceMaterial.current.emissiveIntensity +=
+          ((hovered ? 0.62 : 0.38) -
+            surfaceMaterial.current.emissiveIntensity) *
+          ease;
+      }
+    }
   });
 
   return (
@@ -83,6 +102,7 @@ export default function Planet({
             // otherwise be a near-black silhouette. The cool tint reads as
             // earthshine so oceans/land stay recognizable in the dark.
             <meshStandardMaterial
+              ref={surfaceMaterial}
               map={texture}
               roughness={0.95}
               metalness={0}
@@ -103,6 +123,7 @@ export default function Planet({
           <mesh scale={1.04}>
             <sphereGeometry args={[config.radius, 48, 48]} />
             <meshBasicMaterial
+              ref={atmosphereMaterial}
               color="#6ab0ff"
               transparent
               opacity={0.16}

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -3,6 +3,7 @@ import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import { SUN_RADIUS, sunState } from "./constants";
+import { hoverState } from "../../solarHover";
 import { createSunGlowTexture, createSunTexture } from "../textures";
 
 /**
@@ -67,7 +68,8 @@ export default function Sun({
       sunState.scale = next;
     }
     if (glow.current) {
-      const target = SUN_RADIUS * targetGlowScale;
+      // Hovering the ENTER link (or the sun itself) swells the glow
+      const target = SUN_RADIUS * targetGlowScale * (hoverState.sun ? 1.35 : 1);
       const current = glow.current.scale.x;
       const next = current + (target - current) * ease;
       glow.current.scale.set(next, next, 1);
@@ -75,10 +77,7 @@ export default function Sun({
     if (materialRef.current) {
       // Ease the brightness so the mode toggle doesn't pop; the spot
       // layer follows the same tint or the crossfade would pulse dark
-      materialRef.current.color.lerp(
-        isNightMode ? NIGHT_TINT : DAY_TINT,
-        ease,
-      );
+      materialRef.current.color.lerp(isNightMode ? NIGHT_TINT : DAY_TINT, ease);
       if (spotsMaterialRef.current) {
         spotsMaterialRef.current.color.copy(materialRef.current.color);
       }

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -53,7 +53,7 @@ export default function Sun({
   );
 
   useFrame(({ clock }, delta) => {
-    if (mesh.current) mesh.current.rotation.y += delta * 0.04;
+    if (mesh.current) mesh.current.rotation.y += delta * 0.013;
     if (spotsMaterialRef.current) {
       // Slow morph between the two blotch patterns (~30s round trip)
       spotsMaterialRef.current.opacity =

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -82,10 +82,9 @@ export const EARTH = PLANETS.find((p) => p.name === "Earth")!;
 
 /**
  * Link asteroids: small rocks that float near the sun in the home view.
- * They're near-co-orbital with Earth on purpose — the home camera's look
- * direction sweeps around with Earth, so a truly slow asteroid would be
- * out of frame most of the time. With orbit speeds close to Earth's,
- * they drift across the view VERY slowly (relative ~0.01 rad/s).
+ * They orbit at exactly Earth's angular speed — the home camera co-rotates
+ * with Earth, so matching it freezes them in place on screen, keeping
+ * both links visible at fixed spots.
  */
 export const ASTEROIDS: SolarPlanetConfig[] = [
   {
@@ -93,7 +92,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     kind: "mercury",
     radius: 0.28,
     orbitRadius: 5.2,
-    orbitSpeed: 0.082,
+    orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase + 0.35,
     spinSpeed: 0.6,
   },
@@ -102,7 +101,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     kind: "mercury",
     radius: 0.22,
     orbitRadius: 9.8,
-    orbitSpeed: 0.098,
+    orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase - 0.3,
     spinSpeed: -0.45,
   },


### PR DESCRIPTION
Stacked on #59 (GitHub will retarget to master when it merges).

## Changes

- **Sun rotation 3× slower** — surface spin 0.04 → 0.013 rad/s.
- **Home Earth placement** — on lg+ (≥1280px) screens the camera aims so Earth sits ~300px right and ~120px above the viewport center. Below lg, the same look is kept with proportional offsets (40% / 28% of the half-viewport) so Earth stays up-right without leaving frame on narrow screens.
- **Static asteroids** — both link asteroids now orbit at exactly Earth's angular speed; since the home camera co-rotates with Earth, they're frozen in place on screen with both links visible.
- **Planet link hover** — removed the text underline from ENTER / ABOUT ANDREW (including the global `a:hover` underline for these rings). Hovering anywhere on the ring (text or planet — the whole circle is the hit target) eases a glow up: the sun's corona sprite swells 1.35×, Earth's atmosphere shell and earthshine brighten. Hover flags live in a new three-free `src/solarHover.ts` so the main chunk stays free of three.js (index.js still ~50KB).

## Not tested (per request)

No browser testing was done. Worth checking manually:
- Asteroid link positions under the new Earth framing (orbit phases were tuned for the old aim; both should still be visible but may want a nudge)
- Earth's on-screen spot at various window sizes, and the hover glow feel/intensity on both links
- Note: `src/Home.tsx` has your uncommitted WIP (copy-email tooltip); it's untouched and left out of these commits, but `yarn lint` currently fails on its unused `Wand2` import.