### PR TITLE
Camera reframes + about-page panel and Home-link fixes

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -834,6 +834,16 @@ button {
   transition: color 50ms ease-in-out;
   font-weight: 600;
 
+  // The about page's Home link slides in/out on scroll (Tailwind toggles
+  // -translate-x-32). Tailwind's transition-transform utility lives in a
+  // cascade layer, so the unlayered `transition: color` above would
+  // clobber it and make the slide jump — re-declare both here instead.
+  &.back-to-home-link {
+    transition:
+      color 50ms ease-in-out,
+      translate 300ms ease;
+  }
+
   &:hover {
     color: #010c73;
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -626,15 +626,7 @@ li > ul > li {
   margin: auto;
   margin-top: 80px;
   max-width: 800px;
-  padding: 32px 32px 64px;
   margin-bottom: 96px;
-
-  // Translucent, blurred panel so the text stays legible over whatever
-  // the 3D scene puts behind it (Earth's bright limb, the drifting moon)
-  background: rgba(8, 6, 28, 0.55);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-radius: 16px;
 
   @media (min-width: 1280px) {
     max-width: 980px;
@@ -642,7 +634,19 @@ li > ul > li {
   }
 }
 
-.App.day .resume-inner-container {
+// Translucent, blurred panel so the text stays legible over whatever
+// the 3D scene puts behind it (Earth's bright limb, the drifting moon).
+// The back-to-home link sits above this panel, outside the background;
+// the 24px top padding puts the frosted edge just above "About Andrew".
+.resume-panel {
+  padding: 24px 32px 64px;
+  background: rgba(8, 6, 28, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 16px;
+}
+
+.App.day .resume-panel {
   background: rgba(255, 255, 255, 0.55);
 }
 
@@ -801,7 +805,10 @@ li > ul > li {
     backdrop-filter: blur(10px);
     border-radius: 16px;
     padding: 8px;
+    // The link sits outside the padded .resume-panel now, so it needs its
+    // own left inset (this unlayered margin overrides the Tailwind ml-8)
     margin: -8px;
+    margin-left: 24px;
     width: min-content;
     background: linear-gradient(
       to bottom,

--- a/src/App.scss
+++ b/src/App.scss
@@ -116,7 +116,6 @@ $breakpoint-lg: 1280px;
       fill: white;
       font-weight: 400;
       transition: fill 0.1s;
-      text-decoration: underline;
     }
   }
 }
@@ -867,6 +866,13 @@ a:hover {
   //   url(./cursor_pointer.png) 16 0,
   //   auto;
   cursor: pointer;
+}
+
+// Planet ring links ("ENTER", "ABOUT ANDREW"): no underline — the planet
+// glows on hover instead
+#solar-system a:hover,
+.earth-about-ring:hover {
+  text-decoration: none;
 }
 
 @keyframes spin {

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { SunInternals } from "SunSvg";
+import { hoverState } from "./solarHover";
 import { useOrbitalAnimation } from "./hooks/useOrbitalAnimation";
 import {
   PLANET_CONFIGS,
@@ -57,6 +58,15 @@ const Landing = () => {
     hasPlayedIntro = true;
   }, []);
 
+  // Clicking ENTER navigates away without a pointerleave — don't leave
+  // the sun's hover glow stuck on
+  useEffect(
+    () => () => {
+      hoverState.sun = false;
+    },
+    [],
+  );
+
   return (
     <div className="landing-page">
       <svg
@@ -95,7 +105,15 @@ const Landing = () => {
           </radialGradient>
         </defs>
 
-        <Link to="/home">
+        <Link
+          to="/home"
+          onPointerEnter={() => {
+            hoverState.sun = true;
+          }}
+          onPointerLeave={() => {
+            hoverState.sun = false;
+          }}
+        >
           <SunInternals size={SUN_SIZE} radiusOffset={SUN_RADIUS_OFFSET} />
           <text fontFamily="'Retro Floral', 'Inconsolata', monospace">
             <textPath

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -62,9 +62,11 @@ const experienceItems = [
 
 const Resume = () => {
   const [opacity, setOpacity] = useState(false);
+  // Drives the Home link's slide: at rest the heading sits ~288px from
+  // the viewport top on xl, so the -260px margin keeps it "in view" until
+  // the user scrolls a few dozen px, then the link slides away
   const { ref, inView } = useInView({
-    /* Optional options */
-    rootMargin: "-320px",
+    rootMargin: "-260px",
     threshold: 0,
   });
 
@@ -79,131 +81,135 @@ const Resume = () => {
 
   return (
     <div className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
+      {/* The link lives outside .resume-panel so the frosted background
+          starts above the "About Andrew" heading, not around the link */}
       <div className="resume-inner-container">
         <Link
           className={cx(
-            "back-to-home-link flex transition-transform items-center gap-4 mb-12 inverse xl:sticky xl:top-[200px] xl:-ml-16",
-            !inView && isLarge && "-translate-x-32"
+            "back-to-home-link flex transition-transform items-center gap-4 mb-6 inverse ml-8 xl:sticky xl:top-[200px] xl:-ml-8",
+            !inView && isLarge && "-translate-x-32",
           )}
           to="/home"
         >
           <ArrowLeftCircle size={40} />
           Home
         </Link>
-        <h1 ref={ref} className="mb-6">
-          About Andrew
-        </h1>
-        <h4>
-          Hey! I’m a frontend engineer based in San Francisco. I’m currently
-          working as a staff engineer at{" "}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            className="inverse"
-            href="https://ziphq.com"
-          >
-            Zip
-          </a>
-          . For consulting inquiries, reach out to{" "}
-          <a
-            className="inverse"
-            href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"
-          >
-            andrew@hunt.codes
-          </a>
-          .
-        </h4>
-        <div className="resume-divider" />
-        <h3>A few things I care about:</h3>
-        <ul className="hor-list">
-          <li>
-            <div className="card-title">Dev infrastructure</div>I believe it’s
-            difficult to overstate the importance of investing in the
-            development process. Great DevX is a prerequisite to quality UX and
-            efficient product development — this includes strong linters, fast
-            and thorough CI checks, and investment in AI tools to take the
-            burden of repetitive work off of engineers.
-          </li>
-          <li>
-            <div className="card-title">Component systems</div>Investing in a
-            well-structured and robust component system will accelerate design
-            and engineering work, reduce bugs, and create a more consistent user
-            experience.
-          </li>
-          <li>
-            <div className="card-title">Product collaboration</div>I excel when
-            collaborating closely with designers + researchers to build
-            delightful, engaging web products.
-          </li>
-          <li>
-            <div className="card-title">Performance</div>
-            I’m passionate about delivering a lightning-fast, responsive user
-            experience. Performance can be a complex problem, and often needs to
-            be approached with both a data-driven and user-centric lens.
-          </li>
-        </ul>
-        <div>
-          <div className="card-title">
-            Tools and frameworks I know fairly well:
-          </div>
-          TypeScript / JavaScript, Material UI, React, Apollo + GraphQL,
-          Storybook, ESLint, GitHub Actions, D3, Tailwind, Chromatic,
-          Cloudflare, Jest, Webpack, Vite, Vue
-        </div>
-
-        <div className="resume-divider" />
-
-        <h2>Experience</h2>
-        {experienceItems.map((item) => (
-          <React.Fragment key={item.title}>
-            <div className="splitRow">
-              <h4 className="flex items-center">
-                {item.title}{" "}
-                <span className="pill location-pill">{item.location}</span>
-              </h4>
-              <h4 className="flex items-center gap-2">
-                {item.date}
-                <Calendar size={12} />
-              </h4>
-            </div>
-            <ul>
-              {item.description.map((d, idx) => (
-                <li key={idx}>
-                  {typeof d === "string" ? (
-                    d
-                  ) : (
-                    <>
-                      {d.item}
-                      <ul>
-                        {d.subbullets?.map((s) => (
-                          <li key={s}>{s}</li>
-                        ))}
-                      </ul>
-                    </>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </React.Fragment>
-        ))}
-        <div className="resume-divider" />
-        <h2>Education</h2>
-        <div className="splitRow">
-          <h4 className="flex items-center">
-            Princeton University
-            <span className="pill location-pill">BSE</span>
-            <span className="pill location-pill">Computer Science</span>
+        <div className="resume-panel">
+          <h1 ref={ref} className="mt-0 mb-6">
+            About Andrew
+          </h1>
+          <h4>
+            Hey! I’m a frontend engineer based in San Francisco. I’m currently
+            working as a staff engineer at{" "}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              className="inverse"
+              href="https://ziphq.com"
+            >
+              Zip
+            </a>
+            . For consulting inquiries, reach out to{" "}
+            <a
+              className="inverse"
+              href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"
+            >
+              andrew@hunt.codes
+            </a>
+            .
           </h4>
-          <h4>September 2013 — June 2017</h4>
-        </div>
-        <div className="resume-divider" />
-        <h2>Other interests</h2>
-        <div className="flex flex-wrap gap-2">
-          {interests.map((i) => (
-            <span className="pill interest-pill" key={i}>
-              {i}
-            </span>
+          <div className="resume-divider" />
+          <h3>A few things I care about:</h3>
+          <ul className="hor-list">
+            <li>
+              <div className="card-title">Dev infrastructure</div>I believe it’s
+              difficult to overstate the importance of investing in the
+              development process. Great DevX is a prerequisite to quality UX
+              and efficient product development — this includes strong linters,
+              fast and thorough CI checks, and investment in AI tools to take
+              the burden of repetitive work off of engineers.
+            </li>
+            <li>
+              <div className="card-title">Component systems</div>Investing in a
+              well-structured and robust component system will accelerate design
+              and engineering work, reduce bugs, and create a more consistent
+              user experience.
+            </li>
+            <li>
+              <div className="card-title">Product collaboration</div>I excel
+              when collaborating closely with designers + researchers to build
+              delightful, engaging web products.
+            </li>
+            <li>
+              <div className="card-title">Performance</div>
+              I’m passionate about delivering a lightning-fast, responsive user
+              experience. Performance can be a complex problem, and often needs
+              to be approached with both a data-driven and user-centric lens.
+            </li>
+          </ul>
+          <div>
+            <div className="card-title">
+              Tools and frameworks I know fairly well:
+            </div>
+            TypeScript / JavaScript, Material UI, React, Apollo + GraphQL,
+            Storybook, ESLint, GitHub Actions, D3, Tailwind, Chromatic,
+            Cloudflare, Jest, Webpack, Vite, Vue
+          </div>
+
+          <div className="resume-divider" />
+
+          <h2>Experience</h2>
+          {experienceItems.map((item) => (
+            <React.Fragment key={item.title}>
+              <div className="splitRow">
+                <h4 className="flex items-center">
+                  {item.title}{" "}
+                  <span className="pill location-pill">{item.location}</span>
+                </h4>
+                <h4 className="flex items-center gap-2">
+                  {item.date}
+                  <Calendar size={12} />
+                </h4>
+              </div>
+              <ul>
+                {item.description.map((d, idx) => (
+                  <li key={idx}>
+                    {typeof d === "string" ? (
+                      d
+                    ) : (
+                      <>
+                        {d.item}
+                        <ul>
+                          {d.subbullets?.map((s) => (
+                            <li key={s}>{s}</li>
+                          ))}
+                        </ul>
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </React.Fragment>
           ))}
+          <div className="resume-divider" />
+          <h2>Education</h2>
+          <div className="splitRow">
+            <h4 className="flex items-center">
+              Princeton University
+              <span className="pill location-pill">BSE</span>
+              <span className="pill location-pill">Computer Science</span>
+            </h4>
+            <h4>September 2013 — June 2017</h4>
+          </div>
+          <div className="resume-divider" />
+          <h2>Other interests</h2>
+          <div className="flex flex-wrap gap-2">
+            {interests.map((i) => (
+              <span className="pill interest-pill" key={i}>
+                {i}
+              </span>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -11,6 +11,7 @@ import {
   asteroidAnchorId,
   EARTH_ABOUT_RING_ID,
 } from "./space3d/solar/BodyAnchors";
+import { hoverState } from "./solarHover";
 
 /**
  * DOM overlays for the home page's 3D bodies. The canvases never take
@@ -33,59 +34,79 @@ const ASTEROID_LINKS = [
   },
 ];
 
-const SolarOverlays = () => (
-  <>
-    {/* Earth is the /about link: a ring glued around its projection with
+const SolarOverlays = () => {
+  // Clicking the ring navigates away without a pointerleave — don't
+  // leave Earth's hover glow stuck on
+  React.useEffect(
+    () => () => {
+      hoverState.earth = false;
+    },
+    [],
+  );
+
+  return (
+    <>
+      {/* Earth is the /about link: a ring glued around its projection with
         "About Andrew" curved over the top, styled like the landing
         "enter" ring. The whole circle (Earth included) is clickable. */}
-    <Link
-      to="/about"
-      id={EARTH_ABOUT_RING_ID}
-      className="earth-about-ring"
-      aria-label="About Andrew"
-    >
-      <svg viewBox="0 0 100 100" width="100%" height="100%">
-        <path
-          id="earth-about-ring-path"
-          fill="none"
-          d="
+      <Link
+        to="/about"
+        id={EARTH_ABOUT_RING_ID}
+        className="earth-about-ring"
+        aria-label="About Andrew"
+        onPointerEnter={() => {
+          hoverState.earth = true;
+        }}
+        onPointerLeave={() => {
+          hoverState.earth = false;
+        }}
+      >
+        <svg viewBox="0 0 100 100" width="100%" height="100%">
+          <path
+            id="earth-about-ring-path"
+            fill="none"
+            d="
             M 9,50
             a 41,41 0 1,1 82,0
             a 41,41 0 1,1 -82,0
           "
-        />
-        <text fontFamily="'Retro Floral', 'Inconsolata', monospace" textAnchor="middle">
-          <textPath
-            href="#earth-about-ring-path"
-            startOffset="25%"
-            className="svg-link-tspan"
-            fontSize="13px"
+          />
+          <text
+            fontFamily="'Retro Floral', 'Inconsolata', monospace"
+            textAnchor="middle"
           >
-            ABOUT ANDREW
-          </textPath>
-        </text>
-      </svg>
-    </Link>
-    {ASTEROID_LINKS.map((link) => (
-      <TooltipProvider key={link.name} delayDuration={100}>
-        <Tooltip disableHoverableContent>
-          <TooltipTrigger asChild>
-            <a
-              id={asteroidAnchorId(link.name)}
-              className="asteroid-link"
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={link.label}
-            />
-          </TooltipTrigger>
-          <TooltipContent updatePositionStrategy="always">
-            <p>{link.label}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    ))}
-  </>
-);
+            <textPath
+              href="#earth-about-ring-path"
+              startOffset="25%"
+              className="svg-link-tspan"
+              fontSize="13px"
+            >
+              ABOUT ANDREW
+            </textPath>
+          </text>
+        </svg>
+      </Link>
+      {ASTEROID_LINKS.map((link) => (
+        <TooltipProvider key={link.name} delayDuration={100}>
+          <Tooltip disableHoverableContent>
+            <TooltipTrigger asChild>
+              <a
+                id={asteroidAnchorId(link.name)}
+                className="asteroid-link"
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={link.label}
+              />
+            </TooltipTrigger>
+            <TooltipContent updatePositionStrategy="always">
+              <p>{link.label}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ))}
+    </>
+  );
+};
 
 export default SolarOverlays;

--- a/src/SunSvg.tsx
+++ b/src/SunSvg.tsx
@@ -161,7 +161,6 @@ export function SunInternals({
             fill: black;
             font-weight: 400;
             transition: fill 0.1s;
-            text-decoration: underline;
 
             &:hover {
               fill: #7400b3;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -1,0 +1,8 @@
+/**
+ * Hover flags for the planet-link overlays, bridged into the WebGL scene
+ * (the DOM sets them; Sun/Planet read them per frame to ease their glow
+ * up). Lives in its own three-free module so main-chunk components
+ * (Landing, SolarOverlays) can import it without dragging three.js out
+ * of its lazy chunk.
+ */
+export const hoverState = { sun: false, earth: false };

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -53,7 +53,9 @@ const ANCHORS: BodyAnchorConfig[] = [
     domId: EARTH_ABOUT_RING_ID,
     position: (t, out) => planetPosition(EARTH, t, out),
     radius: EARTH.radius,
-    ringScale: 1.3,
+    // The text path sits at 82% of the overlay's radius, so 1.55 floats
+    // the letters ~27% clear of Earth's limb (1.3 grazed the surface)
+    ringScale: 1.55,
     minSizePx: 140,
     fadeInOnArrival: true,
   },

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -27,11 +27,11 @@ const UP = new THREE.Vector3(0, 1, 0);
 const TRANSITION_SECONDS = 3.2;
 
 // Home-view framing: the sun-perch. Offsets from the SUN's center (r 3),
-// on the far side from Earth, elevated — camera ends up ~0.9 above the
-// surface (well clear of the 0.1 near plane) with the sun's limb filling
-// the bottom third and Earth ~9deg wide in the middle distance.
+// on the far side from Earth, elevated well above the surface so the
+// sun's limb only fills the bottom ~20% of the frame, with Earth ~9deg
+// wide in the middle distance.
 const HOME_CAM_BEHIND = 1.6; // away from Earth
-const HOME_CAM_ABOVE = 3.4;
+const HOME_CAM_ABOVE = 5.6;
 const HOME_CAM_SIDE = 1; // camera right => sun apex drifts screen-left
 // Earth's screen spot: on lg+ screens, pixel offsets from the viewport
 // center; below that, fixed viewport fractions (same look, scaled down)

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -33,7 +33,12 @@ const TRANSITION_SECONDS = 3.2;
 const HOME_CAM_BEHIND = 1.6; // away from Earth
 const HOME_CAM_ABOVE = 3.4;
 const HOME_CAM_SIDE = 1; // camera right => sun apex drifts screen-left
-const HOME_LOOK_HEIGHT = 3; // raise the aim so Earth sits below center
+// Earth's screen spot: on lg+ screens, pixel offsets from the viewport
+// center; below that, fixed viewport fractions (same look, scaled down)
+const HOME_EARTH_RIGHT_PX = 300;
+const HOME_EARTH_UP_PX = 120;
+const HOME_EARTH_NDC_X_SMALL = 0.4;
+const HOME_EARTH_NDC_Y_SMALL = 0.28;
 
 // About-view framing: the Earth-perch, placed on the side of Earth
 // OPPOSITE the moon and co-rotating with the moon's orbit (the same way
@@ -71,7 +76,7 @@ function computeGoal(
   view: SolarView,
   t: number,
   camera: THREE.Camera,
-  viewportWidth: number,
+  viewport: { width: number; height: number },
 ) {
   if (view === "landing") {
     goalPos.copy(LANDING_POS);
@@ -84,7 +89,7 @@ function computeGoal(
     moonPosition(t, moonPos);
     moonDir.copy(moonPos).sub(earthPos).normalize();
     side.crossVectors(moonDir, UP).normalize();
-    const centered = viewportWidth < LG_BREAKPOINT_PX;
+    const centered = viewport.width < LG_BREAKPOINT_PX;
     goalPos
       .copy(earthPos)
       .addScaledVector(moonDir, -ABOUT_CAM_BEHIND)
@@ -100,8 +105,7 @@ function computeGoal(
       const persp = camera as THREE.PerspectiveCamera;
       const tanHalfH =
         Math.tan((persp.fov * Math.PI) / 360) * (persp.aspect || 1);
-      const lateral =
-        goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
+      const lateral = goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
       goalLook.addScaledVector(side, -lateral);
     }
   } else {
@@ -116,8 +120,21 @@ function computeGoal(
       .addScaledVector(toEarth, -HOME_CAM_BEHIND)
       .addScaledVector(side, HOME_CAM_SIDE);
     goalPos.y += HOME_CAM_ABOVE;
-    goalLook.copy(earthPos);
-    goalLook.y += HOME_LOOK_HEIGHT;
+    // Aim so Earth lands right of and above the viewport center (aiming
+    // left of / below a body pushes it right / up on screen)
+    const persp = camera as THREE.PerspectiveCamera;
+    const tanHalfV = Math.tan((persp.fov * Math.PI) / 360);
+    const tanHalfH = tanHalfV * (persp.aspect || 1);
+    const lg = viewport.width >= LG_BREAKPOINT_PX;
+    const ndcX = lg
+      ? HOME_EARTH_RIGHT_PX / (viewport.width / 2)
+      : HOME_EARTH_NDC_X_SMALL;
+    const ndcY = lg
+      ? HOME_EARTH_UP_PX / (viewport.height / 2)
+      : HOME_EARTH_NDC_Y_SMALL;
+    const d = goalPos.distanceTo(earthPos);
+    goalLook.copy(earthPos).addScaledVector(side, -ndcX * d * tanHalfH);
+    goalLook.y = earthPos.y - ndcY * d * tanHalfV;
   }
 }
 
@@ -139,7 +156,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
       fromLook.current.copy(camera.position).addScaledVector(viewDir, 20);
     }
 
-    computeGoal(view, t, camera, size.width);
+    computeGoal(view, t, camera, size);
 
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
     rigState.settled = p >= 1;

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -56,6 +56,10 @@ const ABOUT_LOOK_HEIGHT = 0.45; // aim slightly above the moon's plane
  *  offset instead, putting itself on the Earth-moon line so the moon
  *  reads dead-center, directly above Earth. */
 const ABOUT_MOON_NDC_X = -0.5;
+/** Extra downward aim, as an NDC fraction at the moon's distance: rotating
+ *  the view down lifts the whole scene — the moon rides ~20vh higher and
+ *  more of Earth's limb clears the bottom edge. */
+const ABOUT_MOON_NDC_Y_LIFT = 0.4;
 const LG_BREAKPOINT_PX = 1280;
 
 // scratch vectors, reused every frame
@@ -97,14 +101,17 @@ function computeGoal(
       // reads directly above Earth
       .addScaledVector(side, centered ? 0 : ABOUT_CAM_SIDE);
     goalPos.y += ABOUT_CAM_ABOVE;
+    const persp = camera as THREE.PerspectiveCamera;
+    const tanHalfV = Math.tan((persp.fov * Math.PI) / 360);
     goalLook.copy(moonPos);
-    goalLook.y = moonPos.y + ABOUT_LOOK_HEIGHT;
+    goalLook.y =
+      moonPos.y +
+      ABOUT_LOOK_HEIGHT -
+      goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_Y_LIFT * tanHalfV;
     if (!centered) {
       // Aim sideways of the moon by the angle that lands it at
       // ABOUT_MOON_NDC_X for the current aspect (~25vw from the left)
-      const persp = camera as THREE.PerspectiveCamera;
-      const tanHalfH =
-        Math.tan((persp.fov * Math.PI) / 360) * (persp.aspect || 1);
+      const tanHalfH = tanHalfV * (persp.aspect || 1);
       const lateral = goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
       goalLook.addScaledVector(side, -lateral);
     }

--- a/src/space3d/solar/Planet.tsx
+++ b/src/space3d/solar/Planet.tsx
@@ -4,6 +4,7 @@ import * as THREE from "three";
 
 import { planetPosition, type SolarPlanetConfig } from "./constants";
 import { createPlanetTexture } from "../textures";
+import { hoverState } from "../../solarHover";
 import earthMapUrl from "../../assets/earth.jpg";
 
 /**
@@ -23,6 +24,8 @@ export default function Planet({
 }) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
+  const atmosphereMaterial = useRef<THREE.MeshBasicMaterial>(null);
 
   const texture = useMemo(() => {
     if (config.kind === "earth") {
@@ -63,6 +66,22 @@ export default function Planet({
     if (mesh.current) {
       mesh.current.rotation.y += delta * config.spinSpeed;
     }
+    if (config.kind === "earth") {
+      // Ease the glow up while the "About Andrew" ring/planet is hovered:
+      // the atmosphere shell thickens and the earthshine brightens
+      const hovered = hoverState.earth;
+      const ease = Math.min(delta * 6, 1);
+      if (atmosphereMaterial.current) {
+        atmosphereMaterial.current.opacity +=
+          ((hovered ? 0.5 : 0.16) - atmosphereMaterial.current.opacity) * ease;
+      }
+      if (surfaceMaterial.current) {
+        surfaceMaterial.current.emissiveIntensity +=
+          ((hovered ? 0.62 : 0.38) -
+            surfaceMaterial.current.emissiveIntensity) *
+          ease;
+      }
+    }
   });
 
   return (
@@ -83,6 +102,7 @@ export default function Planet({
             // otherwise be a near-black silhouette. The cool tint reads as
             // earthshine so oceans/land stay recognizable in the dark.
             <meshStandardMaterial
+              ref={surfaceMaterial}
               map={texture}
               roughness={0.95}
               metalness={0}
@@ -103,6 +123,7 @@ export default function Planet({
           <mesh scale={1.04}>
             <sphereGeometry args={[config.radius, 48, 48]} />
             <meshBasicMaterial
+              ref={atmosphereMaterial}
               color="#6ab0ff"
               transparent
               opacity={0.16}

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -3,6 +3,7 @@ import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import { SUN_RADIUS, sunState } from "./constants";
+import { hoverState } from "../../solarHover";
 import { createSunGlowTexture, createSunTexture } from "../textures";
 
 /**
@@ -67,7 +68,8 @@ export default function Sun({
       sunState.scale = next;
     }
     if (glow.current) {
-      const target = SUN_RADIUS * targetGlowScale;
+      // Hovering the ENTER link (or the sun itself) swells the glow
+      const target = SUN_RADIUS * targetGlowScale * (hoverState.sun ? 1.35 : 1);
       const current = glow.current.scale.x;
       const next = current + (target - current) * ease;
       glow.current.scale.set(next, next, 1);
@@ -75,10 +77,7 @@ export default function Sun({
     if (materialRef.current) {
       // Ease the brightness so the mode toggle doesn't pop; the spot
       // layer follows the same tint or the crossfade would pulse dark
-      materialRef.current.color.lerp(
-        isNightMode ? NIGHT_TINT : DAY_TINT,
-        ease,
-      );
+      materialRef.current.color.lerp(isNightMode ? NIGHT_TINT : DAY_TINT, ease);
       if (spotsMaterialRef.current) {
         spotsMaterialRef.current.color.copy(materialRef.current.color);
       }

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -53,7 +53,7 @@ export default function Sun({
   );
 
   useFrame(({ clock }, delta) => {
-    if (mesh.current) mesh.current.rotation.y += delta * 0.04;
+    if (mesh.current) mesh.current.rotation.y += delta * 0.013;
     if (spotsMaterialRef.current) {
       // Slow morph between the two blotch patterns (~30s round trip)
       spotsMaterialRef.current.opacity =

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -82,10 +82,9 @@ export const EARTH = PLANETS.find((p) => p.name === "Earth")!;
 
 /**
  * Link asteroids: small rocks that float near the sun in the home view.
- * They're near-co-orbital with Earth on purpose — the home camera's look
- * direction sweeps around with Earth, so a truly slow asteroid would be
- * out of frame most of the time. With orbit speeds close to Earth's,
- * they drift across the view VERY slowly (relative ~0.01 rad/s).
+ * They orbit at exactly Earth's angular speed — the home camera co-rotates
+ * with Earth, so matching it freezes them in place on screen, keeping
+ * both links visible at fixed spots.
  */
 export const ASTEROIDS: SolarPlanetConfig[] = [
   {
@@ -93,7 +92,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     kind: "mercury",
     radius: 0.28,
     orbitRadius: 5.2,
-    orbitSpeed: 0.082,
+    orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase + 0.35,
     spinSpeed: 0.6,
   },
@@ -102,7 +101,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     kind: "mercury",
     radius: 0.22,
     orbitRadius: 9.8,
-    orbitSpeed: 0.098,
+    orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase - 0.3,
     spinSpeed: -0.45,
   },


### PR DESCRIPTION
**Note:** this PR also carries the four commits from #60 (sun spin, home Earth framing, static asteroids, hover glow) — #60 was merged into `ah-moon-left-retro-font` two minutes *after* #59 merged that branch, so those commits never reached master. Merging this brings them in.

## New changes

- **Home: sun ~20% of viewport** — raised the sun-perch (`HOME_CAM_ABOVE` 3.4 → 5.6); the limb now tops out ~78% down the frame (verified at 1440×900).
- **Home: "ABOUT ANDREW" floats above Earth** — ring overlay scale 1.3 → 1.55, putting the text path ~27% clear of Earth's limb instead of grazing it.
- **About: scene lifted** — the camera aims 0.4 NDC lower at the moon's distance, so the moon rides ~20vh higher (now ~43% down the viewport) and more of Earth's limb clears the bottom edge. Applies on all breakpoints.
- **About: Home-link slide fixed** — the global `a { transition: color 50ms }` in App.scss is unlayered CSS, so it was clobbering Tailwind v4's layered `transition-transform` utility and the link snapped instead of sliding. An explicit `translate 300ms ease` transition on `.back-to-home-link` restores the animation (verified interpolating both directions).
- **About: frosted panel starts above the heading** — the Home link moved out of the blurred panel; the panel's top edge now sits exactly 24px above "About Andrew". The in-view margin was retuned (-320px → -260px) for the new heading position, and the small-screen link pill got its own 24px left inset since it no longer sits inside the panel's padding.

Verified in the preview browser at 1440×900 and 375×812: home sun height, text float, panel gap (24px), slide animation interpolation, mobile link inset.