### PR TITLE
Asteroid link polish, WebGL ABOUT ME label, faster camera swoop

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -637,7 +637,7 @@ li > ul > li {
 // Translucent, blurred panel so the text stays legible over whatever
 // the 3D scene puts behind it (Earth's bright limb, the drifting moon).
 // The back-to-home link sits above this panel, outside the background;
-// the 24px top padding puts the frosted edge just above "About Andrew".
+// the 24px top padding puts the frosted edge just above "About Me".
 .resume-panel {
   padding: 24px 32px 64px;
   background: rgba(8, 6, 28, 0.55);
@@ -887,7 +887,7 @@ a:hover {
   cursor: pointer;
 }
 
-// Planet ring links ("ENTER", "ABOUT ANDREW"): no underline — the planet
+// Planet ring links ("ENTER", "ABOUT ME"): no underline — the planet
 // glows on hover instead
 #solar-system a:hover,
 .earth-about-ring:hover {
@@ -1021,20 +1021,59 @@ a:hover {
   border-radius: 50%;
   pointer-events: auto;
   cursor: pointer;
-  transition: box-shadow 0.15s ease;
+}
 
-  &:hover,
-  &:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.45);
+// Hover treatment: the rock freezes and its actual silhouette (a hull the
+// scene recomputes from the frozen mesh, so it matches whatever
+// orientation the hover caught it in) lights up purple with white pulses
+// chasing around the perimeter. Both paths carry pathLength="100", so the
+// dash animation below works for any silhouette shape or length.
+.asteroid-outline {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+
+  path {
+    fill: none;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .asteroid-outline-base {
+    stroke: $purp-light;
+    stroke-width: 2px;
+  }
+
+  .asteroid-outline-pulse {
+    stroke: #ffffff;
+    stroke-width: 2.5px;
+    stroke-dasharray: 12 88;
+    animation: asteroid-outline-pulse 1.8s linear infinite;
   }
 }
 
-.App.day .asteroid-link:hover,
-.App.day .asteroid-link:focus-visible {
-  box-shadow: 0 0 0 2px rgba(65, 37, 150, 0.45);
+.asteroid-link:hover .asteroid-outline,
+.asteroid-link:focus-visible .asteroid-outline {
+  opacity: 1;
 }
 
-// Earth's /about ring: "About Andrew" curved over the projected Earth,
+.App.day .asteroid-outline .asteroid-outline-base {
+  stroke: $purp;
+}
+
+@keyframes asteroid-outline-pulse {
+  to {
+    stroke-dashoffset: -100;
+  }
+}
+
+// Earth's /about ring: "About Me" curved over the projected Earth,
 // styled after the landing "enter" arc. The whole circle is the link.
 // It fades in only once the camera's swoop to the home view settles
 // (BodyAnchors drives opacity 0 -> 1; this transition does the fading).
@@ -1370,7 +1409,8 @@ a:hover {
 #solar-system[data-rendered-3d] {
   .orbit-path,
   .planet,
-  .planet-label {
+  .planet-label,
+  .landing-enter-text {
     display: none;
   }
 }

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, memo, lazy, Suspense } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  memo,
+  lazy,
+  Suspense,
+} from "react";
 import { useLocation } from "react-router-dom";
 import cx from "classnames";
 
@@ -81,6 +88,33 @@ const AppBackground = ({
     }
     return () => clearTimeout(timeout);
   }, [isNightMode]);
+
+  // Start the music when the visitor clicks ENTER on the landing page:
+  // that click is a user gesture, so play() is allowed. The flag survives
+  // one render in case the <audio> isn't mounted yet (musicEnabled flips
+  // first, then the re-run of this effect starts playback).
+  const prevPathname = useRef(location.pathname);
+  const autoplayPending = useRef(false);
+  useEffect(() => {
+    const cameFromLanding =
+      prevPathname.current === "/" || prevPathname.current === "";
+    prevPathname.current = location.pathname;
+    if (cameFromLanding && isHomePage) {
+      autoplayPending.current = true;
+    }
+    if (!autoplayPending.current) return;
+    if (!musicEnabled) {
+      setMusicEnabled(true);
+      return;
+    }
+    autoplayPending.current = false;
+    document
+      .querySelector("audio")
+      ?.play()
+      // Playback can still be denied (e.g. autoplay policies on a stale
+      // gesture) — the visible controls remain the fallback
+      .catch(() => {});
+  }, [location.pathname, isHomePage, musicEnabled]);
 
   return (
     <>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,7 +3,7 @@ import Typed from "typed.js";
 import cx from "classnames";
 
 import { GitHub, Linkedin, Mail } from "react-feather";
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftCircleIcon } from "lucide-react";
 import useWindowSize from "./useWindowSize";
 import SolarOverlays from "./SolarOverlays";
 
@@ -91,8 +91,8 @@ const Home = () => {
           className={cx("mt-4 flex items-center gap-1 transition-transform")}
           to="/"
         >
-          <ArrowLeftIcon className="starIcon" size={16} />
-          <span>Back to space</span>
+          <ArrowLeftCircleIcon className="starIcon" size={16} />
+          <span>Landing page</span>
         </Link>
       </div>
       <main className={cx("homeInfoContainer", logoOpacity === 1 && "show")}>

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -115,7 +115,10 @@ const Landing = () => {
           }}
         >
           <SunInternals size={SUN_SIZE} radiusOffset={SUN_RADIUS_OFFSET} />
-          <text fontFamily="'Retro Floral', 'Inconsolata', monospace">
+          <text
+            className="landing-enter-text"
+            fontFamily="'Retro Floral', 'Inconsolata', monospace"
+          >
             <textPath
               fill="white"
               pointerEvents="fill"

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -82,7 +82,7 @@ const Resume = () => {
   return (
     <div className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
       {/* The link lives outside .resume-panel so the frosted background
-          starts above the "About Andrew" heading, not around the link */}
+          starts above the "About Me" heading, not around the link */}
       <div className="resume-inner-container">
         <Link
           className={cx(
@@ -96,7 +96,7 @@ const Resume = () => {
         </Link>
         <div className="resume-panel">
           <h1 ref={ref} className="mt-0 mb-6">
-            About Andrew
+            About Me
           </h1>
           <h4>
             Hey! I’m a frontend engineer based in San Francisco. I’m currently
@@ -217,6 +217,7 @@ const Resume = () => {
 };
 
 const interests = [
+  "3D Printing",
   "Singing",
   "Easter Eggs",
   "Crosswords",

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -9,6 +9,7 @@ import {
 } from "./ui/tooltip";
 import {
   asteroidAnchorId,
+  asteroidOutlineId,
   EARTH_ABOUT_RING_ID,
 } from "./space3d/solar/BodyAnchors";
 import { hoverState } from "./solarHover";
@@ -32,60 +33,43 @@ const ASTEROID_LINKS = [
     label: "GitHub",
     href: "https://www.github.com/amhunt",
   },
+  {
+    name: "linkedin",
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/andrewmhunt/",
+  },
 ];
 
 const SolarOverlays = () => {
-  // Clicking the ring navigates away without a pointerleave — don't
-  // leave Earth's hover glow stuck on
+  // Navigating away doesn't fire pointerleave — don't leave a hover
+  // glow stuck on
   React.useEffect(
     () => () => {
       hoverState.earth = false;
+      hoverState.asteroid = null;
     },
     [],
   );
 
   return (
     <>
-      {/* Earth is the /about link: a ring glued around its projection with
-        "About Andrew" curved over the top, styled like the landing
-        "enter" ring. The whole circle (Earth included) is clickable. */}
+      {/* Earth is the /about link. The "ABOUT ME" label curving over the top
+          is now rendered in WebGL (space3d/solar/AboutRing) around the 3D
+          Earth; this element is just the circular hit target (Earth included)
+          that BodyAnchors glues to Earth's projection — the canvas itself
+          takes no pointer input. */}
       <Link
         to="/about"
         id={EARTH_ABOUT_RING_ID}
         className="earth-about-ring"
-        aria-label="About Andrew"
+        aria-label="About Me"
         onPointerEnter={() => {
           hoverState.earth = true;
         }}
         onPointerLeave={() => {
           hoverState.earth = false;
         }}
-      >
-        <svg viewBox="0 0 100 100" width="100%" height="100%">
-          <path
-            id="earth-about-ring-path"
-            fill="none"
-            d="
-            M 9,50
-            a 41,41 0 1,1 82,0
-            a 41,41 0 1,1 -82,0
-          "
-          />
-          <text
-            fontFamily="'Retro Floral', 'Inconsolata', monospace"
-            textAnchor="middle"
-          >
-            <textPath
-              href="#earth-about-ring-path"
-              startOffset="25%"
-              className="svg-link-tspan"
-              fontSize="13px"
-            >
-              ABOUT ANDREW
-            </textPath>
-          </text>
-        </svg>
-      </Link>
+      />
       {ASTEROID_LINKS.map((link) => (
         <TooltipProvider key={link.name} delayDuration={100}>
           <Tooltip disableHoverableContent>
@@ -97,7 +81,29 @@ const SolarOverlays = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={link.label}
-              />
+                onPointerEnter={() => {
+                  hoverState.asteroid = link.name;
+                }}
+                onPointerLeave={() => {
+                  if (hoverState.asteroid === link.name) {
+                    hoverState.asteroid = null;
+                  }
+                }}
+              >
+                {/* Hover outline: the rock's projected silhouette, drawn
+                    by Asteroid into these paths (viewBox matches the
+                    anchor box; pathLength normalizes the dash pulse) */}
+                <svg
+                  className="asteroid-outline"
+                  viewBox="0 0 100 100"
+                  aria-hidden
+                >
+                  <g id={asteroidOutlineId(link.name)}>
+                    <path className="asteroid-outline-base" pathLength={100} />
+                    <path className="asteroid-outline-pulse" pathLength={100} />
+                  </g>
+                </svg>
+              </a>
             </TooltipTrigger>
             <TooltipContent updatePositionStrategy="always">
               <p>{link.label}</p>

--- a/src/SunSvg.tsx
+++ b/src/SunSvg.tsx
@@ -13,7 +13,7 @@ export const HOME_SUN_CY = 276;
 export const HOME_SUN_RADIUS = 175;
 
 // The orbiting text links are retired for now (replaced by the asteroid
-// links + the Earth "About Andrew" ring in the 3D scene) but kept
+// links + the Earth "About Me" ring in the 3D scene) but kept
 // compiled behind this flag in case they come back.
 const SHOW_ORBITING_LINKS = false;
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* CSS requires every @import to lead the file, so the webfont, Tailwind, and
    the animation utilities are grouped here ahead of everything else. */
-@import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@300;400;500;600;700;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inconsolata:wght@300;400;500;600;700;900&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -18,7 +18,7 @@
   src: url("./NovaMono-Regular.ttf");
 }
 
-/* Display font for the planet ring links ("ENTER", "ABOUT ANDREW") */
+/* Display font for the planet ring links ("ENTER", "About Me") */
 @font-face {
   font-family: "Retro Floral";
   src: url("./RetroFloral.ttf");
@@ -27,35 +27,44 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, "infini", "Helvetica Neue", "Segoe UI", "Roboto", "Oxygen",
+  font-family:
+    -apple-system, "infini", "Helvetica Neue", "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-
-h1, h2, h3, main {
-  font-family: "Inconsolata", "Helvetica Neue", "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", sans-serif;
+h1,
+h2,
+h3,
+main {
+  font-family:
+    "Inconsolata", "Helvetica Neue", "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", sans-serif;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 @layer base {
-  ul, ol, li {
+  ul,
+  ol,
+  li {
     list-style: revert;
     margin-left: 1rem;
   }
 
-  h1, h2, h3, h4 {
+  h1,
+  h2,
+  h3,
+  h4 {
     margin: revert;
     padding: revert;
     font-weight: revert;
   }
-  
+
   :root {
     --background: 0 0% 100%;
     --foreground: 222.2 47.4% 11.2%;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -14,6 +14,16 @@ declare module "*.avif" {
   export default src;
 }
 
+declare module "*.ttf" {
+  const src: string;
+  export default src;
+}
+
+declare module "*.woff" {
+  const src: string;
+  export default src;
+}
+
 declare module "*.bmp" {
   const src: string;
   export default src;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -5,4 +5,9 @@
  * (Landing, SolarOverlays) can import it without dragging three.js out
  * of its lazy chunk.
  */
-export const hoverState = { sun: false, earth: false };
+export const hoverState = {
+  sun: false,
+  earth: false,
+  /** Name of the hovered link asteroid (constants.ts ASTEROIDS), or null */
+  asteroid: null as string | null,
+};

--- a/src/space3d/StarField.tsx
+++ b/src/space3d/StarField.tsx
@@ -478,15 +478,28 @@ const TextStars = ({
   return <points geometry={data.buffers.geometry} material={material} />;
 };
 
+// Hold the stars hidden for a beat after mount before the fade-in starts
+// (part of the landing intro choreography)
+const FADE_IN_DELAY_SECONDS = 2;
+
 const StarField = ({ isLanding, opacityTarget }: StarFieldProps) => {
-  // Shared fade value, ramped in the frame loop (mount fade-in ~1s,
-  // day/night switch fade-out ~0.6s to match the legacy CSS transitions).
+  // Shared fade value, ramped in the frame loop (mount fade-in ~1s after
+  // the delay above, day/night switch fade-out ~0.6s to match the legacy
+  // CSS transitions).
   const opacityRef = useRef(0);
   const targetRef = useRef(opacityTarget);
+  const delayRef = useRef(FADE_IN_DELAY_SECONDS);
   const groupRef = useRef<THREE.Group>(null);
   targetRef.current = opacityTarget;
 
   useFrame((_, delta) => {
+    // Stars mount at opacity 0, so burning the delay first postpones only
+    // the initial reveal — later day/night fades are unaffected
+    if (delayRef.current > 0) {
+      delayRef.current -= Math.min(delta, 0.1);
+      if (groupRef.current) groupRef.current.visible = false;
+      return;
+    }
     const target = targetRef.current;
     const rate = target > opacityRef.current ? 1 : 1.6;
     const step = Math.min(delta, 0.1) * rate;

--- a/src/space3d/solar/AboutRing.tsx
+++ b/src/space3d/solar/AboutRing.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+import { EARTH, rigState } from "./constants";
+import { hoverState } from "../../solarHover";
+import {
+  createLetterPlane,
+  measureCharWidths,
+  retroFloralFont,
+  useRetroFloralReady,
+  type CurvedLetter,
+} from "./curvedText";
+
+/**
+ * The "ABOUT ME" link label curved over the top of Earth — the WebGL port of
+ * the SVG textPath that SolarOverlays used to glue to Earth's projection. The
+ * group billboards to face the camera each frame, so the word curves around
+ * Earth in screen space (exactly like the flat SVG ring did) while living in
+ * the 3D scene. The clickable hit target stays in the DOM (SolarOverlays),
+ * since the canvas takes no pointer input.
+ *
+ * Sizes are derived from the old overlay so the label lands in the same spot:
+ * BodyAnchors sized the overlay to 1.55× Earth's projected diameter, the SVG
+ * text path sat at 41/50 of that radius, and the font was 13/100 of the
+ * viewBox — all reproduced here in Earth-radius world units.
+ */
+
+const ABOUT_TEXT = "ABOUT ME";
+const ABOUT_FONT_SIZE = 13; // matches the SVG textPath fontSize
+const ABOUT_FONT = retroFloralFont(ABOUT_FONT_SIZE);
+const ABOUT_RING_SCALE = 1.55; // BodyAnchors overlay diameter multiple
+const ABOUT_PATH_RADIUS_FRAC = 41 / 50; // text path radius within the overlay
+const ABOUT_FONT_FRAC = ABOUT_FONT_SIZE / 100; // font size as a viewBox fraction
+
+const NIGHT_COLOR = new THREE.Color("#ffffff");
+const DAY_COLOR = new THREE.Color("#412596");
+const HOVER_COLOR = new THREE.Color("#9e80f9");
+
+const xAxis = new THREE.Vector3();
+const yAxis = new THREE.Vector3();
+const zAxis = new THREE.Vector3(0, 0, 1);
+const letterBasis = new THREE.Matrix4();
+
+/**
+ * Orient a glyph in the billboard's local XY plane (+Y is screen-up once the
+ * group faces the camera) so its baseline follows the circle tangent at
+ * `angle`, with the top of the letter pointing radially outward.
+ */
+function orientLetter(quaternion: THREE.Quaternion, angle: number) {
+  // Reading direction (left→right along the top runs clockwise, i.e. toward
+  // decreasing angle) and radial-outward "up" for the glyph.
+  xAxis.set(Math.sin(angle), -Math.cos(angle), 0);
+  yAxis.set(Math.cos(angle), Math.sin(angle), 0);
+  letterBasis.makeBasis(xAxis, yAxis, zAxis);
+  quaternion.setFromRotationMatrix(letterBasis);
+}
+
+export default function AboutRing({
+  active,
+  isNightMode,
+}: {
+  /** True on the home view — the label fades in once the camera settles */
+  active: boolean;
+  isNightMode: boolean;
+}) {
+  const group = useRef<THREE.Group>(null);
+  const opacity = useRef(0);
+  const fontReady = useRetroFloralReady(ABOUT_FONT);
+
+  const letters = useMemo((): CurvedLetter[] | null => {
+    if (!fontReady) return null;
+
+    const charWidths = measureCharWidths(
+      ABOUT_TEXT,
+      ABOUT_FONT,
+      ABOUT_FONT_SIZE * 0.6,
+    );
+    const totalWidth = charWidths.reduce((sum, width) => sum + width, 0);
+    if (totalWidth <= 0) return null;
+
+    const overlayRadius = EARTH.radius * ABOUT_RING_SCALE;
+    const worldRadius = overlayRadius * ABOUT_PATH_RADIUS_FRAC;
+    const worldFontSize = overlayRadius * 2 * ABOUT_FONT_FRAC;
+    const worldArcLength = totalWidth * (worldFontSize / ABOUT_FONT_SIZE);
+    const totalAngle = worldArcLength / worldRadius;
+    // Center the word over the top of Earth (local +Y). Reading L→R runs
+    // clockwise, so step through decreasing angle.
+    let angle = Math.PI / 2 + totalAngle / 2;
+
+    return charWidths.map((width, index) => {
+      const char = ABOUT_TEXT[index] ?? "";
+      const letterArc = (width / totalWidth) * totalAngle;
+      angle -= letterArc / 2;
+
+      const letter = createLetterPlane(
+        char,
+        width,
+        ABOUT_FONT_SIZE,
+        worldFontSize,
+        ABOUT_FONT,
+      );
+      letter.position.set(
+        Math.cos(angle) * worldRadius,
+        Math.sin(angle) * worldRadius,
+        0,
+      );
+      orientLetter(letter.quaternion, angle);
+
+      angle -= letterArc / 2;
+      return letter;
+    });
+  }, [fontReady]);
+
+  useEffect(
+    () => () => {
+      letters?.forEach(({ material, geometry }) => {
+        material.map?.dispose();
+        material.dispose();
+        geometry.dispose();
+      });
+    },
+    [letters],
+  );
+
+  useFrame(({ camera }, delta) => {
+    // Billboard: match the camera's orientation so the ring always faces us
+    if (group.current) group.current.quaternion.copy(camera.quaternion);
+    if (!letters) return;
+
+    // Fade in only once the camera settles on the home view (mirrors the old
+    // DOM ring's opacity transition); fade back out otherwise.
+    const targetOpacity = active && rigState.settled ? 1 : 0;
+    opacity.current += (targetOpacity - opacity.current) * Math.min(1, delta * 4);
+
+    const base = isNightMode ? NIGHT_COLOR : DAY_COLOR;
+    const targetColor = hoverState.earth ? HOVER_COLOR : base;
+    const colorEase = Math.min(1, delta * 10);
+    for (const { material } of letters) {
+      material.opacity = opacity.current;
+      material.color.lerp(targetColor, colorEase);
+    }
+  });
+
+  if (!letters) return null;
+
+  return (
+    <group ref={group}>
+      {letters.map(({ material, geometry, position, quaternion }, index) => (
+        <mesh
+          key={index}
+          geometry={geometry}
+          material={material}
+          position={position}
+          quaternion={quaternion}
+          renderOrder={50}
+        />
+      ))}
+    </group>
+  );
+}

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -4,7 +4,9 @@ import * as THREE from "three";
 import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 
 import { planetPosition, type SolarPlanetConfig } from "./constants";
-import { createGitHubMarkTexture, createPlanetTexture } from "../textures";
+import { asteroidOutlineId } from "./BodyAnchors";
+import { createLogoBadgeTexture, createPlanetTexture } from "../textures";
+import { hoverState } from "../../solarHover";
 
 /**
  * A small rocky link-asteroid: a jittered icosahedron (lumpy, flat-shaded)
@@ -13,26 +15,78 @@ import { createGitHubMarkTexture, createPlanetTexture } from "../textures";
  * matching DOM link overlay is glued to it by BodyAnchors via the same
  * planetPosition() the mesh uses, so the two can't drift apart.
  *
- * `withGithubLogo` projects a GitHub-mark badge onto two opposite sides of
- * the rock's surface (DecalGeometry clips the sticker to the mesh, so it
- * follows the lumps and spins with them).
+ * `config.logo` projects a brand badge onto two opposite sides of the
+ * rock's surface (DecalGeometry clips the sticker to the mesh, so it
+ * follows the lumps and spins with them). Logo rocks spin about the
+ * world-vertical axis only — the decals' texture-up stays world-up, so
+ * the mark always reads (approximately) right-side up as it pans by.
+ *
+ * `visible` fades the whole rock (materials' opacity eased per frame):
+ * the asteroids are hidden in the landing view and fade in during the
+ * swoop to the home perch.
  */
+const FADE_IN_SECONDS = 3;
+const FADE_OUT_SECONDS = 1;
+
+const scratchVertex = new THREE.Vector3();
+
+type Point2 = [number, number];
+
+const cross = (o: Point2, a: Point2, b: Point2) =>
+  (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+
+/** Convex hull (Andrew's monotone chain), counter-clockwise. The rock is
+ *  a jittered icosahedron — near-convex — so the hull of its projected
+ *  vertices is an excellent stand-in for its screen silhouette. */
+function convexHull(points: Point2[]): Point2[] {
+  const pts = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  if (pts.length <= 3) return pts;
+  const lower: Point2[] = [];
+  for (const p of pts) {
+    while (
+      lower.length >= 2 &&
+      cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0
+    ) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+  const upper: Point2[] = [];
+  for (let i = pts.length - 1; i >= 0; i--) {
+    const p = pts[i];
+    while (
+      upper.length >= 2 &&
+      cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0
+    ) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+  lower.pop();
+  upper.pop();
+  return lower.concat(upper);
+}
+
 export default function Asteroid({
   config,
-  withGithubLogo = false,
+  visible = true,
 }: {
   config: SolarPlanetConfig;
-  withGithubLogo?: boolean;
+  visible?: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const rockMaterial = useRef<THREE.MeshStandardMaterial>(null);
+  // Start faded out when mounting into a view that hides asteroids (the
+  // landing page), fully shown when mounting straight into /home
+  const opacity = useRef(visible ? 1 : 0);
 
   const texture = useMemo(() => createPlanetTexture(config.kind), [config]);
   useEffect(() => () => texture.dispose(), [texture]);
 
   const logoTexture = useMemo(
-    () => (withGithubLogo ? createGitHubMarkTexture() : null),
-    [withGithubLogo],
+    () => (config.logo ? createLogoBadgeTexture(config.logo) : null),
+    [config.logo],
   );
   useEffect(() => () => logoTexture?.dispose(), [logoTexture]);
 
@@ -62,7 +116,7 @@ export default function Asteroid({
   // spinning mesh keeps them glued to the lumps they were cut from. The
   // box is sized to swallow the full jitter range (0.8r..1.2r).
   const decalGeometries = useMemo(() => {
-    if (!withGithubLogo) return null;
+    if (!config.logo) return null;
     const r = config.radius;
     const target = new THREE.Mesh(geometry);
     const size = new THREE.Vector3(r * 1.82, r * 1.82, r * 1.6);
@@ -80,30 +134,111 @@ export default function Asteroid({
         size,
       ),
     ];
-  }, [withGithubLogo, geometry, config.radius]);
+  }, [config.logo, geometry, config.radius]);
   useEffect(
     () => () => decalGeometries?.forEach((g) => g.dispose()),
     [decalGeometries],
   );
 
-  useFrame(({ clock }, delta) => {
+  useFrame(({ clock, camera, size }, delta) => {
+    const hovered = hoverState.asteroid === config.name;
+
     if (group.current) {
       planetPosition(config, clock.elapsedTime, group.current.position);
+
+      // Linear ramp toward shown/hidden — a slow 3s reveal riding the
+      // landing->home swoop, a quicker 1s exit on the way back — pushed
+      // into the rock and decal materials (a group-level opacity doesn't
+      // exist in three)
+      const step = visible
+        ? delta / FADE_IN_SECONDS
+        : -delta / FADE_OUT_SECONDS;
+      opacity.current = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
+      group.current.visible = opacity.current > 0.005;
+      group.current.traverse((obj) => {
+        const material = (obj as THREE.Mesh).material;
+        if (material && !Array.isArray(material)) {
+          material.opacity = opacity.current;
+        }
+      });
     }
-    if (mesh.current) {
+    // Hover freezes the tumble (the outline below is cut from the frozen
+    // pose, and a spinning rock under a static outline would look broken)
+    if (mesh.current && !hovered) {
       mesh.current.rotation.y += delta * config.spinSpeed;
-      mesh.current.rotation.x += delta * config.spinSpeed * 0.3;
+      // Logo rocks skip the x-axis tumble: any pitch would tilt the badge
+      // (projected with texture-up = +y), and yaw-only spin can't
+      if (!config.logo) {
+        mesh.current.rotation.x += delta * config.spinSpeed * 0.3;
+      }
+    }
+    if (rockMaterial.current) {
+      // Hovering the rock's link washes the surface out to near-white
+      // (flat white emissive over the texture); the unlit decal badges
+      // have their own materials and don't change
+      const ease = Math.min(delta * 6, 1);
+      rockMaterial.current.emissiveIntensity +=
+        ((hovered ? 0.9 : 0) - rockMaterial.current.emissiveIntensity) * ease;
+    }
+    if (hovered && mesh.current) {
+      // Cut the rock's screen silhouette in its frozen pose and hand it to
+      // the DOM overlay's outline paths. Recomputed per frame (cheap: a
+      // couple hundred vertices) so it tracks the slow orbital drift; the
+      // SHAPE stays put because the spin is frozen while hovered.
+      const outlineGroup = document.getElementById(
+        asteroidOutlineId(config.name),
+      );
+      const svg = outlineGroup?.closest("svg");
+      if (outlineGroup && svg) {
+        mesh.current.updateWorldMatrix(true, false);
+        const positions = geometry.getAttribute(
+          "position",
+        ) as THREE.BufferAttribute;
+        const points: Point2[] = [];
+        for (let i = 0; i < positions.count; i++) {
+          scratchVertex
+            .fromBufferAttribute(positions, i)
+            .applyMatrix4(mesh.current.matrixWorld)
+            .project(camera);
+          points.push([
+            (scratchVertex.x * 0.5 + 0.5) * size.width,
+            (0.5 - scratchVertex.y * 0.5) * size.height,
+          ]);
+        }
+        // Map viewport px -> the overlay svg's 0-100 viewBox (its rect is
+        // the anchor box BodyAnchors placed around the rock's projection)
+        const rect = svg.getBoundingClientRect();
+        if (rect.width > 0) {
+          const d =
+            convexHull(points)
+              .map(
+                ([x, y], i) =>
+                  `${i === 0 ? "M" : "L"}${(((x - rect.left) / rect.width) * 100).toFixed(2)} ${(((y - rect.top) / rect.height) * 100).toFixed(2)}`,
+              )
+              .join(" ") + " Z";
+          outlineGroup.querySelectorAll("path").forEach((path) => {
+            path.setAttribute("d", d);
+          });
+        }
+      }
     }
   });
 
   return (
     <group ref={group}>
       <mesh ref={mesh} geometry={geometry}>
+        {/* transparent so the landing->home fade-in can drive opacity;
+            the white emissive is the hover brighten (intensity eased
+            0 -> 0.9 in useFrame) */}
         <meshStandardMaterial
+          ref={rockMaterial}
           map={texture}
           roughness={1}
           metalness={0}
           flatShading
+          transparent
+          emissive="#ffffff"
+          emissiveIntensity={0}
         />
         {logoTexture &&
           decalGeometries?.map((decalGeometry, i) => (

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -26,6 +26,9 @@ import { liveElementById } from "../svgTracking";
 
 export const EARTH_ABOUT_RING_ID = "earth-about-ring";
 export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;
+/** Group inside the anchor holding the hover-outline paths; Asteroid
+ *  writes the projected silhouette into every path under it. */
+export const asteroidOutlineId = (name: string) => `asteroid-outline-${name}`;
 
 interface BodyAnchorConfig {
   domId: string;

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -24,7 +24,13 @@ export type SolarView = "landing" | "home" | "about";
 const LANDING_POS = new THREE.Vector3(0, 35, 0.01);
 const ORIGIN = new THREE.Vector3(0, 0, 0);
 const UP = new THREE.Vector3(0, 1, 0);
-const TRANSITION_SECONDS = 3.2;
+const TRANSITION_SECONDS = 2;
+
+// On lg/xl screens, pan the top-down landing camera straight down (world −Z
+// is screen-up, so panning −Z drops the sun below center). A pure pan keeps
+// the orbital diagram flat/undistorted rather than tilting it into ellipses.
+// Expressed in vh below the viewport's vertical center (50vh = half-height).
+const LANDING_SUN_DROP_VH = 15;
 
 // Home-view framing: the sun-perch. Offsets from the SUN's center (r 3),
 // on the far side from Earth, elevated well above the surface so the
@@ -62,15 +68,16 @@ const ABOUT_MOON_NDC_X = -0.5;
 const ABOUT_MOON_NDC_Y_LIFT = 0.4;
 const LG_BREAKPOINT_PX = 1280;
 
-// scratch vectors, reused every frame
+// scratch values, reused every frame
 const goalPos = new THREE.Vector3();
 const goalLook = new THREE.Vector3();
 const earthPos = new THREE.Vector3();
 const moonPos = new THREE.Vector3();
 const toEarth = new THREE.Vector3();
 const moonDir = new THREE.Vector3();
-const viewDir = new THREE.Vector3();
 const side = new THREE.Vector3();
+const goalQuat = new THREE.Quaternion();
+const lookMatrix = new THREE.Matrix4();
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
@@ -83,8 +90,18 @@ function computeGoal(
   viewport: { width: number; height: number },
 ) {
   if (view === "landing") {
-    goalPos.copy(LANDING_POS);
-    goalLook.copy(ORIGIN);
+    if (viewport.width >= LG_BREAKPOINT_PX) {
+      // Drop the sun below center by panning the camera + look target the
+      // same amount in −Z (screen-down), so the view stays straight-down.
+      const persp = camera as THREE.PerspectiveCamera;
+      const tanHalfV = Math.tan((persp.fov * Math.PI) / 360);
+      const drop = (LANDING_SUN_DROP_VH / 50) * tanHalfV * LANDING_POS.y;
+      goalPos.set(LANDING_POS.x, LANDING_POS.y, LANDING_POS.z - drop);
+      goalLook.set(0, 0, -drop);
+    } else {
+      goalPos.copy(LANDING_POS);
+      goalLook.copy(ORIGIN);
+    }
   } else if (view === "about") {
     // Perch over Earth's limb opposite the moon, riding the moon's orbit:
     // Earth's top curve fills the bottom of the frame and the moon stays
@@ -149,7 +166,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
   const activeView = useRef(view);
   const transitionStart = useRef(-Infinity);
   const fromPos = useRef(LANDING_POS.clone());
-  const fromLook = useRef(ORIGIN.clone());
+  const fromQuat = useRef(new THREE.Quaternion());
 
   useFrame(({ camera, clock, size }) => {
     const t = clock.elapsedTime;
@@ -159,8 +176,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
       activeView.current = view;
       transitionStart.current = t;
       fromPos.current.copy(camera.position);
-      camera.getWorldDirection(viewDir);
-      fromLook.current.copy(camera.position).addScaledVector(viewDir, 20);
+      fromQuat.current.copy(camera.quaternion);
     }
 
     computeGoal(view, t, camera, size);
@@ -168,10 +184,16 @@ export default function CameraRig({ view }: { view: SolarView }) {
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
     rigState.settled = p >= 1;
     if (p < 1) {
+      // Movement and rotation ride the same eased progress: the position
+      // lerps to the perch while the orientation slerps to the arrival
+      // pose, so the whole spin is spread evenly across the transition
+      // (lerping a look POINT instead whipped the view around wherever
+      // the point's chord passed near the camera — spin first, then zoom)
       const e = easeInOutCubic(p);
       camera.position.lerpVectors(fromPos.current, goalPos, e);
-      goalLook.lerpVectors(fromLook.current, goalLook, e);
-      camera.lookAt(goalLook);
+      lookMatrix.lookAt(goalPos, goalLook, UP);
+      goalQuat.setFromRotationMatrix(lookMatrix);
+      camera.quaternion.slerpQuaternions(fromQuat.current, goalQuat, e);
     } else {
       // fully arrived: track the (possibly moving) goal exactly
       camera.position.copy(goalPos);

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -15,16 +15,25 @@ import moonMapUrl from "../../assets/moon.jpg";
  * emissive) so the /about camera — which perches over the moon's far side
  * — still reads it when that face is turned away from the sun.
  */
+/** Fade duration for the landing-intro reveal */
+const REVEAL_SECONDS = 0.8;
+
 export default function Moon({
   orbitColor,
   orbitOpacity,
+  revealed = true,
 }: {
   orbitColor: string;
   orbitOpacity: number;
+  /** Fades the moon + its orbit ring in (landing intro) */
+  revealed?: boolean;
 }) {
   const earthGroup = useRef<THREE.Group>(null);
   const moonGroup = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
+  const orbitMaterial = useRef<THREE.LineBasicMaterial>(null);
+  const revealOpacity = useRef(revealed ? 1 : 0);
 
   const texture = useMemo(() => {
     const tex = new THREE.TextureLoader().load(moonMapUrl);
@@ -66,12 +75,26 @@ export default function Moon({
     if (mesh.current) {
       mesh.current.rotation.y += delta * MOON.spinSpeed;
     }
+
+    // Landing-intro reveal: fade the moon + its orbit ring in with the planets
+    revealOpacity.current = THREE.MathUtils.clamp(
+      revealOpacity.current + (revealed ? delta : -delta) / REVEAL_SECONDS,
+      0,
+      1,
+    );
+    if (surfaceMaterial.current) {
+      surfaceMaterial.current.opacity = revealOpacity.current;
+    }
+    if (orbitMaterial.current) {
+      orbitMaterial.current.opacity = orbitOpacity * revealOpacity.current;
+    }
   });
 
   return (
     <group ref={earthGroup}>
       <lineLoop geometry={orbitLine}>
         <lineBasicMaterial
+          ref={orbitMaterial}
           color={orbitColor}
           transparent
           opacity={orbitOpacity}
@@ -81,12 +104,14 @@ export default function Moon({
         <mesh ref={mesh}>
           <sphereGeometry args={[MOON.radius, 48, 48]} />
           <meshStandardMaterial
+            ref={surfaceMaterial}
             map={texture}
             roughness={1}
             metalness={0}
             emissive="#aab1bd"
             emissiveMap={texture}
             emissiveIntensity={0.22}
+            transparent
           />
         </mesh>
       </group>

--- a/src/space3d/solar/Planet.tsx
+++ b/src/space3d/solar/Planet.tsx
@@ -5,27 +5,46 @@ import * as THREE from "three";
 import { planetPosition, type SolarPlanetConfig } from "./constants";
 import { createPlanetTexture } from "../textures";
 import { hoverState } from "../../solarHover";
+import AboutRing from "./AboutRing";
 import earthMapUrl from "../../assets/earth.jpg";
 
 /**
  * One orbiting planet + its orbit ring, ported from hunt-codes-3.
  * Textures are the shared procedural canvas maps; Earth gets a faint
  * back-side atmosphere shell. Positions come from the shared clock so
- * the camera rig can compute the same orbit for its Earth perch.
+ * the camera rig can compute the same orbit for its Earth perch. Earth
+ * also carries the curved "ABOUT ME" link label (space3d AboutRing).
  */
+/** Fade duration for the landing-intro reveal */
+const REVEAL_SECONDS = 0.8;
+
 export default function Planet({
   config,
   orbitColor,
   orbitOpacity,
+  isNightMode = true,
+  aboutActive = false,
+  revealed = true,
 }: {
   config: SolarPlanetConfig;
   orbitColor: string;
   orbitOpacity: number;
+  /** Drives the Earth "ABOUT ME" label color (white at night, purple in day) */
+  isNightMode?: boolean;
+  /** Show the Earth "ABOUT ME" label (home view only) */
+  aboutActive?: boolean;
+  /** Fades the planet + its orbit ring in (landing intro) */
+  revealed?: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
   const atmosphereMaterial = useRef<THREE.MeshBasicMaterial>(null);
+  const orbitMaterial = useRef<THREE.LineBasicMaterial>(null);
+  const revealOpacity = useRef(revealed ? 1 : 0);
+  // Atmosphere base opacity (hover-eased); multiplied by the reveal so the
+  // fade-in and the hover swell compose instead of fighting each other
+  const atmosphereBase = useRef(0.16);
 
   const texture = useMemo(() => {
     if (config.kind === "earth") {
@@ -66,14 +85,31 @@ export default function Planet({
     if (mesh.current) {
       mesh.current.rotation.y += delta * config.spinSpeed;
     }
+
+    // Landing-intro reveal: ramp opacity 0→1 (or back) and push it into the
+    // surface + orbit ring, so the planets fade in a beat after the sun.
+    revealOpacity.current = THREE.MathUtils.clamp(
+      revealOpacity.current + (revealed ? delta : -delta) / REVEAL_SECONDS,
+      0,
+      1,
+    );
+    if (surfaceMaterial.current) {
+      surfaceMaterial.current.opacity = revealOpacity.current;
+    }
+    if (orbitMaterial.current) {
+      orbitMaterial.current.opacity = orbitOpacity * revealOpacity.current;
+    }
+
     if (config.kind === "earth") {
-      // Ease the glow up while the "About Andrew" ring/planet is hovered:
+      // Ease the glow up while the "About Me" ring/planet is hovered:
       // the atmosphere shell thickens and the earthshine brightens
       const hovered = hoverState.earth;
       const ease = Math.min(delta * 6, 1);
+      atmosphereBase.current +=
+        ((hovered ? 0.5 : 0.16) - atmosphereBase.current) * ease;
       if (atmosphereMaterial.current) {
-        atmosphereMaterial.current.opacity +=
-          ((hovered ? 0.5 : 0.16) - atmosphereMaterial.current.opacity) * ease;
+        atmosphereMaterial.current.opacity =
+          atmosphereBase.current * revealOpacity.current;
       }
       if (surfaceMaterial.current) {
         surfaceMaterial.current.emissiveIntensity +=
@@ -88,6 +124,7 @@ export default function Planet({
     <>
       <lineLoop geometry={orbitLine}>
         <lineBasicMaterial
+          ref={orbitMaterial}
           color={orbitColor}
           transparent
           opacity={orbitOpacity}
@@ -109,12 +146,15 @@ export default function Planet({
               emissive="#a7bad4"
               emissiveMap={texture}
               emissiveIntensity={0.38}
+              transparent
             />
           ) : (
             <meshStandardMaterial
+              ref={surfaceMaterial}
               map={texture}
               roughness={0.95}
               metalness={0}
+              transparent
             />
           )}
         </mesh>
@@ -130,6 +170,11 @@ export default function Planet({
               side={THREE.BackSide}
             />
           </mesh>
+        )}
+        {/* Curved "ABOUT ME" link label, billboarded around Earth. Lives in
+            the group (not the spinning mesh) so it stays put over Earth. */}
+        {config.kind === "earth" && (
+          <AboutRing active={aboutActive} isNightMode={isNightMode} />
         )}
       </group>
     </>

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
 import CameraRig, { type SolarView } from "./CameraRig";
@@ -19,6 +19,15 @@ import { ASTEROIDS, PLANETS } from "./constants";
  * The canvas never takes pointer input — the clickable sun rings are
  * DOM/SVG overlays that SunSvgAnchor glues to the projected sun.
  */
+
+// First landing load plays a staggered reveal: the sun is up immediately,
+// the planets fade in at +1s and the "ENTER" ring at +2s. Only the very
+// first landing visit runs it — remounts / returning from /home skip
+// straight to fully shown so the scene doesn't blink out.
+const PLANETS_DELAY_MS = 1000;
+const ENTER_DELAY_MS = 2000;
+let hasPlayedLandingIntro = false;
+
 const SolarScene = ({
   view,
   isNightMode,
@@ -26,6 +35,34 @@ const SolarScene = ({
   view: SolarView;
   isNightMode: boolean;
 }) => {
+  const isLanding = view === "landing";
+  const [planetsRevealed, setPlanetsRevealed] = useState(
+    () => hasPlayedLandingIntro || !isLanding,
+  );
+  const [enterRevealed, setEnterRevealed] = useState(
+    () => hasPlayedLandingIntro || !isLanding,
+  );
+
+  useEffect(() => {
+    if (hasPlayedLandingIntro || !isLanding) {
+      setPlanetsRevealed(true);
+      setEnterRevealed(true);
+      return;
+    }
+    const planetsTimer = window.setTimeout(
+      () => setPlanetsRevealed(true),
+      PLANETS_DELAY_MS,
+    );
+    const enterTimer = window.setTimeout(() => {
+      setEnterRevealed(true);
+      hasPlayedLandingIntro = true;
+    }, ENTER_DELAY_MS);
+    return () => {
+      window.clearTimeout(planetsTimer);
+      window.clearTimeout(enterTimer);
+    };
+  }, [isLanding]);
+
   return (
     <Canvas
       className="solar-canvas"
@@ -43,8 +80,10 @@ const SolarScene = ({
       {/* From the home sun-perch the full glow would fill the frame and
           wash out the stars — shrink it to hug the limb there */}
       <Sun
-        targetGlowScale={view === "home" ? 2.5 : 6}
+        targetGlowScale={view === "home" ? 2.5 : 4}
         isNightMode={isNightMode}
+        showEnterRing={isLanding}
+        enterRevealed={enterRevealed}
       />
       {PLANETS.map((planet) => (
         <Planet
@@ -53,17 +92,23 @@ const SolarScene = ({
           // hunt-codes-3's faint white rings, flipped dark for day mode
           orbitColor={isNightMode ? "#ffffff" : "#141428"}
           orbitOpacity={isNightMode ? 0.08 : 0.2}
+          isNightMode={isNightMode}
+          aboutActive={view === "home"}
+          revealed={planetsRevealed}
         />
       ))}
       <Moon
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.08 : 0.2}
+        revealed={planetsRevealed}
       />
       {ASTEROIDS.map((asteroid) => (
+        // Hidden in the top-down landing view (they'd read as clutter
+        // around the sun); they fade in on the way to the home perch
         <Asteroid
           key={asteroid.name}
           config={asteroid}
-          withGithubLogo={asteroid.name === "github"}
+          visible={view !== "landing"}
         />
       ))}
       <CameraRig view={view} />

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -3,8 +3,16 @@ import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import { SUN_RADIUS, sunState } from "./constants";
+import { SUN_SIZE, SUN_SURFACE_RADIUS } from "../../landingScene";
 import { hoverState } from "../../solarHover";
 import { createSunGlowTexture, createSunTexture } from "../textures";
+import {
+  createLetterPlane,
+  measureCharWidths,
+  retroFloralFont,
+  useRetroFloralReady,
+  type CurvedLetter,
+} from "./curvedText";
 
 /**
  * The sun, ported from hunt-codes-3: a slowly rotating sphere with the
@@ -22,18 +30,161 @@ import { createSunGlowTexture, createSunTexture } from "../textures";
 // subtler lift.
 const DAY_TINT = new THREE.Color(1.55, 1.55, 1.7);
 const NIGHT_TINT = new THREE.Color(1.12, 1.12, 1.15);
+const ENTER_TEXT = "ENTER";
+const ENTER_FONT_SIZE_SVG = 22;
+/** Enlarge the curved "ENTER" label relative to its SVG-derived size */
+const ENTER_TEXT_SCALE = 1.5;
+/** Push the label off the sun's surface by ~10% of the sun's diameter */
+const ENTER_SURFACE_OFFSET = 0.2 * SUN_RADIUS;
+/** SunInternals #circle2 — the textPath the SVG "ENTER" link follows */
+const ENTER_RING_OUTER_RADIUS = 200 * SUN_SIZE;
+const ENTER_FONT = retroFloralFont(ENTER_FONT_SIZE_SVG);
+const ENTER_TEXT_COLOR = new THREE.Color("#ffffff");
+const ENTER_DAY_COLOR = new THREE.Color("#412596");
+const ENTER_HOVER_COLOR = new THREE.Color("#9e80f9");
+/** Fade duration for the landing-intro reveal of the ENTER label */
+const ENTER_REVEAL_SECONDS = 0.8;
+
+const letterBasis = new THREE.Matrix4();
+const tangentAxis = new THREE.Vector3();
+const radialAxis = new THREE.Vector3();
+const upAxis = new THREE.Vector3(0, 1, 0);
+
+/**
+ * Orient a glyph flat in the XZ plane (facing the top-down camera) with its
+ * baseline along the circle tangent at `angle`, so the word curves around the
+ * sun the way an SVG textPath does.
+ */
+function orientLetter(quaternion: THREE.Quaternion, angle: number) {
+  tangentAxis.set(-Math.sin(angle), 0, Math.cos(angle));
+  radialAxis.set(Math.cos(angle), 0, Math.sin(angle));
+  letterBasis.makeBasis(tangentAxis, radialAxis, upAxis);
+  quaternion.setFromRotationMatrix(letterBasis);
+}
+
+/** Curved "ENTER" text above the sun, matching the landing SVG textPath. */
+function EnterRing({
+  isNightMode,
+  revealed,
+}: {
+  isNightMode: boolean;
+  /** Fades the label in (the landing intro reveals it after the planets) */
+  revealed: boolean;
+}) {
+  const fontReady = useRetroFloralReady(ENTER_FONT);
+  const opacity = useRef(revealed ? 1 : 0);
+
+  const letters = useMemo((): CurvedLetter[] | null => {
+    if (!fontReady) return null;
+
+    const charWidths = measureCharWidths(
+      ENTER_TEXT,
+      ENTER_FONT,
+      ENTER_FONT_SIZE_SVG * 0.6,
+    );
+    const totalWidth = charWidths.reduce((sum, width) => sum + width, 0);
+    if (totalWidth <= 0) return null;
+
+    const worldFontSize =
+      SUN_RADIUS * (ENTER_FONT_SIZE_SVG / SUN_SURFACE_RADIUS) * ENTER_TEXT_SCALE;
+    // Float the ring off the sun's surface by ~10% of its diameter so the
+    // (now larger) word clears the limb instead of grazing it.
+    const worldRadius =
+      SUN_RADIUS * (ENTER_RING_OUTER_RADIUS / SUN_SURFACE_RADIUS) +
+      ENTER_SURFACE_OFFSET;
+    const worldArcLength = totalWidth * (worldFontSize / ENTER_FONT_SIZE_SVG);
+    const totalAngle = worldArcLength / worldRadius;
+    // Center the word at the top of the screen (−Z is screen-up for the
+    // top-down landing camera); increasing angle runs left→right.
+    let angle = -Math.PI / 2 - totalAngle / 2;
+
+    return charWidths.map((width, index) => {
+      const char = ENTER_TEXT[index] ?? "";
+      const letterArc = (width / totalWidth) * totalAngle;
+      angle += letterArc / 2;
+
+      const letter = createLetterPlane(
+        char,
+        width,
+        ENTER_FONT_SIZE_SVG,
+        worldFontSize,
+        ENTER_FONT,
+      );
+      letter.position.set(
+        Math.cos(angle) * worldRadius,
+        0.04,
+        Math.sin(angle) * worldRadius,
+      );
+      orientLetter(letter.quaternion, angle);
+
+      angle += letterArc / 2;
+      return letter;
+    });
+  }, [fontReady]);
+
+  useEffect(
+    () => () => {
+      letters?.forEach(({ material, geometry }) => {
+        material.map?.dispose();
+        material.dispose();
+        geometry.dispose();
+      });
+    },
+    [letters],
+  );
+
+  useFrame((_, delta) => {
+    if (!letters) return;
+    opacity.current = THREE.MathUtils.clamp(
+      opacity.current + (revealed ? delta : -delta) / ENTER_REVEAL_SECONDS,
+      0,
+      1,
+    );
+    const base = isNightMode ? ENTER_TEXT_COLOR : ENTER_DAY_COLOR;
+    const target = hoverState.sun ? ENTER_HOVER_COLOR : base;
+    const ease = Math.min(1, delta * 10);
+    for (const { material } of letters) {
+      material.color.lerp(target, ease);
+      material.opacity = opacity.current;
+    }
+  });
+
+  if (!letters) return null;
+
+  return (
+    <group>
+      {letters.map(({ material, geometry, position, quaternion }, index) => (
+        <mesh
+          key={index}
+          geometry={geometry}
+          material={material}
+          position={position}
+          quaternion={quaternion}
+          renderOrder={50}
+        />
+      ))}
+    </group>
+  );
+}
 
 export default function Sun({
   targetScale = 1,
   targetGlowScale = 6,
   isNightMode,
+  showEnterRing = false,
+  enterRevealed = true,
 }: {
   targetScale?: number;
   /** Glow sprite size as a multiple of SUN_RADIUS (eased) */
   targetGlowScale?: number;
   isNightMode: boolean;
+  /** Landing-only curved "ENTER" link label */
+  showEnterRing?: boolean;
+  /** Fades the ENTER label in during the landing intro */
+  enterRevealed?: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
+  const enterScaler = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const glow = useRef<THREE.Sprite>(null);
   const materialRef = useRef<THREE.MeshBasicMaterial>(null);
@@ -66,6 +217,7 @@ export default function Sun({
       const next = current + (targetScale - current) * ease;
       group.current.scale.setScalar(next);
       sunState.scale = next;
+      enterScaler.current?.scale.setScalar(next);
     }
     if (glow.current) {
       // Hovering the ENTER link (or the sun itself) swells the glow
@@ -85,34 +237,41 @@ export default function Sun({
   });
 
   return (
-    <group ref={group}>
-      <mesh ref={mesh}>
-        <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
-        <meshBasicMaterial ref={materialRef} map={texture} toneMapped={false} />
-        {/* Crossfading spot layer, drawn just over the base surface */}
-        <mesh scale={1.001} renderOrder={1}>
+    <>
+      <group ref={group}>
+        <mesh ref={mesh}>
           <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
-          <meshBasicMaterial
-            ref={spotsMaterialRef}
-            map={spotsTexture}
-            toneMapped={false}
-            transparent
-            opacity={0}
-            depthWrite={false}
-          />
+          <meshBasicMaterial ref={materialRef} map={texture} toneMapped={false} />
+          {/* Crossfading spot layer, drawn just over the base surface */}
+          <mesh scale={1.001} renderOrder={1}>
+            <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
+            <meshBasicMaterial
+              ref={spotsMaterialRef}
+              map={spotsTexture}
+              toneMapped={false}
+              transparent
+              opacity={0}
+              depthWrite={false}
+            />
+          </mesh>
         </mesh>
-      </mesh>
-      {/* soft corona billboard */}
-      <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>
-        <spriteMaterial
-          map={glowTexture}
-          transparent
-          depthWrite={false}
-          blending={THREE.AdditiveBlending}
-        />
-      </sprite>
-      {/* the sun is the scene's light source */}
-      <pointLight intensity={900} distance={0} decay={2} color="#fff2d5" />
-    </group>
+        {/* soft corona billboard */}
+        <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>
+          <spriteMaterial
+            map={glowTexture}
+            transparent
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </sprite>
+        {/* the sun is the scene's light source */}
+        <pointLight intensity={900} distance={0} decay={2} color="#fff2d5" />
+      </group>
+      {showEnterRing && (
+        <group ref={enterScaler}>
+          <EnterRing isNightMode={isNightMode} revealed={enterRevealed} />
+        </group>
+      )}
+    </>
   );
 }

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 
 import type { PlanetKind } from "../../landingScene";
+import type { AsteroidLogo } from "../textures";
 
 /**
  * The 3D solar system, ported from the hunt-codes-3 prototype. World
@@ -21,6 +22,13 @@ export interface SolarPlanetConfig {
   orbitPhase: number;
   /** radians per second of self-rotation */
   spinSpeed: number;
+  /** Vertical (world-Y) offset from the orbital plane, world units.
+   *  Planets sit at y=0; asteroids float a bit higher (near the sun's
+   *  top) so they don't read as level with the sun's equator. */
+  yOffset?: number;
+  /** Brand badge decal projected onto both sides of the body (asteroids
+   *  with a logo also spin upright-only so the mark stays readable) */
+  logo?: AsteroidLogo;
 }
 
 export const SUN_RADIUS = 3;
@@ -35,17 +43,18 @@ export const sunState = { scale: 1 };
 /**
  * Whether the camera has finished its swoop to the current view. Written
  * by CameraRig each frame; overlays that should only appear once the
- * camera settles (the Earth "About Andrew" ring) read it.
+ * camera settles (the Earth "About Me" ring) read it.
  */
 export const rigState = { settled: true };
 
+const EARTH_ORBIT_SPEED = 0.09;
 export const PLANETS: SolarPlanetConfig[] = [
   {
     name: "Mercury",
     kind: "mercury",
     radius: 0.55,
     orbitRadius: 7.5,
-    orbitSpeed: 0.22,
+    orbitSpeed: EARTH_ORBIT_SPEED,
     orbitPhase: 0.6,
     spinSpeed: 0.12,
   },
@@ -85,25 +94,44 @@ export const EARTH = PLANETS.find((p) => p.name === "Earth")!;
  * They orbit at exactly Earth's angular speed — the home camera co-rotates
  * with Earth, so matching it freezes them in place on screen, keeping
  * both links visible at fixed spots.
+ *
+ * They float `ASTEROID_Y` above the orbital plane so they line up roughly
+ * with the top of the sun rather than its equator.
  */
+const ASTEROID_Y = SUN_RADIUS;
 export const ASTEROIDS: SolarPlanetConfig[] = [
   {
     name: "recent",
     kind: "mercury",
     radius: 0.28,
-    orbitRadius: 5.2,
+    orbitRadius: 4.2,
     orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase + 0.35,
-    spinSpeed: 0.6,
+    spinSpeed: 0.2,
+    yOffset: ASTEROID_Y,
+    logo: "blog",
   },
   {
     name: "github",
     kind: "mercury",
-    radius: 0.22,
-    orbitRadius: 9.8,
+    radius: 0.32,
+    orbitRadius: 2.8,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase - 0.3,
-    spinSpeed: -0.45,
+    orbitPhase: EARTH.orbitPhase - 0.7,
+    spinSpeed: -0.25,
+    logo: "github",
+    yOffset: ASTEROID_Y,
+  },
+  {
+    name: "linkedin",
+    kind: "mercury",
+    radius: 0.22,
+    orbitRadius: 2.4,
+    orbitSpeed: EARTH.orbitSpeed,
+    orbitPhase: EARTH.orbitPhase - 1.15,
+    spinSpeed: 0.3,
+    logo: "linkedin",
+    yOffset: ASTEROID_Y,
   },
 ];
 
@@ -127,7 +155,7 @@ export function planetPosition(
   const angle = p.orbitPhase + t * p.orbitSpeed;
   return out.set(
     Math.cos(angle) * p.orbitRadius,
-    0,
+    p.yOffset ?? 0,
     Math.sin(angle) * p.orbitRadius,
   );
 }

--- a/src/space3d/solar/curvedText.ts
+++ b/src/space3d/solar/curvedText.ts
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import * as THREE from "three";
+
+import retroFloralUrl from "../../RetroFloral.ttf";
+
+/**
+ * Shared helpers for the curved ring labels ("ENTER" around the sun,
+ * "ABOUT ME" around Earth). Each glyph is rasterized to its own canvas
+ * texture and hung on a small plane mesh; the calling component arranges the
+ * planes along an arc (flat in the world for the top-down sun, billboarded
+ * for the perspective Earth). The font is the bundled Retro Floral face.
+ */
+
+/** `400 <px>px "Retro Floral"` — the family the ring labels render in. */
+export const retroFloralFont = (px: number) => `400 ${px}px "Retro Floral"`;
+
+let faceRegistered: Promise<void> | null = null;
+
+/** Register the bundled Retro Floral face with the document exactly once. */
+function registerRetroFloralFace(): Promise<void> {
+  if (!faceRegistered) {
+    faceRegistered = (async () => {
+      const face = new FontFace("Retro Floral", `url(${retroFloralUrl})`);
+      const loaded = await face.load();
+      document.fonts.add(loaded);
+    })();
+  }
+  return faceRegistered;
+}
+
+/**
+ * Resolve once Retro Floral is ready to rasterize at the *exact* `probeFont`
+ * string. `document.fonts.load` must be awaited per size string — loading one
+ * size doesn't guarantee a fresh offscreen canvas will use the face at another
+ * size, which is what made the labels intermittently fall back to serif.
+ */
+export async function ensureRetroFloralFont(probeFont: string): Promise<void> {
+  await registerRetroFloralFace();
+  await document.fonts.load(probeFont);
+}
+
+/** True once Retro Floral can be measured/rasterized for `probeFont`. */
+export function useRetroFloralReady(probeFont: string): boolean {
+  // Never trust `document.fonts.check()` for the initial value: it can report
+  // the family as available before a specific size is committed for canvas
+  // use. Always await the explicit per-size load below before rasterizing.
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setReady(false);
+    void (async () => {
+      try {
+        await ensureRetroFloralFont(probeFont);
+      } catch {
+        // Give up gracefully — the canvas will use a fallback rather than hang
+      }
+      if (!cancelled) setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [probeFont]);
+
+  return ready;
+}
+
+export interface CurvedLetter {
+  material: THREE.MeshBasicMaterial;
+  geometry: THREE.PlaneGeometry;
+  position: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+}
+
+/** Rasterize one glyph to an unlit, always-on-top plane mesh. */
+export function createLetterPlane(
+  char: string,
+  widthPx: number,
+  fontSizePx: number,
+  worldFontSize: number,
+  font: string,
+): CurvedLetter {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d")!;
+  const pad = 4;
+  const cssW = Math.max(Math.ceil(widthPx) + pad * 2, 8);
+  const cssH = Math.max(Math.ceil(fontSizePx * 1.25) + pad * 2, 8);
+  canvas.width = cssW * dpr;
+  canvas.height = cssH * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.font = font;
+  ctx.fillStyle = "#ffffff";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(char, cssW / 2, cssH / 2);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    toneMapped: false,
+    depthTest: false,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const aspect = cssW / cssH;
+  const geometry = new THREE.PlaneGeometry(
+    worldFontSize * aspect,
+    worldFontSize,
+  );
+
+  return {
+    material,
+    geometry,
+    position: new THREE.Vector3(),
+    quaternion: new THREE.Quaternion(),
+  };
+}
+
+/** Per-character advance widths for `text` at `font`, with a fallback width. */
+export function measureCharWidths(
+  text: string,
+  font: string,
+  fallback: number,
+): number[] {
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) return text.split("").map(() => fallback);
+  ctx.font = font;
+  return text.split("").map((char) => {
+    const width = ctx.measureText(char).width;
+    return width > 0 ? width : fallback;
+  });
+}

--- a/src/space3d/solar/projection.ts
+++ b/src/space3d/solar/projection.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 
 /**
  * Shared camera->screen projection for the DOM overlays that ride 3D
- * bodies (the sun rings, the Earth "About Andrew" ring, the asteroid
+ * bodies (the sun rings, the Earth "About Me" ring, the asteroid
  * links). Positions come out in CSS pixels; projR is the body's apparent
  * radius on screen.
  */
@@ -37,7 +37,8 @@ export function projectBody(
 
   const distance = camera.position.distanceTo(worldPos);
   out.projR =
-    (worldRadius / Math.max(distance, 1e-6) /
+    (worldRadius /
+      Math.max(distance, 1e-6) /
       Math.tan((camera.fov * Math.PI) / 360)) *
     (size.height / 2);
   return out;

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -195,9 +195,44 @@ const GITHUB_MARK_PATH =
   "1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 " +
   "17.592 24 12.297c0-6.627-5.373-12-12-12";
 
-/** White badge with the dark GitHub mark, transparent outside the disc —
- *  a "sticker" decal for the GitHub link asteroid. */
-export function createGitHubMarkTexture(): THREE.CanvasTexture {
+/** The LinkedIn logo (rounded square with "in" knocked out), from
+ *  simple-icons (CC0), in a 24x24 viewBox. */
+const LINKEDIN_MARK_PATH =
+  "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 " +
+  "0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 " +
+  "1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 " +
+  "7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 " +
+  "1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 " +
+  "13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 " +
+  "1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 " +
+  "22.271V1.729C24 .774 23.2 0 22.225 0z";
+
+/** The RSS/feed mark (dot + two arcs) — the generic "blog" icon — from
+ *  simple-icons (CC0), in a 24x24 viewBox. */
+const RSS_MARK_PATH =
+  "M19.199 24C19.199 13.467 10.533 4.8 0 4.8V0c13.165 0 24 10.835 24 " +
+  "24h-4.801zM3.291 17.415c1.814 0 3.293 1.479 3.293 3.295 0 1.813-1.485 " +
+  "3.29-3.301 3.29C1.47 24 0 22.526 0 20.71s1.475-3.294 3.291-3.295zM15." +
+  "909 24h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727 0 15.909 " +
+  "7.184 15.909 15.91z";
+
+export type AsteroidLogo = "github" | "linkedin" | "blog";
+
+const LOGO_MARKS: Record<
+  AsteroidLogo,
+  { path: string; color: string; scale: number }
+> = {
+  github: { path: GITHUB_MARK_PATH, color: "#5000f0", scale: 0.72 },
+  // The square marks are scaled down so their corners stay inside the disc
+  linkedin: { path: LINKEDIN_MARK_PATH, color: "#0a66c2", scale: 0.6 },
+  blog: { path: RSS_MARK_PATH, color: "#f26522", scale: 0.6 },
+};
+
+/** White badge disc with a brand mark, transparent outside the disc —
+ *  a "sticker" decal for the link asteroids. */
+export function createLogoBadgeTexture(
+  logo: AsteroidLogo,
+): THREE.CanvasTexture {
   const size = 256;
   const canvas = createCanvas(size, size);
   const ctx = canvas.getContext("2d");
@@ -206,15 +241,16 @@ export function createGitHubMarkTexture(): THREE.CanvasTexture {
   const c = size / 2;
   ctx.beginPath();
   ctx.arc(c, c, c * 0.98, 0, Math.PI * 2);
-  ctx.fillStyle = "#f6f8fa";
+  ctx.fillStyle = "#f6f8faaa";
   ctx.fill();
 
-  const scale = (size / 24) * 0.72; // mark at 72% of the badge
+  const mark = LOGO_MARKS[logo];
+  const scale = (size / 24) * mark.scale;
   ctx.translate(c, c);
   ctx.scale(scale, scale);
   ctx.translate(-12, -12);
-  ctx.fillStyle = "#5000f0"; // saturated indigo
-  ctx.fill(new Path2D(GITHUB_MARK_PATH));
+  ctx.fillStyle = mark.color;
+  ctx.fill(new Path2D(mark.path));
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   return asTexture(canvas);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,11 +3737,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.10.38":
-  version: 2.10.40
-  resolution: "baseline-browser-mapping@npm:2.10.40"
+  version: 2.10.41
+  resolution: "baseline-browser-mapping@npm:2.10.41"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/5d3547aa9333b71f6239db89ef9d4aaf32ec0ee6cfa307025842722b5d225026995185ae4fc1e12e84a22199c905411bf3cce8076ae0a445b342982eb025171e
+  checksum: 10c0/54e0832e4146f5db0df5fc51412e6f9580f4d2455b9cdfc219618c5722ea3de5938e442c7764759932975ddaf045446b4d4897ecfddbb3705c52ca4e2ab52adf
   languageName: node
   linkType: hard
 
@@ -3947,14 +3947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001769
-  resolution: "caniuse-lite@npm:1.0.30001769"
-  checksum: 10c0/161b8c30ab967371807d45d361f0d5bc06e38ef2dbf811493d70cd97c21e1522f5b91fd944c419a00047ee09c931ca64627f125a9ffa7a17a9fdff8dad9765b0
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001799":
+"caniuse-lite@npm:^1.0.30001718, caniuse-lite@npm:^1.0.30001799":
   version: 1.0.30001800
   resolution: "caniuse-lite@npm:1.0.30001800"
   checksum: 10c0/107ad692b89ce3b6c060f39159a19577b6b171c678a9174fbe827a6f3b2c3c9cd67f1e46076aa4731cefbd21ba2da754ca2300c6a448c7a05bdda078f73fa3b0


### PR DESCRIPTION
## Asteroid links
- All three asteroids (blog / GitHub / LinkedIn) now carry logo badge decals projected onto the rock surface (`DecalGeometry`): RSS mark in orange, GitHub octocat in indigo, LinkedIn square in brand blue, each on a translucent white disc on two opposite sides.
- Logo rocks spin yaw-only so the badges always read right-side up; asteroids float a sun-radius above the orbital plane.
- Hover: spin freezes, the rock brightens to near-white, and the old circular ring is replaced by the rock's actual projected silhouette (convex hull, recomputed from the frozen pose) stroked purple with white pulses chasing the perimeter via a normalized (`pathLength=100`) CSS dash animation.
- Hidden on the landing view; 3s fade-in riding the swoop to home, 1s fade-out heading back.

## WebGL "ABOUT ME" label
- The curved label around Earth moved from a DOM/SVG textPath overlay into the 3D scene (`AboutRing` + `curvedText`): per-letter canvas-textured planes on a billboarded ring, with the same fade-on-arrival and hover color as before. The DOM overlay remains as the invisible click target.

## Camera & choreography
- View transitions cut from 3.2s to 2s, and rotation is now a quaternion slerp running simultaneously with the position lerp (the old look-point lerp whipped the spin early — spin-then-zoom).
- On lg+ screens the landing view pans the sun 15vh below center.
- Interactive stars hold hidden for 2s after mount before their fade-in.
- Music autoplays when entering /home from the landing page (the ENTER click is the enabling user gesture).

## Misc
- Copy tweaks ("About Me"), home copy-email tooltip rework, small screen layout tweaks.