### PR TITLE
WebGL perf, animated sun shaders, star parallax, and solar-scene polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,11 @@
   "configurations": [
     {
       "name": "dev",
-      "runtimeExecutable": "yarn",
-      "runtimeArgs": ["start"],
+      "runtimeExecutable": "zsh",
+      "runtimeArgs": [
+        "-c",
+        "export PATH=\"$(ls -d $HOME/.nvm/versions/node/*/bin | sort -V | tail -1):$PATH\" && exec yarn start"
+      ],
       "port": 3000,
       "autoPort": true
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,11 @@ Invariants worth knowing:
 - `offAxisSquash` must apply R·S·R⁻¹ (wrapper rotation + inner
   counter-rotation); dropping the counter-rotation reorients textured
   globes (Earth reads upside down) — regression to watch for.
-- The flare corona anchors to the sun's *visible silhouette* (near-side
-  tangent ray, computed per frame), not the sphere radius.
+- The flare corona is a back-side 3D shell around the sun; the shader
+  derives the limb per fragment from the view ray's distance to the
+  center (impact parameter b: tangent rays have b = R exactly), so it
+  aligns with the silhouette by construction. Don't replace it with a
+  billboard — screen-space anchoring drifted twice.
 - Fade-in ramps write material opacity from `useFrame`; anything guarded
   by "only when changed" needs a first-frame initialization (JSX materials
   mount at opacity 1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# hunt.codes — CLAUDE.md
+
+Andrew Hunt's personal site: a whimsical space-themed SPA. React 19 +
+react-router v7 + TypeScript + rsbuild + Tailwind v4 (via `@tailwindcss`
+import in `src/index.css`) + SCSS (`src/App.scss`) + three.js /
+@react-three/fiber for the WebGL solar-system background.
+
+## Environment gotcha (read first)
+
+The default shell resolves an **old node (v20.10)** that breaks nearly
+everything: rspack refuses to start, eslint/knip crash, and the husky
+pre-commit hook (lint-staged → listr2 needs `styleText`) **fails commits**.
+Before ANY yarn command — including `git commit` — put a modern node on
+PATH:
+
+```sh
+export PATH="$(ls -d $HOME/.nvm/versions/node/*/bin | sort -V | tail -1):$PATH"
+```
+
+`.nvmrc` may name a version that isn't installed; the newest installed nvm
+node works. `.claude/launch.json` already wraps `yarn start` this way for
+the preview tool.
+
+## Commands
+
+- `corepack yarn start` — rsbuild dev server (port 3000, HMR)
+- `corepack yarn tsc --noEmit` / `corepack yarn lint` / `corepack yarn build`
+  — run all three to verify changes
+- `corepack yarn knip` — known false positives: `postcss`, `tw-animate-css`
+  (used via CSS), `serve`, jest config paths, and a few intentionally-kept
+  exports. Don't chase these.
+- `yarn deploy` — S3 sync with `--profile andrew` (hashed assets immutable,
+  HTML/manifest no-cache). Never deploy unprompted.
+
+## Routes & structure
+
+- `/` → `Landing.tsx` — WebGL solar system; the sun is a clickable "ENTER"
+- `/home` → `Home.tsx` — social links; Earth = "ABOUT ME" link; asteroids +
+  Sputnik satellite = blog/LinkedIn/GitHub links (home view only)
+- `/about` → `Resume.tsx` — the résumé page (frosted panel over the scene)
+- `/draw` → `SvgGenerator.tsx` — AI SVG generator (OpenAI, browser-side key)
+
+Day/night is a user toggle in `App.tsx` (night default); every page must
+stay legible in both palettes (`.App.night` / `.App.day` overrides).
+
+## 3D architecture (src/space3d/)
+
+Two independent fullscreen canvases, both `pointer-events: none`:
+- `SpaceCanvas` + `StarField` — orthographic, world units = CSS px. Two
+  point clouds: static background stars (pan/wrap with camera rotation via
+  `starPan.ts`) and the landing "text stars" (glyph layout + cursor
+  gravity; must NOT pan).
+- `solar/SolarScene` — perspective sun/planets/moon. `CameraRig` swoops
+  between views and accumulates star-pan rotation deltas.
+
+Clickable 3D bodies use DOM overlays glued to projections each frame
+(`BodyAnchors`, `SunSvgAnchor`); hover state flows through plain mutable
+modules (`solarHover.ts`, `starPan.ts`, `sunState`/`rigState` in
+`constants.ts`) — not React state, which would be too slow at 60fps.
+Hover outlines share one pattern: `writeSilhouette` (convex hull of
+projected verts) → `.body-outline` SVG paths in `SolarOverlays.tsx`.
+
+Invariants worth knowing:
+- `SPEED_SCALE` in `solar/constants.ts` is the global orbital tempo; the
+  asteroids must orbit at exactly `EARTH.orbitSpeed` (the home camera
+  co-rotates with Earth, freezing them on screen).
+- `offAxisSquash` must apply R·S·R⁻¹ (wrapper rotation + inner
+  counter-rotation); dropping the counter-rotation reorients textured
+  globes (Earth reads upside down) — regression to watch for.
+- The flare corona anchors to the sun's *visible silhouette* (near-side
+  tangent ray, computed per frame), not the sphere radius.
+- Fade-in ramps write material opacity from `useFrame`; anything guarded
+  by "only when changed" needs a first-frame initialization (JSX materials
+  mount at opacity 1).
+
+## Performance rules (learned the hard way)
+
+- **Never put `backdrop-filter` over the animated canvases** — a blurred
+  panel forces a backdrop re-capture every canvas AND scroll frame; it
+  froze the /about background. Use higher-opacity backgrounds instead.
+- Canvas DPR is capped at 1.5; the star canvas runs without MSAA (point
+  sprites don't benefit). Keep `powerPreference: "high-performance"`.
+- Shader-heavy sun effects self-regulate by pixel coverage — the sun is
+  only big on /home — so view-gating is unnecessary.
+- Fullscreen CSS `filter` animations must not run on invisible layers
+  (see `.App-background_day.off`), and looping animations need
+  `prefers-reduced-motion` coverage (one shared block in App.scss).
+
+## Content facts & intentional quirks
+
+- Andrew is an independent consultant in **NYC**; he **left Zip in 2025**
+  (staff engineer). Past roles correctly say San Francisco — history, not
+  stale copy. `twitter:creator` `@_andrew_hunt` is correct.
+- **Easter eggs are intentional — do not "clean up":** the
+  `console.log("bro what r u doing in the console...")` in App.tsx, and
+  the unused-but-kept `Logo.tsx` / `RetroMac.tsx` (knip flags them; leave
+  them).
+- The interests pill list in Resume.tsx pairs with `nth-of-type` animation
+  delays in App.scss — keep counts in sync.
+- Site voice is playful; preserve it when editing copy or UI.
+
+## Testing preferences
+
+- Verify with `tsc` + `lint` + `build`; keep browser/visual checking under
+  ~2 minutes — Andrew tests visually himself. Screenshots are optional
+  confirmation, not proof.
+- The preview tool throttles rAF while hidden: frame-driven intros (star
+  fade-in, camera swoops) advance ~5 frames per screenshot, so "missing"
+  stars/labels are usually just a starved clock, not a bug. If a
+  screenshot renders tiny/scrambled after navigation, call `preview_resize`
+  and capture again.

--- a/src/App.scss
+++ b/src/App.scss
@@ -899,12 +899,13 @@ a:hover {
   cursor: pointer;
 }
 
-// Hover treatment: the rock freezes and its actual silhouette (a hull the
-// scene recomputes from the frozen mesh, so it matches whatever
-// orientation the hover caught it in) lights up purple with white pulses
-// chasing around the perimeter. Both paths carry pathLength="100", so the
-// dash animation below works for any silhouette shape or length.
-.asteroid-outline {
+// Hover treatment shared by every link body (asteroids, the satellite,
+// and Earth's /about ring): the body's actual screen silhouette (a hull
+// the scene recomputes from the mesh, so it matches whatever orientation
+// the hover caught it in) lights up purple with white pulses chasing
+// around the perimeter. Both paths carry pathLength="100", so the dash
+// animation below works for any silhouette shape or length.
+.body-outline {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -921,29 +922,31 @@ a:hover {
     vector-effect: non-scaling-stroke;
   }
 
-  .asteroid-outline-base {
+  .body-outline-base {
     stroke: $purp-light;
     stroke-width: 2px;
   }
 
-  .asteroid-outline-pulse {
+  .body-outline-pulse {
     stroke: #ffffff;
     stroke-width: 2.5px;
     stroke-dasharray: 12 88;
-    animation: asteroid-outline-pulse 1.8s linear infinite;
+    animation: body-outline-pulse 1.8s linear infinite;
   }
 }
 
-.asteroid-link:hover .asteroid-outline,
-.asteroid-link:focus-visible .asteroid-outline {
+.asteroid-link:hover .body-outline,
+.asteroid-link:focus-visible .body-outline,
+.earth-about-ring:hover .body-outline,
+.earth-about-ring:focus-visible .body-outline {
   opacity: 1;
 }
 
-.App.day .asteroid-outline .asteroid-outline-base {
+.App.day .body-outline .body-outline-base {
   stroke: $purp;
 }
 
-@keyframes asteroid-outline-pulse {
+@keyframes body-outline-pulse {
   to {
     stroke-dashoffset: -100;
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -480,22 +480,24 @@ li > ul > li {
   }
 }
 
-// Translucent, blurred panel so the text stays legible over whatever
-// the 3D scene puts behind it (Earth's bright limb, the drifting moon).
+// Translucent panel so the text stays legible over whatever the 3D scene
+// puts behind it (Earth's bright limb, the drifting moon). No
+// backdrop-filter: blurring a content-height panel over two animating
+// WebGL canvases forces a backdrop capture + re-blur every canvas frame
+// AND every scroll frame, which froze the background during scrolling —
+// a higher-opacity background gives the same legibility for free.
 // The back-to-home link sits above this panel, outside the background;
-// the 24px top padding puts the frosted edge just above "About Me".
+// the 24px top padding puts the panel edge just above "About Me".
 .resume-panel {
   padding: 24px 32px 64px;
-  background: rgba(8, 6, 28, 0.55);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  background: rgba(8, 6, 28, 0.82);
   border-radius: 16px;
 }
 
 .App.day .resume-panel {
   // More opaque + a soft shadow so the panel separates from the very bright
   // pink-to-white day gradient and the dark body text keeps its contrast
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.88);
   box-shadow: 0 8px 24px rgba(80, 40, 120, 0.12);
 }
 
@@ -670,8 +672,9 @@ li > ul > li {
   }
 
   .back-to-home-link {
-    // This is all for a slight background behind the link so that it's always legible
-    backdrop-filter: blur(10px);
+    // A slight background behind the link so that it's always legible.
+    // (No backdrop-filter — blurring over the animating WebGL canvas
+    // costs a backdrop re-capture every frame; see .resume-panel.)
     border-radius: 16px;
     padding: 8px;
     // The link sits outside the padded .resume-panel now, so it needs its
@@ -682,8 +685,8 @@ li > ul > li {
     background: linear-gradient(
       to bottom,
       transparent,
-      #002d1965 30%,
-      #002d1965 70%,
+      #002d19a6 30%,
+      #002d19a6 70%,
       transparent
     );
   }
@@ -964,8 +967,15 @@ a:hover {
 .App-background_day {
   // Gentle full-spectrum hue drift on the pastel day gradient (the night
   // layer's stars animate in-shader instead). Disabled under
-  // prefers-reduced-motion.
+  // prefers-reduced-motion, and removed entirely while the layer is faded
+  // out in night mode — a fullscreen filter animation keeps the layer on
+  // the (GPU) filtered compositing path even at opacity 0.
   animation: 20s linear infinite alternate starsHueAnim;
+
+  &.off {
+    animation: none;
+  }
+
   background: linear-gradient(
     168deg,
     hsl(337.38, 100%, 88.04%) 0%,

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -10,6 +10,7 @@ import {
 import {
   asteroidAnchorId,
   asteroidOutlineId,
+  EARTH_ABOUT_OUTLINE_ID,
   EARTH_ABOUT_RING_ID,
 } from "./space3d/solar/BodyAnchors";
 import { hoverState } from "./solarHover";
@@ -21,6 +22,18 @@ import { hoverState } from "./solarHover";
  * frame. Everything starts `visibility: hidden` (App.scss) and is
  * revealed once positioned.
  */
+
+/** Hover outline shared by every link body (Earth, asteroids, satellite):
+ *  the body's projected silhouette, drawn by the 3D scene into these paths
+ *  (viewBox matches the anchor box; pathLength normalizes the dash pulse). */
+const BodyOutline = ({ outlineId }: { outlineId: string }) => (
+  <svg className="body-outline" viewBox="0 0 100 100" aria-hidden>
+    <g id={outlineId}>
+      <path className="body-outline-base" pathLength={100} />
+      <path className="body-outline-pulse" pathLength={100} />
+    </g>
+  </svg>
+);
 
 const ASTEROID_LINKS = [
   {
@@ -69,7 +82,9 @@ const SolarOverlays = () => {
         onPointerLeave={() => {
           hoverState.earth = false;
         }}
-      />
+      >
+        <BodyOutline outlineId={EARTH_ABOUT_OUTLINE_ID} />
+      </Link>
       {ASTEROID_LINKS.map((link) => (
         <TooltipProvider key={link.name} delayDuration={100}>
           <Tooltip disableHoverableContent>
@@ -90,19 +105,7 @@ const SolarOverlays = () => {
                   }
                 }}
               >
-                {/* Hover outline: the rock's projected silhouette, drawn
-                    by Asteroid into these paths (viewBox matches the
-                    anchor box; pathLength normalizes the dash pulse) */}
-                <svg
-                  className="asteroid-outline"
-                  viewBox="0 0 100 100"
-                  aria-hidden
-                >
-                  <g id={asteroidOutlineId(link.name)}>
-                    <path className="asteroid-outline-base" pathLength={100} />
-                    <path className="asteroid-outline-pulse" pathLength={100} />
-                  </g>
-                </svg>
+                <BodyOutline outlineId={asteroidOutlineId(link.name)} />
               </a>
             </TooltipTrigger>
             <TooltipContent updatePositionStrategy="always">

--- a/src/space3d/SpaceCanvas.tsx
+++ b/src/space3d/SpaceCanvas.tsx
@@ -39,8 +39,16 @@ const SpaceCanvas = ({ children }: { children: React.ReactNode }) => {
       orthographic
       flat
       camera={{ position: [0, 0, 1000], near: 0.1, far: 4000, zoom: 1 }}
-      dpr={[1, 2]}
-      gl={{ alpha: true, antialias: true }}
+      // Cap DPR at 1.5: on retina, 2x meant ~78% more pixels for a soft
+      // star field where the difference is invisible
+      dpr={[1, 1.5]}
+      // No MSAA: this canvas only draws alpha-blended point sprites, which
+      // antialiasing does nothing for — skip the multisample cost entirely
+      gl={{
+        alpha: true,
+        antialias: false,
+        powerPreference: "high-performance",
+      }}
     >
       {children}
     </Canvas>

--- a/src/space3d/StarField.tsx
+++ b/src/space3d/StarField.tsx
@@ -24,6 +24,7 @@ import {
   type SampledStar,
 } from "./starSampling";
 import { domToWorldX, domToWorldY, Z_STARS } from "./SpaceCanvas";
+import { starPanState } from "./starPan";
 
 /**
  * GPU star field. Replaces the legacy DOM/SVG stars (one element per star,
@@ -44,6 +45,10 @@ const DISCO_PERIOD_S = 8; // star-disco: 4s alternate = 8s round trip
 
 const HALO_FACTOR = 3; // sprite is 3x the dot diameter, for the glow halo
 
+// Extra wrap range beyond the viewport so big sprites drift fully
+// offscreen before re-entering on the far side instead of popping
+const PAN_WRAP_PAD_PX = 160;
+
 const vertexShader = /* glsl */ `
   attribute float aSize;
   attribute vec3 aColor;
@@ -53,6 +58,8 @@ const vertexShader = /* glsl */ `
   uniform float uTime;
   uniform float uPixelRatio;
   uniform float uMaxPointSize;
+  uniform vec2 uPan;
+  uniform vec2 uWrap;
   varying vec3 vColor;
   varying float vExtraHue;
 
@@ -69,9 +76,16 @@ const vertexShader = /* glsl */ `
     vExtraHue = extraHue;
     // tinycolor.brighten(n) adds n% of full white
     vColor = clamp(aColor + vec3(aBrighten * 0.01), 0.0, 1.0);
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    // Camera-rotation parallax (starPan.ts): shift by the accumulated pan
+    // and wrap around the padded viewport so the field is endless. uWrap
+    // stays 0 for the text stars, which must hold their glyph positions.
+    vec3 pos = position;
+    if (uWrap.x > 0.5) {
+      pos.xy = mod(pos.xy + uPan + 0.5 * uWrap, uWrap) - 0.5 * uWrap;
+    }
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
     gl_PointSize = min(
-      aSize * 2.5 * ${HALO_FACTOR.toFixed(1)} * scale * uPixelRatio,
+      aSize * 1.5 * ${HALO_FACTOR.toFixed(1)} * scale * uPixelRatio,
       uMaxPointSize
     );
   }
@@ -138,6 +152,8 @@ const createStarMaterial = (glowColor: string, glowStrength: number) => {
       uMaxPointSize: { value: 256 },
       uGlowColor: { value: new THREE.Vector3(glow[0], glow[1], glow[2]) },
       uGlowStrength: { value: glowStrength },
+      uPan: { value: new THREE.Vector2() },
+      uWrap: { value: new THREE.Vector2() },
     },
   });
 };
@@ -193,10 +209,13 @@ const createStarGeometry = (
   };
 };
 
-/** Per-frame uniform updates + the GPU's max point-sprite size cap. */
+/** Per-frame uniform updates + the GPU's max point-sprite size cap.
+ *  `pansWithCamera` opts the material into the solar camera's rotation
+ *  parallax (background stars only — text stars hold their glyphs). */
 const useConfigureMaterial = (
   material: THREE.ShaderMaterial,
   opacityRef: React.MutableRefObject<number>,
+  pansWithCamera = false,
 ) => {
   const gl = useThree((s) => s.gl);
   useEffect(() => {
@@ -216,6 +235,16 @@ const useConfigureMaterial = (
       ((state.clock.elapsedTime / HUE_ROTATION_PERIOD_S) % 1) * Math.PI * 2;
     material.uniforms.uPixelRatio.value = state.gl.getPixelRatio();
     material.uniforms.uOpacity.value = opacityRef.current;
+    if (pansWithCamera) {
+      (material.uniforms.uPan.value as THREE.Vector2).set(
+        starPanState.x,
+        starPanState.y,
+      );
+      (material.uniforms.uWrap.value as THREE.Vector2).set(
+        state.size.width + PAN_WRAP_PAD_PX,
+        state.size.height + PAN_WRAP_PAD_PX,
+      );
+    }
   });
 };
 
@@ -258,7 +287,9 @@ const BackgroundStars = ({
     [],
   );
 
-  useConfigureMaterial(material, opacityRef);
+  // Background stars pan/wrap with the solar camera's rotation, so the
+  // sky turns with the co-rotating home and about views
+  useConfigureMaterial(material, opacityRef, true);
 
   useEffect(() => () => buffers.geometry.dispose(), [buffers]);
   useEffect(() => () => material.dispose(), [material]);

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -39,9 +39,13 @@ export default function Asteroid({
   const group = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const rockMaterial = useRef<THREE.MeshStandardMaterial>(null);
-  // Start faded out when mounting into a view that hides asteroids (the
-  // landing page), fully shown when mounting straight into /home
+  // Start faded out when mounting into a view that hides asteroids
+  // (landing, /about), fully shown when mounting straight into /home
   const opacity = useRef(visible ? 1 : 0);
+  // Last opacity pushed into the group/materials; starts out-of-band so
+  // the first frame always initializes them (the JSX materials mount at
+  // opacity 1 regardless of the fade state)
+  const appliedOpacity = useRef(-1);
 
   const texture = useMemo(() => createPlanetTexture(config.kind), [config]);
   useEffect(() => () => texture.dispose(), [texture]);
@@ -115,15 +119,17 @@ export default function Asteroid({
       const step = visible
         ? delta / FADE_IN_SECONDS
         : -delta / FADE_OUT_SECONDS;
-      const next = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
-      // Only walk the material tree while the fade is actually moving
-      if (next !== opacity.current) {
-        opacity.current = next;
-        group.current.visible = next > 0.005;
+      opacity.current = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
+      // Only walk the material tree when the pushed value actually
+      // changes (appliedOpacity starts at -1, so the first frame always
+      // initializes the group/material state)
+      if (opacity.current !== appliedOpacity.current) {
+        appliedOpacity.current = opacity.current;
+        group.current.visible = opacity.current > 0.005;
         group.current.traverse((obj) => {
           const material = (obj as THREE.Mesh).material;
           if (material && !Array.isArray(material)) {
-            material.opacity = next;
+            material.opacity = opacity.current;
           }
         });
       }

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
+import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 
 import { planetPosition, type SolarPlanetConfig } from "./constants";
 import { asteroidOutlineId } from "./BodyAnchors";
@@ -10,11 +11,12 @@ import { createLogoBadgeTexture, createPlanetTexture } from "../textures";
 import { hoverState } from "../../solarHover";
 
 /**
- * A small rocky link-asteroid: a jittered icosahedron (lumpy, flat-shaded)
- * that slowly orbits the sun. No orbit ring — these are meant to read as
- * floating debris, and rings would clutter the zoomed landing view. The
- * matching DOM link overlay is glued to it by BodyAnchors via the same
- * planetPosition() the mesh uses, so the two can't drift apart.
+ * A small rocky link-asteroid: a smooth-shaded icosphere with gentle
+ * coherent lumps that slowly orbits the sun. No orbit ring — these are
+ * meant to read as floating debris, and rings would clutter the zoomed
+ * landing view. The matching DOM link overlay is glued to it by
+ * BodyAnchors via the same planetPosition() the mesh uses, so the two
+ * can't drift apart.
  *
  * `config.logo` projects a brand badge onto two opposite sides of the
  * rock's surface (DecalGeometry clips the sticker to the mesh, so it
@@ -57,17 +59,25 @@ export default function Asteroid({
   useEffect(() => () => logoTexture?.dispose(), [logoTexture]);
 
   const geometry = useMemo(() => {
-    const geo = new THREE.IcosahedronGeometry(config.radius, 1);
-    // One-time deterministic radial jitter so it reads as a lumpy rock
-    // (seeded per-vertex from the position, not Math.random, so the two
-    // asteroids differ via their radii/phases but stay stable per mount)
+    // Smooth lumpy rock: a well-subdivided icosphere with welded vertices
+    // (smooth normals need shared verts — PolyhedronGeometry ships them
+    // duplicated per face), displaced by a few low-frequency sine lumps.
+    // Coherent bumps + smooth shading read as a weathered boulder instead
+    // of the old low-poly crystal (per-vertex hash jitter, flat shading) —
+    // which also fixes the logo decals: on huge flat facets the decal
+    // vanished in big chunks the moment a facet turned past edge-on.
+    const geo = mergeVertices(new THREE.IcosahedronGeometry(config.radius, 3));
     const pos = geo.getAttribute("position") as THREE.BufferAttribute;
     const v = new THREE.Vector3();
+    // Deterministic, but distinct per rock (phases keyed off the radius)
+    const phase = config.radius * 97.3;
     for (let i = 0; i < pos.count; i++) {
-      v.fromBufferAttribute(pos, i);
-      const seed = Math.sin(v.x * 91.7 + v.y * 47.3 + v.z * 13.1) * 43758.5;
-      const jitter = 1 + (seed - Math.floor(seed) - 0.5) * 0.4; // ±20%
-      v.multiplyScalar(jitter);
+      v.fromBufferAttribute(pos, i).normalize();
+      const lump =
+        0.11 * Math.sin(v.x * 3.1 + v.y * 5.2 + phase) +
+        0.07 * Math.sin(v.y * 4.3 + v.z * 6.1 + phase * 1.7) +
+        0.045 * Math.sin(v.z * 5.7 + v.x * 7.3 + phase * 2.3);
+      v.multiplyScalar(config.radius * (1 + lump));
       pos.setXYZ(i, v.x, v.y, v.z);
     }
     pos.needsUpdate = true;
@@ -80,7 +90,7 @@ export default function Asteroid({
   // a mesh to shoot at; an identity-transform temp mesh keeps the decal
   // vertices in the rock's local space, so parenting the decals under the
   // spinning mesh keeps them glued to the lumps they were cut from. The
-  // box is sized to swallow the full jitter range (0.8r..1.2r).
+  // box is sized to swallow the full lump range (~0.78r..1.23r).
   const decalGeometries = useMemo(() => {
     if (!config.logo) return null;
     const r = config.radius;
@@ -177,7 +187,6 @@ export default function Asteroid({
           map={texture}
           roughness={1}
           metalness={0}
-          flatShading
           transparent
           emissive="#ffffff"
           emissiveIntensity={0}

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -115,14 +115,18 @@ export default function Asteroid({
       const step = visible
         ? delta / FADE_IN_SECONDS
         : -delta / FADE_OUT_SECONDS;
-      opacity.current = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
-      group.current.visible = opacity.current > 0.005;
-      group.current.traverse((obj) => {
-        const material = (obj as THREE.Mesh).material;
-        if (material && !Array.isArray(material)) {
-          material.opacity = opacity.current;
-        }
-      });
+      const next = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
+      // Only walk the material tree while the fade is actually moving
+      if (next !== opacity.current) {
+        opacity.current = next;
+        group.current.visible = next > 0.005;
+        group.current.traverse((obj) => {
+          const material = (obj as THREE.Mesh).material;
+          if (material && !Array.isArray(material)) {
+            material.opacity = next;
+          }
+        });
+      }
     }
     // Hover freezes the tumble (the outline below is cut from the frozen
     // pose, and a spinning rock under a static outline would look broken)

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -25,6 +25,9 @@ import { liveElementById } from "../svgTracking";
  */
 
 export const EARTH_ABOUT_RING_ID = "earth-about-ring";
+/** Group inside the /about ring holding Earth's hover-outline paths;
+ *  Planet writes Earth's projected silhouette into every path under it. */
+export const EARTH_ABOUT_OUTLINE_ID = "earth-about-outline";
 export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;
 /** Group inside the anchor holding the hover-outline paths; Asteroid
  *  writes the projected silhouette into every path under it. */

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -3,6 +3,7 @@ import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import { EARTH, moonPosition, planetPosition, rigState } from "./constants";
+import { starPanState } from "../starPan";
 
 /**
  * Camera choreography, ported from hunt-codes-3. Landing hovers straight
@@ -78,6 +79,8 @@ const moonDir = new THREE.Vector3();
 const side = new THREE.Vector3();
 const goalQuat = new THREE.Quaternion();
 const lookMatrix = new THREE.Matrix4();
+const oldForward = new THREE.Vector3();
+const invQuat = new THREE.Quaternion();
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
@@ -167,6 +170,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
   const transitionStart = useRef(-Infinity);
   const fromPos = useRef(LANDING_POS.clone());
   const fromQuat = useRef(new THREE.Quaternion());
+  const prevQuat = useRef<THREE.Quaternion | null>(null);
 
   useFrame(({ camera, clock, size }) => {
     const t = clock.elapsedTime;
@@ -198,6 +202,27 @@ export default function CameraRig({ view }: { view: SolarView }) {
       // fully arrived: track the (possibly moving) goal exactly
       camera.position.copy(goalPos);
       camera.lookAt(goalLook);
+    }
+
+    // Star parallax: fold this frame's camera rotation into a pixel-space
+    // pan (starPan.ts) by measuring where a distant point along LAST
+    // frame's forward lands in the new camera frame. Delta-based, so it's
+    // smooth through swoops, exact for the slow co-rotation on the home
+    // and about perches, and immune to the straight-down landing pose
+    // (where absolute yaw/pitch are degenerate).
+    if (prevQuat.current === null) {
+      prevQuat.current = camera.quaternion.clone();
+    } else if (!camera.quaternion.equals(prevQuat.current)) {
+      const persp = camera as THREE.PerspectiveCamera;
+      oldForward.set(0, 0, -1).applyQuaternion(prevQuat.current);
+      invQuat.copy(camera.quaternion).invert();
+      oldForward.applyQuaternion(invQuat); // in current camera space
+      if (oldForward.z < -0.1) {
+        const focalPx = size.height / 2 / Math.tan((persp.fov * Math.PI) / 360);
+        starPanState.x += (oldForward.x / -oldForward.z) * focalPx;
+        starPanState.y += (oldForward.y / -oldForward.z) * focalPx;
+      }
+      prevQuat.current.copy(camera.quaternion);
     }
   });
 

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -34,6 +34,7 @@ export default function Moon({
   const earthGroup = useRef<THREE.Group>(null);
   const moonGroup = useRef<THREE.Group>(null);
   const squashWrapper = useRef<THREE.Group>(null);
+  const squashCounterRotate = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
   const orbitMaterial = useRef<THREE.LineBasicMaterial>(null);
@@ -77,12 +78,17 @@ export default function Moon({
       );
       // Cancel the wide-lens corner stretching (fades out up close, e.g.
       // under the about view's moon-adjacent perch)
-      if (squashWrapper.current && earthGroup.current) {
+      if (
+        squashWrapper.current &&
+        squashCounterRotate.current &&
+        earthGroup.current
+      ) {
         moonWorldPos
           .copy(earthGroup.current.position)
           .add(moonGroup.current.position);
         applyOffAxisSquash(
           squashWrapper.current,
+          squashCounterRotate.current,
           camera,
           moonWorldPos,
           MOON.radius,
@@ -119,19 +125,21 @@ export default function Moon({
       </lineLoop>
       <group ref={moonGroup}>
         <group ref={squashWrapper}>
-          <mesh ref={mesh}>
-            <sphereGeometry args={[MOON.radius, 48, 48]} />
-            <meshStandardMaterial
-              ref={surfaceMaterial}
-              map={texture}
-              roughness={1}
-              metalness={0}
-              emissive="#aab1bd"
-              emissiveMap={texture}
-              emissiveIntensity={0.22}
-              transparent
-            />
-          </mesh>
+          <group ref={squashCounterRotate}>
+            <mesh ref={mesh}>
+              <sphereGeometry args={[MOON.radius, 48, 48]} />
+              <meshStandardMaterial
+                ref={surfaceMaterial}
+                map={texture}
+                roughness={1}
+                metalness={0}
+                emissive="#aab1bd"
+                emissiveMap={texture}
+                emissiveIntensity={0.22}
+                transparent
+              />
+            </mesh>
+          </group>
         </group>
       </group>
     </group>

--- a/src/space3d/solar/Planet.tsx
+++ b/src/space3d/solar/Planet.tsx
@@ -6,6 +6,8 @@ import { planetPosition, type SolarPlanetConfig } from "./constants";
 import { applyOffAxisSquash } from "./offAxisSquash";
 import { createPlanetTexture } from "../textures";
 import { hoverState } from "../../solarHover";
+import { EARTH_ABOUT_OUTLINE_ID } from "./BodyAnchors";
+import { writeSilhouette } from "./outline";
 import AboutRing from "./AboutRing";
 import earthMapUrl from "../../assets/earth.jpg";
 
@@ -44,6 +46,7 @@ export default function Planet({
 }) {
   const group = useRef<THREE.Group>(null);
   const squashWrapper = useRef<THREE.Group>(null);
+  const squashCounterRotate = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
   const surfaceMaterial = useRef<THREE.MeshStandardMaterial>(null);
   const atmosphereMaterial = useRef<THREE.MeshBasicMaterial>(null);
@@ -85,13 +88,14 @@ export default function Planet({
   }, [config.orbitRadius]);
   useEffect(() => () => orbitLine.dispose(), [orbitLine]);
 
-  useFrame(({ clock, camera }, delta) => {
+  useFrame(({ clock, camera, size }, delta) => {
     if (group.current) {
       planetPosition(config, clock.elapsedTime, group.current.position);
       // Cancel the wide-lens corner stretching (fades out up close)
-      if (squashWrapper.current) {
+      if (squashWrapper.current && squashCounterRotate.current) {
         applyOffAxisSquash(
           squashWrapper.current,
+          squashCounterRotate.current,
           camera,
           group.current.position,
           config.radius,
@@ -133,6 +137,13 @@ export default function Planet({
             surfaceMaterial.current.emissiveIntensity) *
           ease;
       }
+      if (hovered && mesh.current) {
+        // Same pulsing hover outline as the link asteroids/satellite: cut
+        // Earth's screen silhouette and hand it to the /about overlay's
+        // outline paths (Earth stays a circle while spinning, so no
+        // spin-freeze is needed here)
+        writeSilhouette(EARTH_ABOUT_OUTLINE_ID, [mesh.current], camera, size);
+      }
     }
   });
 
@@ -148,47 +159,50 @@ export default function Planet({
       </lineLoop>
       <group ref={group}>
         <group ref={squashWrapper}>
-          <mesh ref={mesh}>
-            <sphereGeometry args={[config.radius, 48, 48]} />
-            {config.kind === "earth" ? (
-              // Earth self-illuminates faintly (its own map as the emissive
-              // map): the home view faces its night side, which would
-              // otherwise be a near-black silhouette. The cool tint reads as
-              // earthshine so oceans/land stay recognizable in the dark.
-              <meshStandardMaterial
-                ref={surfaceMaterial}
-                map={texture}
-                color={EARTH_SUNLIT_BOOST}
-                roughness={0.95}
-                metalness={0}
-                emissive="#a7bad4"
-                emissiveMap={texture}
-                emissiveIntensity={0.28}
-                transparent
-              />
-            ) : (
-              <meshStandardMaterial
-                ref={surfaceMaterial}
-                map={texture}
-                roughness={0.95}
-                metalness={0}
-                transparent
-              />
-            )}
-          </mesh>
-          {config.kind === "earth" && (
-            // faint atmosphere shell
-            <mesh scale={1.04}>
+          <group ref={squashCounterRotate}>
+            <mesh ref={mesh}>
               <sphereGeometry args={[config.radius, 48, 48]} />
-              <meshBasicMaterial
-                ref={atmosphereMaterial}
-                color="#6ab0ff"
-                transparent
-                opacity={0.16}
-                side={THREE.BackSide}
-              />
+              {config.kind === "earth" ? (
+                // Earth self-illuminates faintly (its own map as the
+                // emissive map): the home view faces its night side, which
+                // would otherwise be a near-black silhouette. The cool tint
+                // reads as earthshine so oceans/land stay recognizable in
+                // the dark.
+                <meshStandardMaterial
+                  ref={surfaceMaterial}
+                  map={texture}
+                  color={EARTH_SUNLIT_BOOST}
+                  roughness={0.95}
+                  metalness={0}
+                  emissive="#a7bad4"
+                  emissiveMap={texture}
+                  emissiveIntensity={0.28}
+                  transparent
+                />
+              ) : (
+                <meshStandardMaterial
+                  ref={surfaceMaterial}
+                  map={texture}
+                  roughness={0.95}
+                  metalness={0}
+                  transparent
+                />
+              )}
             </mesh>
-          )}
+            {config.kind === "earth" && (
+              // faint atmosphere shell
+              <mesh scale={1.04}>
+                <sphereGeometry args={[config.radius, 48, 48]} />
+                <meshBasicMaterial
+                  ref={atmosphereMaterial}
+                  color="#6ab0ff"
+                  transparent
+                  opacity={0.16}
+                  side={THREE.BackSide}
+                />
+              </mesh>
+            )}
+          </group>
         </group>
         {/* Curved "ABOUT ME" link label, billboarded around Earth. Lives in
             the group (not the squash wrapper) so it stays put over Earth. */}

--- a/src/space3d/solar/Satellite.tsx
+++ b/src/space3d/solar/Satellite.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
+import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 
 import { EARTH, planetPosition, type SolarPlanetConfig } from "./constants";
 import { asteroidOutlineId } from "./BodyAnchors";
@@ -22,6 +23,10 @@ import { hoverState } from "../../solarHover";
  * slow roll about that leg axis — the cone spins in place, so the legs
  * always point right. The beacon hangs off the rig, not the rolling
  * body, so it stays on top of the head.
+ *
+ * The GitHub badge is a pair of decals projected onto opposite sides of
+ * the sphere (the same sticker treatment as the asteroids), glued to the
+ * rolling body so the mark turns with the spin.
  */
 
 const FADE_IN_SECONDS = 3;
@@ -32,13 +37,14 @@ const LEG_TILT = 0.32; // radians each leg splays off the cone axis
 const BLINK_PERIOD_SECONDS = 1.2;
 const BLINK_ON_FRACTION = 0.55;
 const HOVER_EMISSIVE = 0.9;
+/** Slow the body roll well below the config spin (a stately tumble) */
+const ROLL_SPEED_SCALE = 0.35;
 
 const Z_AXIS = new THREE.Vector3(0, 0, 1);
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
 const UP = new THREE.Vector3(0, 1, 0);
 const earthPos = new THREE.Vector3();
 const legsDir = new THREE.Vector3();
-const camDir = new THREE.Vector3();
 
 export default function Satellite({
   config,
@@ -51,7 +57,6 @@ export default function Satellite({
   const rig = useRef<THREE.Group>(null); // aims the leg cone screen-right
   const body = useRef<THREE.Group>(null); // rolls about the leg axis
   const bulb = useRef<THREE.Mesh>(null);
-  const badge = useRef<THREE.Mesh>(null);
   const opacity = useRef(visible ? 1 : 0);
   const roll = useRef(0);
 
@@ -80,10 +85,14 @@ export default function Satellite({
         color: "#ff5252",
         transparent: true,
       }),
+      // Same decal treatment as the asteroids: unlit so the mark stays
+      // legible on the dark side, polygonOffset floats it off the faces
       badge: new THREE.MeshBasicMaterial({
         map: createLogoBadgeTexture("github"),
         transparent: true,
-        alphaTest: 0.5,
+        depthWrite: false,
+        polygonOffset: true,
+        polygonOffsetFactor: -4,
       }),
     }),
     [],
@@ -94,6 +103,42 @@ export default function Satellite({
       Object.values(materials).forEach((material) => material.dispose());
     },
     [materials],
+  );
+
+  const bodyGeometry = useMemo(
+    () => new THREE.SphereGeometry(bodyRadius, 24, 16),
+    [bodyRadius],
+  );
+  useEffect(() => () => bodyGeometry.dispose(), [bodyGeometry]);
+
+  // Badge decals on opposite sides of the sphere, perpendicular to the
+  // roll axis (local Z, the leg cone) so the marks sweep past the camera
+  // as the body rolls — one on each side, like the asteroid stickers.
+  const badgeGeometries = useMemo(() => {
+    const target = new THREE.Mesh(bodyGeometry);
+    const size = new THREE.Vector3(
+      bodyRadius * 1.4,
+      bodyRadius * 1.4,
+      bodyRadius * 1.1,
+    );
+    return [
+      new DecalGeometry(
+        target,
+        new THREE.Vector3(bodyRadius, 0, 0),
+        new THREE.Euler(0, Math.PI / 2, 0),
+        size,
+      ),
+      new DecalGeometry(
+        target,
+        new THREE.Vector3(-bodyRadius, 0, 0),
+        new THREE.Euler(0, -Math.PI / 2, 0),
+        size,
+      ),
+    ];
+  }, [bodyGeometry, bodyRadius]);
+  useEffect(
+    () => () => badgeGeometries.forEach((g) => g.dispose()),
+    [badgeGeometries],
   );
 
   // The antenna cone: thin rods splayed LEG_TILT off local +Z, evenly
@@ -149,8 +194,11 @@ export default function Satellite({
 
     // Slow roll about the leg axis — the cone spins in place, legs never
     // leave screen-right. Frozen while hovered, like the asteroid spins.
+    // The badge decals are children of the body, so they roll along.
     if (body.current) {
-      if (!hovered) roll.current += delta * Math.abs(config.spinSpeed);
+      if (!hovered) {
+        roll.current += delta * Math.abs(config.spinSpeed) * ROLL_SPEED_SCALE;
+      }
       body.current.rotation.z = roll.current;
     }
 
@@ -158,13 +206,6 @@ export default function Satellite({
     if (bulb.current) {
       bulb.current.visible =
         t % BLINK_PERIOD_SECONDS < BLINK_PERIOD_SECONDS * BLINK_ON_FRACTION;
-    }
-
-    // GitHub badge rides the camera-facing side of the sphere, upright
-    if (badge.current && group.current) {
-      camDir.copy(camera.position).sub(group.current.position).normalize();
-      badge.current.position.copy(camDir).multiplyScalar(bodyRadius * 1.12);
-      badge.current.quaternion.copy(camera.quaternion);
     }
 
     // Hover: wash the metal out toward white (badge/bulb unaffected)
@@ -188,9 +229,11 @@ export default function Satellite({
     <group ref={group}>
       <group ref={rig}>
         <group ref={body}>
-          <mesh material={materials.body}>
-            <sphereGeometry args={[bodyRadius, 24, 16]} />
-          </mesh>
+          <mesh material={materials.body} geometry={bodyGeometry} />
+          {/* GitHub badge stickers, one per side, rolling with the body */}
+          {badgeGeometries.map((badgeGeometry, i) => (
+            <mesh key={i} geometry={badgeGeometry} material={materials.badge} />
+          ))}
           {legs.map((leg, i) => (
             <mesh
               key={i}
@@ -215,9 +258,6 @@ export default function Satellite({
           <sphereGeometry args={[bodyRadius * 0.15, 12, 8]} />
         </mesh>
       </group>
-      <mesh ref={badge} material={materials.badge}>
-        <planeGeometry args={[bodyRadius * 1.15, bodyRadius * 1.15]} />
-      </mesh>
     </group>
   );
 }

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -81,9 +81,10 @@ const SolarScene = ({
     >
       <ambientLight intensity={0.14} />
       {/* From the home sun-perch the full glow would fill the frame and
-          wash out the stars — shrink it to hug the limb there */}
+          wash out the stars (and the crisp flare corona) — shrink it to
+          hug the limb there */}
       <Sun
-        targetGlowScale={view === "home" ? 2.5 : 4}
+        targetGlowScale={view === "home" ? 2.2 : 4}
         isNightMode={isNightMode}
         showEnterRing={isLanding}
         enterRevealed={enterRevealed}

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -94,7 +94,7 @@ const SolarScene = ({
           config={planet}
           // hunt-codes-3's faint white rings, flipped dark for day mode
           orbitColor={isNightMode ? "#ffffff" : "#141428"}
-          orbitOpacity={isNightMode ? 0.08 : 0.2}
+          orbitOpacity={isNightMode ? 0.28 : 0.2}
           isNightMode={isNightMode}
           aboutActive={view === "home"}
           revealed={planetsRevealed}
@@ -102,24 +102,26 @@ const SolarScene = ({
       ))}
       <Moon
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
-        orbitOpacity={isNightMode ? 0.08 : 0.2}
+        orbitOpacity={isNightMode ? 0.28 : 0.2}
         revealed={planetsRevealed}
       />
-      {/* Link bodies — hidden in the top-down landing view (they'd read
-          as clutter around the sun); they fade in on the way to the home
-          perch. GitHub gets the Sputnik satellite, the rest are rocks. */}
+      {/* Link bodies — home view only: on landing they'd read as clutter
+          around the sun, and on /about their DOM overlays don't exist, so
+          the rocks would be dead weight drifting near the sun. They fade
+          in on the way to the home perch. GitHub gets the Sputnik
+          satellite, the rest are rocks. */}
       {ASTEROIDS.map((asteroid) =>
         asteroid.name === "github" ? (
           <Satellite
             key={asteroid.name}
             config={asteroid}
-            visible={view !== "landing"}
+            visible={view === "home"}
           />
         ) : (
           <Asteroid
             key={asteroid.name}
             config={asteroid}
-            visible={view !== "landing"}
+            visible={view === "home"}
           />
         ),
       )}

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -74,8 +74,10 @@ const SolarScene = ({
         gl.domElement.style.pointerEvents = "none";
       }}
       camera={{ position: [0, 58, 0.01], fov: 55, near: 0.1, far: 1200 }}
-      dpr={[1, 2]}
-      gl={{ alpha: true, antialias: true }}
+      // Cap DPR at 1.5 (2x on retina was ~78% more pixels for little
+      // visible gain); keep MSAA — the sphere limbs do need it
+      dpr={[1, 1.5]}
+      gl={{ alpha: true, antialias: true, powerPreference: "high-performance" }}
     >
       <ambientLight intensity={0.14} />
       {/* From the home sun-perch the full glow would fill the frame and

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -207,7 +207,7 @@ export default function Sun({
   );
 
   useFrame(({ clock }, delta) => {
-    if (mesh.current) mesh.current.rotation.y += delta * 0.013;
+    if (mesh.current) mesh.current.rotation.y += delta * 0.0065;
     if (spotsMaterialRef.current) {
       // Slow morph between the two blotch patterns (~30s round trip)
       spotsMaterialRef.current.opacity =

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -5,7 +5,11 @@ import * as THREE from "three";
 import { SUN_RADIUS, sunState } from "./constants";
 import { SUN_SIZE, SUN_SURFACE_RADIUS } from "../../landingScene";
 import { hoverState } from "../../solarHover";
-import { createSunGlowTexture, createSunTexture } from "../textures";
+import { createSunGlowTexture } from "../textures";
+import {
+  createSunCoronaMaterial,
+  createSunSurfaceMaterial,
+} from "./sunShaders";
 import {
   createLetterPlane,
   measureCharWidths,
@@ -15,21 +19,27 @@ import {
 } from "./curvedText";
 
 /**
- * The sun, ported from hunt-codes-3: a slowly rotating sphere with the
- * mottled golden canvas texture, a soft glow sprite (billboarded, so the
- * corona reads from any camera angle), and the point light that lights
- * the planets. The whole group eases toward a per-view scale and
- * publishes the rendered scale so the DOM rings can track it; the glow
- * sprite eases toward a per-view size too — from the home sun-perch the
- * full 6x glow would span the whole frame and wash out the stars, so
- * that view shrinks it to hug the limb.
+ * The sun: a slowly rotating sphere with an animated fbm shader surface
+ * (convection cells and dark spots that drift, grow and dissolve — see
+ * sunShaders.ts), a flare corona billboard whose rim hugs a fixed ~24 CSS
+ * px past the projected limb with traveling eruption lobes, a soft wide
+ * glow sprite for distant ambience, and the point light that lights the
+ * planets. The whole group eases toward a per-view scale and publishes
+ * the rendered scale so the DOM rings can track it; the glow sprite eases
+ * toward a per-view size too — from the home sun-perch the full 6x glow
+ * would span the whole frame and wash out the stars, so that view shrinks
+ * it to hug the limb.
  */
-// Surface brightness multipliers (meshBasicMaterial.color, toneMapped
-// off, so components >1 push the texture toward white). Day mode reads
-// noticeably brighter/whiter against the light gradient; night gets a
-// subtler lift.
+// Surface brightness multipliers (shader uTint; components >1 push the
+// palette toward white). Day mode reads noticeably brighter/whiter
+// against the light gradient; night gets a subtler lift.
 const DAY_TINT = new THREE.Color(1.55, 1.55, 1.7);
 const NIGHT_TINT = new THREE.Color(1.12, 1.12, 1.15);
+
+/** How far the flare corona's nominal rim extends past the limb, CSS px */
+const FLARE_RING_PX = 24;
+/** Corona plane half-size, in sun radii (must fit the biggest flare) */
+const CORONA_HALF_RADII = 2.4;
 const ENTER_TEXT = "ENTER";
 const ENTER_FONT_SIZE_SVG = 22;
 /** Enlarge the curved "ENTER" label relative to its SVG-derived size */
@@ -188,38 +198,39 @@ export default function Sun({
   const group = useRef<THREE.Group>(null);
   const enterScaler = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
+  const corona = useRef<THREE.Mesh>(null);
   const glow = useRef<THREE.Sprite>(null);
-  const materialRef = useRef<THREE.MeshBasicMaterial>(null);
-  const spotsMaterialRef = useRef<THREE.MeshBasicMaterial>(null);
-  const texture = useMemo(() => createSunTexture(), []);
-  // A second, independently-random blotch layer: crossfading it in and
-  // out over the base makes the surface spots slowly shift
-  const spotsTexture = useMemo(() => createSunTexture(), []);
+  const surfaceMaterial = useMemo(() => createSunSurfaceMaterial(), []);
+  const coronaMaterial = useMemo(
+    // Disc radius in plane units: the plane's half-size is 1
+    () => createSunCoronaMaterial(1 / CORONA_HALF_RADII),
+    [],
+  );
   const glowTexture = useMemo(() => createSunGlowTexture(), []);
 
   useEffect(
     () => () => {
-      texture.dispose();
-      spotsTexture.dispose();
+      surfaceMaterial.dispose();
+      coronaMaterial.dispose();
       glowTexture.dispose();
     },
-    [texture, spotsTexture, glowTexture],
+    [surfaceMaterial, coronaMaterial, glowTexture],
   );
 
-  useFrame(({ clock }, delta) => {
+  useFrame(({ clock, camera, size }, delta) => {
+    const t = clock.elapsedTime;
     if (mesh.current) mesh.current.rotation.y += delta * 0.0065;
-    if (spotsMaterialRef.current) {
-      // Slow morph between the two blotch patterns (~30s round trip)
-      spotsMaterialRef.current.opacity =
-        0.5 + 0.5 * Math.sin((clock.elapsedTime * Math.PI * 2) / 30);
-    }
+    surfaceMaterial.uniforms.uTime.value = t;
+    coronaMaterial.uniforms.uTime.value = t;
+
     const ease = Math.min(1, delta * 2.5);
+    let scale = 1;
     if (group.current) {
       const current = group.current.scale.x;
-      const next = current + (targetScale - current) * ease;
-      group.current.scale.setScalar(next);
-      sunState.scale = next;
-      enterScaler.current?.scale.setScalar(next);
+      scale = current + (targetScale - current) * ease;
+      group.current.scale.setScalar(scale);
+      sunState.scale = scale;
+      enterScaler.current?.scale.setScalar(scale);
     }
     if (glow.current) {
       // Hovering the ENTER link (or the sun itself) swells the glow
@@ -228,13 +239,31 @@ export default function Sun({
       const next = current + (target - current) * ease;
       glow.current.scale.set(next, next, 1);
     }
-    if (materialRef.current) {
-      // Ease the brightness so the mode toggle doesn't pop; the spot
-      // layer follows the same tint or the crossfade would pulse dark
-      materialRef.current.color.lerp(isNightMode ? NIGHT_TINT : DAY_TINT, ease);
-      if (spotsMaterialRef.current) {
-        spotsMaterialRef.current.color.copy(materialRef.current.color);
-      }
+    // Ease the brightness so the mode toggle doesn't pop
+    (surfaceMaterial.uniforms.uTint.value as THREE.Color).lerp(
+      isNightMode ? NIGHT_TINT : DAY_TINT,
+      ease,
+    );
+
+    // Flare corona: billboard it, and size its nominal rim to a fixed
+    // screen width (~24 CSS px past the limb) regardless of camera
+    // distance — snug on the close home view, still delicate from the
+    // top-down landing view.
+    if (corona.current) {
+      corona.current.quaternion.copy(camera.quaternion);
+      const persp = camera as THREE.PerspectiveCamera;
+      const worldPerPx =
+        (2 * persp.position.length() * Math.tan((persp.fov * Math.PI) / 360)) /
+        size.height;
+      coronaMaterial.uniforms.uRingW.value = THREE.MathUtils.clamp(
+        (FLARE_RING_PX * worldPerPx) / (CORONA_HALF_RADII * SUN_RADIUS * scale),
+        0.004,
+        0.12,
+      );
+      // Flares surge a touch while the sun/ENTER link is hovered
+      const intensity = coronaMaterial.uniforms.uIntensity;
+      intensity.value +=
+        ((hoverState.sun ? 1.45 : 1) - (intensity.value as number)) * ease;
     }
   });
 
@@ -243,25 +272,20 @@ export default function Sun({
       <group ref={group}>
         <mesh ref={mesh}>
           <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
-          <meshBasicMaterial
-            ref={materialRef}
-            map={texture}
-            toneMapped={false}
-          />
-          {/* Crossfading spot layer, drawn just over the base surface */}
-          <mesh scale={1.001} renderOrder={1}>
-            <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
-            <meshBasicMaterial
-              ref={spotsMaterialRef}
-              map={spotsTexture}
-              toneMapped={false}
-              transparent
-              opacity={0}
-              depthWrite={false}
-            />
-          </mesh>
+          <primitive object={surfaceMaterial} attach="material" />
         </mesh>
-        {/* soft corona billboard */}
+        {/* Flare corona billboard: an animated rim of eruptions hugging
+            the limb (depth-tested, so the sphere hides its inner half) */}
+        <mesh ref={corona} renderOrder={2}>
+          <planeGeometry
+            args={[
+              SUN_RADIUS * 2 * CORONA_HALF_RADII,
+              SUN_RADIUS * 2 * CORONA_HALF_RADII,
+            ]}
+          />
+          <primitive object={coronaMaterial} attach="material" />
+        </mesh>
+        {/* soft wide glow billboard, for ambience at a distance */}
         <sprite ref={glow} scale={[SUN_RADIUS * 6, SUN_RADIUS * 6, 1]}>
           <spriteMaterial
             map={glowTexture}

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -21,10 +21,11 @@ import {
 /**
  * The sun: a slowly rotating sphere with an animated fbm shader surface
  * (convection cells and dark spots that drift, grow and dissolve — see
- * sunShaders.ts), a flare corona billboard whose rim hugs a fixed ~24 CSS
- * px past the projected limb with traveling eruption lobes, a soft wide
- * glow sprite for distant ambience, and the point light that lights the
- * planets. The whole group eases toward a per-view scale and publishes
+ * sunShaders.ts), a flare corona SHELL enveloping it whose rim hugs a
+ * fixed ~24 CSS px past the limb with traveling eruption lobes (aligned
+ * per fragment with the sphere's silhouette, so it can't drift), a soft
+ * wide glow sprite for distant ambience, and the point light that lights
+ * the planets. The whole group eases toward a per-view scale and publishes
  * the rendered scale so the DOM rings can track it; the glow sprite eases
  * toward a per-view size too — from the home sun-perch the full 6x glow
  * would span the whole frame and wash out the stars, so that view shrinks
@@ -38,8 +39,8 @@ const NIGHT_TINT = new THREE.Color(1.12, 1.12, 1.15);
 
 /** How far the flare corona's nominal rim extends past the limb, CSS px */
 const FLARE_RING_PX = 24;
-/** Corona plane half-size, in sun radii (must fit the biggest flare) */
-const CORONA_HALF_RADII = 2.4;
+/** Corona shell radius, in sun radii (must fit the biggest flare burst) */
+const CORONA_SHELL_RADII = 2;
 const ENTER_TEXT = "ENTER";
 const ENTER_FONT_SIZE_SVG = 22;
 /** Enlarge the curved "ENTER" label relative to its SVG-derived size */
@@ -59,8 +60,6 @@ const letterBasis = new THREE.Matrix4();
 const tangentAxis = new THREE.Vector3();
 const radialAxis = new THREE.Vector3();
 const upAxis = new THREE.Vector3(0, 1, 0);
-const camForward = new THREE.Vector3();
-const sunDir = new THREE.Vector3();
 
 /**
  * Orient a glyph flat in the XZ plane (facing the top-down camera) with its
@@ -200,14 +199,9 @@ export default function Sun({
   const group = useRef<THREE.Group>(null);
   const enterScaler = useRef<THREE.Group>(null);
   const mesh = useRef<THREE.Mesh>(null);
-  const corona = useRef<THREE.Mesh>(null);
   const glow = useRef<THREE.Sprite>(null);
   const surfaceMaterial = useMemo(() => createSunSurfaceMaterial(), []);
-  const coronaMaterial = useMemo(
-    // Disc radius in plane units: the plane's half-size is 1
-    () => createSunCoronaMaterial(1 / CORONA_HALF_RADII),
-    [],
-  );
+  const coronaMaterial = useMemo(() => createSunCoronaMaterial(), []);
   const glowTexture = useMemo(() => createSunGlowTexture(), []);
 
   useEffect(
@@ -247,47 +241,24 @@ export default function Sun({
       ease,
     );
 
-    // Flare corona: billboard it, and size its nominal rim to a fixed
-    // screen width (~24 CSS px past the limb) regardless of camera
-    // distance — snug on the close home view, still delicate from the
-    // top-down landing view.
-    if (corona.current) {
-      corona.current.quaternion.copy(camera.quaternion);
+    // Flare corona shell: the limb alignment is baked into the shader
+    // (per-fragment impact parameter — see sunShaders.ts), so the only
+    // per-frame inputs are the sun's world radius and the nominal band
+    // width sized to a fixed screen extent (~24 CSS px past the limb) —
+    // snug on the close home view, still delicate from the landing view.
+    {
       const persp = camera as THREE.PerspectiveCamera;
       const dist = persp.position.length();
       const worldPerPx =
         (2 * dist * Math.tan((persp.fov * Math.PI) / 360)) / size.height;
-      const planeHalf = CORONA_HALF_RADII * SUN_RADIUS * scale;
-      coronaMaterial.uniforms.uRingW.value = THREE.MathUtils.clamp(
-        (FLARE_RING_PX * worldPerPx) / planeHalf,
-        0.004,
-        0.12,
-      );
-      // Ring start: anchor the ring to the sphere's visible SILHOUETTE,
-      // not its radius. Up close the silhouette (the tangent cone) sits
-      // outside a radius-R circle drawn at the center's depth, and when
-      // the sun is off the optical axis (the home perch puts it at the
-      // frame's bottom) the silhouette is additionally an ellipse — so a
-      // radius-R ring floated visibly inside the limb. Anchor instead to
-      // the NEAR-SIDE tangent ray (the arc that's actually in frame):
-      // with β the sun's off-axis angle and θ the tangent-cone half-angle,
-      // that ray crosses the center-depth billboard at
-      //   d·cosβ · (tanβ − tan(β−θ))
-      // from the sun's center — which degrades to the on-axis d·tanθ.
       const worldR = SUN_RADIUS * scale;
-      const theta = Math.asin(Math.min(worldR / dist, 0.999));
-      persp.getWorldDirection(camForward);
-      sunDir.copy(persp.position).multiplyScalar(-1 / dist); // toward origin
-      const cosBeta = THREE.MathUtils.clamp(camForward.dot(sunDir), 0.15, 1);
-      const beta = Math.acos(cosBeta);
-      const silhouette =
-        dist *
-        cosBeta *
-        (Math.tan(beta) - Math.tan(Math.max(beta - theta, -1.4)));
-      coronaMaterial.uniforms.uDiscR.value = THREE.MathUtils.clamp(
-        silhouette / planeHalf,
-        0.05,
-        0.95,
+      coronaMaterial.uniforms.uSunR.value = worldR;
+      coronaMaterial.uniforms.uRingW.value = THREE.MathUtils.clamp(
+        FLARE_RING_PX * worldPerPx,
+        0.01,
+        // Cap so even a peak burst's visible tail (~11x the nominal
+        // width) stays inside the shell geometry's silhouette
+        worldR * 0.09,
       );
       // Flares surge a touch while the sun/ENTER link is hovered
       const intensity = coronaMaterial.uniforms.uIntensity;
@@ -303,15 +274,12 @@ export default function Sun({
           <sphereGeometry args={[SUN_RADIUS, 64, 64]} />
           <primitive object={surfaceMaterial} attach="material" />
         </mesh>
-        {/* Flare corona billboard: an animated rim of eruptions hugging
-            the limb (depth-tested, so the sphere hides its inner half) */}
-        <mesh ref={corona} renderOrder={2}>
-          <planeGeometry
-            args={[
-              SUN_RADIUS * 2 * CORONA_HALF_RADII,
-              SUN_RADIUS * 2 * CORONA_HALF_RADII,
-            ]}
-          />
+        {/* Flare corona: a back-side shell enveloping the sun. The rim of
+            animated eruptions is derived per fragment from the view ray's
+            distance to the sun's center, so it hugs the silhouette from
+            any camera angle; the sun's depth buffer occludes the rest. */}
+        <mesh renderOrder={2}>
+          <sphereGeometry args={[SUN_RADIUS * CORONA_SHELL_RADII, 48, 48]} />
           <primitive object={coronaMaterial} attach="material" />
         </mesh>
         {/* soft wide glow billboard, for ambience at a distance */}

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -59,6 +59,8 @@ const letterBasis = new THREE.Matrix4();
 const tangentAxis = new THREE.Vector3();
 const radialAxis = new THREE.Vector3();
 const upAxis = new THREE.Vector3(0, 1, 0);
+const camForward = new THREE.Vector3();
+const sunDir = new THREE.Vector3();
 
 /**
  * Orient a glyph flat in the XZ plane (facing the top-down camera) with its
@@ -252,13 +254,40 @@ export default function Sun({
     if (corona.current) {
       corona.current.quaternion.copy(camera.quaternion);
       const persp = camera as THREE.PerspectiveCamera;
+      const dist = persp.position.length();
       const worldPerPx =
-        (2 * persp.position.length() * Math.tan((persp.fov * Math.PI) / 360)) /
-        size.height;
+        (2 * dist * Math.tan((persp.fov * Math.PI) / 360)) / size.height;
+      const planeHalf = CORONA_HALF_RADII * SUN_RADIUS * scale;
       coronaMaterial.uniforms.uRingW.value = THREE.MathUtils.clamp(
-        (FLARE_RING_PX * worldPerPx) / (CORONA_HALF_RADII * SUN_RADIUS * scale),
+        (FLARE_RING_PX * worldPerPx) / planeHalf,
         0.004,
         0.12,
+      );
+      // Ring start: anchor the ring to the sphere's visible SILHOUETTE,
+      // not its radius. Up close the silhouette (the tangent cone) sits
+      // outside a radius-R circle drawn at the center's depth, and when
+      // the sun is off the optical axis (the home perch puts it at the
+      // frame's bottom) the silhouette is additionally an ellipse — so a
+      // radius-R ring floated visibly inside the limb. Anchor instead to
+      // the NEAR-SIDE tangent ray (the arc that's actually in frame):
+      // with β the sun's off-axis angle and θ the tangent-cone half-angle,
+      // that ray crosses the center-depth billboard at
+      //   d·cosβ · (tanβ − tan(β−θ))
+      // from the sun's center — which degrades to the on-axis d·tanθ.
+      const worldR = SUN_RADIUS * scale;
+      const theta = Math.asin(Math.min(worldR / dist, 0.999));
+      persp.getWorldDirection(camForward);
+      sunDir.copy(persp.position).multiplyScalar(-1 / dist); // toward origin
+      const cosBeta = THREE.MathUtils.clamp(camForward.dot(sunDir), 0.15, 1);
+      const beta = Math.acos(cosBeta);
+      const silhouette =
+        dist *
+        cosBeta *
+        (Math.tan(beta) - Math.tan(Math.max(beta - theta, -1.4)));
+      coronaMaterial.uniforms.uDiscR.value = THREE.MathUtils.clamp(
+        silhouette / planeHalf,
+        0.05,
+        0.95,
       );
       // Flares surge a touch while the sun/ENTER link is hovered
       const intensity = coronaMaterial.uniforms.uIntensity;

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -47,7 +47,15 @@ export const sunState = { scale: 1 };
  */
 export const rigState = { settled: true };
 
-const EARTH_ORBIT_SPEED = 0.09;
+/**
+ * Global tempo for the whole system: every orbit and self-spin below —
+ * planets, asteroids, the moon (and therefore the /about camera, which
+ * rides the moon's orbit) — scales together, preserving the relative
+ * motion that keeps the co-rotating asteroids frozen on screen.
+ */
+const SPEED_SCALE = 0.5;
+
+const EARTH_ORBIT_SPEED = 0.09 * SPEED_SCALE;
 export const PLANETS: SolarPlanetConfig[] = [
   {
     name: "Mercury",
@@ -56,34 +64,34 @@ export const PLANETS: SolarPlanetConfig[] = [
     orbitRadius: 7.5,
     orbitSpeed: EARTH_ORBIT_SPEED,
     orbitPhase: 0.6,
-    spinSpeed: 0.12,
+    spinSpeed: 0.12 * SPEED_SCALE,
   },
   {
     name: "Venus",
     kind: "venus",
     radius: 1.05,
     orbitRadius: 12,
-    orbitSpeed: 0.14,
+    orbitSpeed: 0.14 * SPEED_SCALE,
     orbitPhase: 2.4,
-    spinSpeed: -0.05,
+    spinSpeed: -0.05 * SPEED_SCALE,
   },
   {
     name: "Earth",
     kind: "earth",
     radius: 1.6,
     orbitRadius: 17.5,
-    orbitSpeed: 0.09,
+    orbitSpeed: EARTH_ORBIT_SPEED,
     orbitPhase: 4.2,
-    spinSpeed: 0.03,
+    spinSpeed: 0.03 * SPEED_SCALE,
   },
   {
     name: "Mars",
     kind: "mars",
     radius: 0.85,
     orbitRadius: 23.5,
-    orbitSpeed: 0.065,
+    orbitSpeed: 0.065 * SPEED_SCALE,
     orbitPhase: 1.3,
-    spinSpeed: 0.3,
+    spinSpeed: 0.3 * SPEED_SCALE,
   },
 ];
 
@@ -107,7 +115,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     orbitRadius: 4.2,
     orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase + 0.35,
-    spinSpeed: 0.2,
+    spinSpeed: 0.2 * SPEED_SCALE,
     yOffset: ASTEROID_Y,
     logo: "blog",
   },
@@ -120,7 +128,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     orbitRadius: 2.8,
     orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase - 0.7,
-    spinSpeed: -0.25,
+    spinSpeed: -0.25 * SPEED_SCALE,
     yOffset: ASTEROID_Y,
   },
   {
@@ -130,7 +138,7 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     orbitRadius: 2.4,
     orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase - 1.15,
-    spinSpeed: 0.3,
+    spinSpeed: 0.3 * SPEED_SCALE,
     logo: "linkedin",
     yOffset: ASTEROID_Y,
   },
@@ -142,9 +150,9 @@ export const MOON = {
   /** orbit radius around Earth's center */
   orbitRadius: 4,
   /** radians per second — slow, so the /about camera drifts gently */
-  orbitSpeed: 0.18,
+  orbitSpeed: 0.18 * SPEED_SCALE,
   orbitPhase: 1.1,
-  spinSpeed: 0.05,
+  spinSpeed: 0.05 * SPEED_SCALE,
 };
 
 /** Position of a planet at elapsed time t (seconds). */

--- a/src/space3d/solar/offAxisSquash.ts
+++ b/src/space3d/solar/offAxisSquash.ts
@@ -26,8 +26,18 @@ const basis = new THREE.Matrix4();
 const BLEND_NEAR_RADII = 5;
 const BLEND_FAR_RADII = 10;
 
+/**
+ * @param wrapper Outer group: rotated into the squash frame and scaled.
+ * @param counterRotate Inner group (direct child of `wrapper`): receives
+ *   the inverse rotation, so the net transform is R·S·R⁻¹ — a pure
+ *   directional squash that leaves the body's world orientation alone.
+ *   Without it the body is visibly REORIENTED to the camera frame: a
+ *   textured globe reads upside down wherever the squash basis points
+ *   its Y axis down, and camera swoops drag it through a tumble.
+ */
 export function applyOffAxisSquash(
   wrapper: THREE.Group,
+  counterRotate: THREE.Group,
   camera: THREE.Camera,
   bodyWorldPos: THREE.Vector3,
   bodyRadius: number,
@@ -45,6 +55,7 @@ export function applyOffAxisSquash(
   if (distance < 1e-4 || blend === 0) {
     wrapper.quaternion.identity();
     wrapper.scale.setScalar(1);
+    counterRotate.quaternion.identity();
     return;
   }
 
@@ -56,14 +67,17 @@ export function applyOffAxisSquash(
     // On-axis: no distortion to cancel
     wrapper.quaternion.identity();
     wrapper.scale.setScalar(1);
+    counterRotate.quaternion.identity();
     return;
   }
   radialDir.multiplyScalar(1 / radialLength);
 
   // Camera-aligned basis with local X on the screen-radial direction,
-  // then squash X by cos theta (blended)
+  // then squash X by cos theta (blended); the inner group undoes the
+  // rotation so only the squash is left
   upDir.crossVectors(forward, radialDir).normalize();
   basis.makeBasis(radialDir, upDir, forward);
   wrapper.quaternion.setFromRotationMatrix(basis);
   wrapper.scale.set(1 - blend * (1 - cos), 1, 1);
+  counterRotate.quaternion.copy(wrapper.quaternion).invert();
 }

--- a/src/space3d/solar/outline.ts
+++ b/src/space3d/solar/outline.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
 /**
- * Shared hover-outline helper for the link bodies (asteroids, the
- * satellite): projects every vertex of the given meshes through the
- * camera, takes the 2D convex hull — an excellent stand-in for the
- * silhouette of near-convex bodies — and writes it as a path into the
- * body's DOM overlay (the `.asteroid-outline` svg), mapped into its
- * 0-100 viewBox. The overlay's CSS supplies the purple stroke and the
+ * Shared hover-outline helper for the link bodies (Earth's /about ring,
+ * the asteroids, the satellite): projects every vertex of the given
+ * meshes through the camera, takes the 2D convex hull — an excellent
+ * stand-in for the silhouette of near-convex bodies — and writes it as a
+ * path into the body's DOM overlay (the `.body-outline` svg), mapped into
+ * its 0-100 viewBox. The overlay's CSS supplies the purple stroke and the
  * white perimeter pulses.
  */
 

--- a/src/space3d/solar/sunShaders.ts
+++ b/src/space3d/solar/sunShaders.ts
@@ -7,10 +7,12 @@ import * as THREE from "three";
  *   the convection cells and dark spots drift, grow and dissolve (the old
  *   static canvas texture couldn't evolve). Limb darkening keeps the
  *   close-up home view reading as a photosphere rather than a flat disc.
- * - Corona: a billboarded ring just past the limb whose width undulates
+ * - Corona: a 3D shell enveloping the sun whose rim glow hugs the limb
  *   with angular waves plus traveling "burst" lobes — solar flares going
- *   off at different spots. The nominal ring width is fed in per frame so
- *   it can hug a fixed ~24 CSS px past the projected limb.
+ *   off at different spots. The limb is derived per fragment from the
+ *   view geometry itself (see the impact-parameter note below), so the
+ *   glow can't misalign with the sphere; the nominal band width is fed
+ *   in per frame to track a fixed ~24 CSS px.
  *
  * Fragment cost scales with the sun's on-screen pixel coverage, so the
  * landing view (small sun) and about view (sun mostly off-frame) pay
@@ -125,31 +127,45 @@ export function createSunSurfaceMaterial(): THREE.ShaderMaterial {
   });
 }
 
+// The corona is a 3D SHELL enveloping the sun (rendered back-side, like
+// Earth's atmosphere), not a billboard. Each fragment computes the
+// impact parameter b — the perpendicular distance from the sun's center
+// to its own view ray. Rays tangent to the sphere have b == R exactly,
+// so (b − R) measures distance past the limb using the GPU's own
+// projection: the glow is aligned with the silhouette by construction,
+// from any camera angle, with no screen-space math to drift. The sun
+// sphere's depth buffer hides the shell inside the silhouette.
 const CORONA_VERTEX = /* glsl */ `
-  varying vec2 vUv;
+  varying vec3 vViewPos;
+  varying vec3 vCenterView;
 
   void main() {
-    vUv = uv;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    vViewPos = mvPosition.xyz;
+    // The sun's center (the shell's origin) in view space
+    vCenterView = (modelViewMatrix * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+    gl_Position = projectionMatrix * mvPosition;
   }
 `;
 
 const CORONA_FRAGMENT = /* glsl */ `
   uniform float uTime;
-  // The sun's projected SILHOUETTE radius mapped onto the billboard
-  // plane, plane units (half-size = 1) — written per frame by Sun, since
-  // up close the silhouette appears larger than the sphere radius at the
-  // plane's depth
-  uniform float uDiscR;
-  uniform float uRingW;      // nominal ring width, plane units
+  uniform float uSunR;   // sun radius, world units (incl. group scale)
+  uniform float uRingW;  // nominal flare band width, world units
   uniform float uIntensity;
   uniform vec3 uColorInner;
   uniform vec3 uColorOuter;
-  varying vec2 vUv;
+  varying vec3 vViewPos;
+  varying vec3 vCenterView;
 
   void main() {
-    vec2 p = vUv * 2.0 - 1.0;
-    float d = length(p);
+    // Impact parameter: perpendicular distance from the sun's center to
+    // this fragment's view ray (camera at the view-space origin)
+    vec3 rayDir = normalize(vViewPos);
+    float b = length(vCenterView - dot(vCenterView, rayDir) * rayDir);
+
+    // Angle around the disc (view-plane approximation) for the lobes
+    vec2 p = vViewPos.xy - vCenterView.xy;
     float ang = atan(p.y, p.x);
     float t = uTime;
 
@@ -169,8 +185,8 @@ const CORONA_FRAGMENT = /* glsl */ `
     float flare = clamp(base, 0.2, 1.3) + 1.9 * (burst1 + burst2);
 
     float w = uRingW * flare;
-    float x = (d - uDiscR) / max(w, 1e-4);
-    if (x < 0.0) discard; // inside the disc (the sphere occludes it anyway)
+    float x = (b - uSunR) / max(w, 1e-4);
+    if (x < 0.0) discard; // inside the silhouette (sun depth hides it too)
     float ring = exp(-x * 2.2);
 
     vec3 col = mix(uColorOuter, uColorInner, clamp(1.0 - x * 0.6, 0.0, 1.0));
@@ -180,19 +196,21 @@ const CORONA_FRAGMENT = /* glsl */ `
   }
 `;
 
-export function createSunCoronaMaterial(
-  discRPlane: number,
-): THREE.ShaderMaterial {
+export function createSunCoronaMaterial(): THREE.ShaderMaterial {
   return new THREE.ShaderMaterial({
     vertexShader: CORONA_VERTEX,
     fragmentShader: CORONA_FRAGMENT,
     transparent: true,
     depthWrite: false,
+    // Back side only: one shell layer per ray (no double-brightness), and
+    // the far half behind the sun's limb is depth-culled by the sun
+    // itself, so occlusion inside the silhouette is pixel-exact
+    side: THREE.BackSide,
     blending: THREE.AdditiveBlending,
     uniforms: {
       uTime: { value: 0 },
-      uDiscR: { value: discRPlane }, // pre-first-frame placeholder
-      uRingW: { value: 0.02 }, // written per frame (screen-space target)
+      uSunR: { value: 1 }, // written per frame
+      uRingW: { value: 0.1 }, // written per frame (screen-space target)
       uIntensity: { value: 1 },
       uColorInner: { value: new THREE.Color("#ffd27a") },
       uColorOuter: { value: new THREE.Color("#ff7a1a") },

--- a/src/space3d/solar/sunShaders.ts
+++ b/src/space3d/solar/sunShaders.ts
@@ -136,7 +136,11 @@ const CORONA_VERTEX = /* glsl */ `
 
 const CORONA_FRAGMENT = /* glsl */ `
   uniform float uTime;
-  uniform float uDiscR;      // sun disc radius, plane units (half-size = 1)
+  // The sun's projected SILHOUETTE radius mapped onto the billboard
+  // plane, plane units (half-size = 1) — written per frame by Sun, since
+  // up close the silhouette appears larger than the sphere radius at the
+  // plane's depth
+  uniform float uDiscR;
   uniform float uRingW;      // nominal ring width, plane units
   uniform float uIntensity;
   uniform vec3 uColorInner;
@@ -187,7 +191,7 @@ export function createSunCoronaMaterial(
     blending: THREE.AdditiveBlending,
     uniforms: {
       uTime: { value: 0 },
-      uDiscR: { value: discRPlane },
+      uDiscR: { value: discRPlane }, // pre-first-frame placeholder
       uRingW: { value: 0.02 }, // written per frame (screen-space target)
       uIntensity: { value: 1 },
       uColorInner: { value: new THREE.Color("#ffd27a") },

--- a/src/space3d/solar/sunShaders.ts
+++ b/src/space3d/solar/sunShaders.ts
@@ -1,0 +1,197 @@
+import * as THREE from "three";
+
+/**
+ * GLSL for the sun's two shader materials:
+ *
+ * - Surface: domain-warped fbm noise over the sphere, animated in time so
+ *   the convection cells and dark spots drift, grow and dissolve (the old
+ *   static canvas texture couldn't evolve). Limb darkening keeps the
+ *   close-up home view reading as a photosphere rather than a flat disc.
+ * - Corona: a billboarded ring just past the limb whose width undulates
+ *   with angular waves plus traveling "burst" lobes — solar flares going
+ *   off at different spots. The nominal ring width is fed in per frame so
+ *   it can hug a fixed ~24 CSS px past the projected limb.
+ *
+ * Fragment cost scales with the sun's on-screen pixel coverage, so the
+ * landing view (small sun) and about view (sun mostly off-frame) pay
+ * almost nothing — the detail is effectively home-page-only for free.
+ */
+
+/** Compact 3D value noise + fbm (hash13 after Dave Hoskins' hash without
+ *  sine, stable across GPUs). */
+const NOISE_GLSL = /* glsl */ `
+  float hash13(vec3 p3) {
+    p3 = fract(p3 * 0.1031);
+    p3 += dot(p3, p3.zyx + 31.32);
+    return fract((p3.x + p3.y) * p3.z);
+  }
+
+  float noise3(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+    float n000 = hash13(i);
+    float n100 = hash13(i + vec3(1.0, 0.0, 0.0));
+    float n010 = hash13(i + vec3(0.0, 1.0, 0.0));
+    float n110 = hash13(i + vec3(1.0, 1.0, 0.0));
+    float n001 = hash13(i + vec3(0.0, 0.0, 1.0));
+    float n101 = hash13(i + vec3(1.0, 0.0, 1.0));
+    float n011 = hash13(i + vec3(0.0, 1.0, 1.0));
+    float n111 = hash13(i + vec3(1.0, 1.0, 1.0));
+    return mix(
+      mix(mix(n000, n100, u.x), mix(n010, n110, u.x), u.y),
+      mix(mix(n001, n101, u.x), mix(n011, n111, u.x), u.y),
+      u.z
+    );
+  }
+
+  float fbm(vec3 p) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    for (int i = 0; i < 5; i++) {
+      value += amplitude * noise3(p);
+      p = p * 2.03 + 19.19;
+      amplitude *= 0.5;
+    }
+    return value;
+  }
+`;
+
+const SURFACE_VERTEX = /* glsl */ `
+  varying vec3 vObjPos;
+  varying vec3 vViewNormal;
+  varying vec3 vViewPos;
+
+  void main() {
+    vObjPos = position;
+    vViewNormal = normalMatrix * normal;
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    vViewPos = mvPosition.xyz;
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+// Palette matches the old canvas texture (#ffb824 base, #ff6a00 embers,
+// #fff3c4 highlights) plus a deep umbral tone for the dark spots.
+const SURFACE_FRAGMENT = /* glsl */ `
+  uniform float uTime;
+  uniform vec3 uTint;
+  varying vec3 vObjPos;
+  varying vec3 vViewNormal;
+  varying vec3 vViewPos;
+
+  ${""}
+  __NOISE__
+
+  void main() {
+    vec3 p = normalize(vObjPos);
+    float t = uTime * 0.05;
+
+    // Domain-warped fbm, drifting in time: cells merge, split and churn.
+    // Sampling in object space means the pattern also rides the mesh spin.
+    vec3 q = p * 2.2;
+    float warp = fbm(q + vec3(t, -t * 0.6, t * 0.3));
+    float field = fbm(q * 1.9 + vec3(warp * 1.7) + vec3(0.0, t * 0.8, -t * 0.5));
+    // Fine granulation "boil", faster than the large cells
+    float gran = noise3(p * 16.0 + vec3(0.0, 0.0, uTime * 0.32));
+    float v = field + (gran - 0.5) * 0.22;
+
+    vec3 SPOT  = vec3(0.478, 0.141, 0.0);   // #7a2400 umbral spot
+    vec3 EMBER = vec3(1.0, 0.416, 0.0);     // #ff6a00
+    vec3 GOLD  = vec3(1.0, 0.722, 0.141);   // #ffb824
+    vec3 CREAM = vec3(1.0, 0.953, 0.769);   // #fff3c4
+
+    vec3 col = mix(SPOT, EMBER, smoothstep(0.18, 0.40, v));
+    col = mix(col, GOLD, smoothstep(0.40, 0.62, v));
+    col = mix(col, CREAM, smoothstep(0.62, 0.85, v));
+
+    // Limb darkening: the photosphere dims and warms toward the edge
+    float ndv = clamp(dot(normalize(vViewNormal), normalize(-vViewPos)), 0.0, 1.0);
+    col *= mix(0.58, 1.0, pow(ndv, 0.55));
+
+    gl_FragColor = vec4(col * uTint, 1.0);
+  }
+`.replace("__NOISE__", NOISE_GLSL);
+
+export function createSunSurfaceMaterial(): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    vertexShader: SURFACE_VERTEX,
+    fragmentShader: SURFACE_FRAGMENT,
+    uniforms: {
+      uTime: { value: 0 },
+      // Written per frame by Sun (day/night tint lerp)
+      uTint: { value: new THREE.Color(1, 1, 1) },
+    },
+  });
+}
+
+const CORONA_VERTEX = /* glsl */ `
+  varying vec2 vUv;
+
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const CORONA_FRAGMENT = /* glsl */ `
+  uniform float uTime;
+  uniform float uDiscR;      // sun disc radius, plane units (half-size = 1)
+  uniform float uRingW;      // nominal ring width, plane units
+  uniform float uIntensity;
+  uniform vec3 uColorInner;
+  uniform vec3 uColorOuter;
+  varying vec2 vUv;
+
+  void main() {
+    vec2 p = vUv * 2.0 - 1.0;
+    float d = length(p);
+    float ang = atan(p.y, p.x);
+    float t = uTime;
+
+    // Undulating rim: layered angular waves...
+    float base =
+        0.55
+      + 0.26 * sin(ang * 3.0 + t * 0.43)
+      + 0.17 * sin(ang * 5.0 - t * 0.71)
+      + 0.11 * sin(ang * 9.0 + t * 1.13);
+    // ...plus localized eruptions that travel around the disc and pulse,
+    // overshooting the nominal width — the visible "flares"
+    float burst1 =
+      pow(max(sin(ang - t * 0.23), 0.0), 8.0) * (0.5 + 0.5 * sin(t * 0.9));
+    float burst2 =
+      pow(max(sin(ang * 2.0 + t * 0.17 + 2.1), 0.0), 10.0) *
+      (0.5 + 0.5 * sin(t * 0.63 + 1.7));
+    float flare = clamp(base, 0.2, 1.3) + 1.9 * (burst1 + burst2);
+
+    float w = uRingW * flare;
+    float x = (d - uDiscR) / max(w, 1e-4);
+    if (x < 0.0) discard; // inside the disc (the sphere occludes it anyway)
+    float ring = exp(-x * 2.2);
+
+    vec3 col = mix(uColorOuter, uColorInner, clamp(1.0 - x * 0.6, 0.0, 1.0));
+    float alpha = ring * uIntensity;
+    if (alpha < 0.004) discard;
+    gl_FragColor = vec4(col, alpha);
+  }
+`;
+
+export function createSunCoronaMaterial(
+  discRPlane: number,
+): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    vertexShader: CORONA_VERTEX,
+    fragmentShader: CORONA_FRAGMENT,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    uniforms: {
+      uTime: { value: 0 },
+      uDiscR: { value: discRPlane },
+      uRingW: { value: 0.02 }, // written per frame (screen-space target)
+      uIntensity: { value: 1 },
+      uColorInner: { value: new THREE.Color("#ffd27a") },
+      uColorOuter: { value: new THREE.Color("#ff7a1a") },
+    },
+  });
+}

--- a/src/space3d/starPan.ts
+++ b/src/space3d/starPan.ts
@@ -1,0 +1,14 @@
+/**
+ * Screen-space pan accumulated from the solar camera's rotation, in CSS
+ * pixels. Written by CameraRig each frame (the per-frame rotation delta
+ * projected to screen axes); read by the star field, which shifts and
+ * wraps the background stars by it — so the distant starscape rotates
+ * with the camera (the home view co-rotates with Earth's orbit, the
+ * about view rides the moon's) instead of being painted on.
+ *
+ * Axes follow the star canvas's world axes: +x right, +y up. The value
+ * grows without bound as the camera keeps orbiting; the star shader
+ * wraps positions around the padded viewport, so only the fractional
+ * part matters.
+ */
+export const starPanState = { x: 0, y: 0 };

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -147,22 +147,8 @@ export function createPlanetTexture(kind: PlanetKind): THREE.CanvasTexture {
   return asTexture(canvas);
 }
 
-/** Mottled golden sun surface (unlit; pair with the glow billboard). */
-export function createSunTexture(): THREE.CanvasTexture {
-  const w = 512;
-  const h = 256;
-  const canvas = createCanvas(w, h);
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return asTexture(canvas);
-
-  ctx.fillStyle = "#ffb824";
-  ctx.fillRect(0, 0, w, h);
-  drawBlotches(ctx, w, h, 240, 6, 40, ["#ff8c00", "#ffd75e", "#ff6a00"], 0.35);
-  drawBlotches(ctx, w, h, 300, 2, 10, ["#fff3c4"], 0.3);
-  return asTexture(canvas);
-}
-
-/** Soft warm radial glow for the sun's corona billboard. */
+/** Soft warm radial glow for the sun's wide ambience billboard (the
+ *  animated surface + flare corona are shaders — see solar/sunShaders). */
 export function createSunGlowTexture(): THREE.CanvasTexture {
   const size = 256;
   const canvas = createCanvas(size, size);


### PR DESCRIPTION
Follow-up to #68 — all the 3D/performance work that landed on the old branch after it merged, rebased cleanly onto master (no conflicts; `tsc`/`lint`/`build` verified against the new base, including the space-jams changes).

## 🥶 Performance
- **Fixed the /about scroll freeze**: `.resume-panel`'s `backdrop-filter: blur(10px)` forced a backdrop re-capture of the content-height panel on every canvas frame *and* every scroll frame over two animating WebGL canvases. Replaced with higher-opacity backgrounds (night 0.82, day 0.88).
- Capped both canvases at **DPR 1.5** (was 2); star canvas drops MSAA (point sprites don't benefit); `powerPreference: "high-performance"`.
- The day background's fullscreen `hue-rotate` animation no longer runs while faded out in night mode.
- **`SPEED_SCALE = 0.5`** in `solar/constants.ts` halves every orbit/spin coherently (asteroid co-rotation with Earth preserved).

## ☀️ Sun overhaul
- **Animated shader surface** (`sunShaders.ts`): domain-warped fbm noise — convection cells and dark spots drift, grow, and dissolve; limb darkening for the close-up home view. Replaces the static canvas texture + crossfade layer (one less draw call).
- **Flare corona as a 3D shell**: a back-side sphere enveloping the sun. The shader derives the limb per fragment from the view ray's *impact parameter* (`b = R` exactly on tangent rays), so the glow aligns with the silhouette **by construction** from any camera angle — after two billboard/screen-space attempts drifted. Nominal band width tracks ~24 CSS px past the limb; angular waves + traveling bursts read as flares; surge on hover.
- Fragment cost self-regulates by pixel coverage (sun is only big on /home), so no view-gating needed.

## ✨ Star parallax
The home camera co-rotates with Earth and the about camera rides the moon, but the stars were painted on. `CameraRig` now folds each frame's rotation delta into a pixel-space pan (`starPan.ts`); the background-star vertex shader shifts + wraps positions around a padded viewport. Text stars stay glyph-locked.

## 🪐 Solar scene fixes
- **Asteroids/satellite are home-view only** (hidden on landing and /about), plus a fade-init fix so rocks mounting hidden don't flash opaque against the landing sun.
- **Earth no longer renders upside down / tumbles during swoops**: `offAxisSquash` was reorienting bodies into its camera-aligned squash basis; it now applies `R·S·R⁻¹` via an inner counter-rotate group (planets + moon).
- **Earth's /about hover matches the other link bodies**: same pulsing silhouette outline, deduped into a shared `BodyOutline` component + `.body-outline` styles.
- **Smoother asteroids**: detail-3 icosphere, welded verts, coherent lumps (no more low-poly crystal) — which also fixes the logo decals vanishing in chunks as facets turned edge-on. **Satellite** rolls slower (0.35×) and carries two GitHub sticker decals on the body, spinning with it (same treatment as the rocks).

## 📄 Tooling
- New `CLAUDE.md` (env gotchas, architecture invariants, perf rules, content facts).
- `.claude/launch.json` launches the dev server with the newest installed nvm node (the default shell node is too old for rspack).

## Notes for review
- Commit `0fcf70d` (billboard silhouette alignment) is superseded by `eab8b00` (the 3D shell) — kept for history.
- Visual tuning knobs, if wanted: `FLARE_RING_PX`, `CORONA_SHELL_RADII`, burst coefficients in `sunShaders.ts`; `SPEED_SCALE`; satellite `ROLL_SPEED_SCALE`.