### PR TITLE
Moon plays the Zip brand video; flip the satellite's backside badge

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -938,7 +938,9 @@ a:hover {
 .asteroid-link:hover .body-outline,
 .asteroid-link:focus-visible .body-outline,
 .earth-about-ring:hover .body-outline,
-.earth-about-ring:focus-visible .body-outline {
+.earth-about-ring:focus-visible .body-outline,
+.moon-link:hover .body-outline,
+.moon-link:focus-visible .body-outline {
   opacity: 1;
 }
 
@@ -965,6 +967,110 @@ a:hover {
   border-radius: 50%;
   pointer-events: auto;
   cursor: pointer;
+}
+
+// The moon's video link on /about (ZipVideoMoon), glued to the moon by
+// BodyAnchors like the rest; z 5 lifts it above the résumé scroll
+// container (z 4) so it stays hoverable
+.moon-link {
+  position: fixed;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.8s ease;
+  z-index: 5;
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+// ─── Zip brand-video popover (ZipVideoMoon) ────────────────
+// While the video plays, `video-mode` on <body> hides everything except
+// the stars: the solar canvas, the name letters, the mode toggle, and
+// the music player/toggle. The résumé panel hides itself (.video-hidden).
+body.video-mode {
+  .solar-canvas,
+  .nameTitle,
+  .day-night-switch,
+  audio,
+  .music-toggle {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+}
+
+// Let the scene fade rather than pop when video-mode toggles it
+.solar-canvas {
+  transition: opacity 0.5s ease;
+}
+
+.resume-inner-container {
+  transition: opacity 0.4s ease;
+
+  &.video-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.zip-video-layer {
+  // Transparent backdrop — the stars stay visible around the popover;
+  // clicking it closes the video
+  position: fixed;
+  inset: 0;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zip-video-popover {
+  position: relative;
+  width: 80vw;
+  animation: zipVideoIn 0.5s ease both;
+
+  video {
+    display: block;
+    width: 100%;
+    max-height: 82vh;
+    object-fit: contain;
+    background: #000;
+    border-radius: 12px;
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.65);
+  }
+}
+
+.zip-video-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  color: #e8e6f5;
+
+  &:hover {
+    color: #ffffff;
+  }
+}
+
+.App.day .zip-video-close {
+  color: #24203a;
+
+  &:hover {
+    color: #000000;
+  }
+}
+
+@keyframes zipVideoIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .App-background_day {

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -109,7 +109,8 @@ const AppBackground = ({
             type="button"
             onClick={() => setMusicEnabled(true)}
             className={cx(
-              "fixed bottom-4 left-4 z-[5000] flex items-center gap-1",
+              // music-toggle: hook for the video-mode hiding rules (App.scss)
+              "music-toggle fixed bottom-4 left-4 z-[5000] flex items-center gap-1",
               isNightMode && "inverse",
             )}
           >

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftCircle, Calendar } from "react-feather";
 import { useInView } from "react-intersection-observer";
 import { Link } from "react-router-dom";
 import useWindowSize from "useWindowSize";
+import ZipVideoMoon from "./ZipVideoMoon";
 
 const experienceItems = [
   {
@@ -72,6 +73,9 @@ const experienceItems = [
 
 const Resume = () => {
   const [opacity, setOpacity] = useState(false);
+  // The moon's video popover (ZipVideoMoon); while it plays, the résumé
+  // panel hides so only the stars remain behind the video
+  const [videoOpen, setVideoOpen] = useState(false);
   // Drives the Home link's slide: at rest the heading sits ~288px from
   // the viewport top on xl, so the -260px margin keeps it "in view" until
   // the user scrolls a few dozen px, then the link slides away
@@ -91,9 +95,13 @@ const Resume = () => {
 
   return (
     <main className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
+      {/* The moon doubles as the Zip brand-video link (overlay + popover) */}
+      <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
       {/* The link lives outside .resume-panel so the frosted background
           starts above the "About Me" heading, not around the link */}
-      <div className="resume-inner-container">
+      <div
+        className={cx("resume-inner-container", videoOpen && "video-hidden")}
+      >
         <Link
           className={cx(
             "back-to-home-link flex transition-transform items-center gap-4 mb-6 inverse ml-8 xl:sticky xl:top-[200px] xl:-ml-8",

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -23,10 +23,11 @@ import { hoverState } from "./solarHover";
  * revealed once positioned.
  */
 
-/** Hover outline shared by every link body (Earth, asteroids, satellite):
- *  the body's projected silhouette, drawn by the 3D scene into these paths
- *  (viewBox matches the anchor box; pathLength normalizes the dash pulse). */
-const BodyOutline = ({ outlineId }: { outlineId: string }) => (
+/** Hover outline shared by every link body (Earth, the moon, asteroids,
+ *  satellite): the body's projected silhouette, drawn by the 3D scene into
+ *  these paths (viewBox matches the anchor box; pathLength normalizes the
+ *  dash pulse). */
+export const BodyOutline = ({ outlineId }: { outlineId: string }) => (
   <svg className="body-outline" viewBox="0 0 100 100" aria-hidden>
     <g id={outlineId}>
       <path className="body-outline-base" pathLength={100} />

--- a/src/ZipVideoMoon.tsx
+++ b/src/ZipVideoMoon.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useEffect } from "react";
+import { X } from "react-feather";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+import {
+  MOON_VIDEO_LINK_ID,
+  MOON_VIDEO_OUTLINE_ID,
+} from "./space3d/solar/BodyAnchors";
+import { BodyOutline } from "./SolarOverlays";
+import { hoverState } from "./solarHover";
+
+/**
+ * The /about moon as a video link: an invisible overlay that BodyAnchors
+ * glues to the moon's projection (same plumbing as the asteroid links),
+ * with a tooltip and the shared pulsing hover outline. Clicking it opens
+ * the Zip brand-redesign launch reel in a ~80vw popover; `video-mode` on
+ * <body> hides everything but the stars behind it (App.scss), and Resume
+ * hides its own panel via the lifted `open` state.
+ *
+ * While the popover is open the overlay itself is unmounted — BodyAnchors
+ * skips absent elements, so there's nothing left hovering over the video.
+ */
+const ZipVideoMoon = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const close = useCallback(() => onOpenChange(false), [onOpenChange]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.classList.add("video-mode");
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.classList.remove("video-mode");
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, close]);
+
+  // Navigating away (or opening the video) doesn't fire pointerleave —
+  // don't leave the moon's hover glow stuck on
+  useEffect(
+    () => () => {
+      hoverState.moon = false;
+    },
+    [],
+  );
+
+  if (open) {
+    return (
+      <div className="zip-video-layer" onClick={close}>
+        <div className="zip-video-popover" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            className="zip-video-close"
+            aria-label="Close video"
+            onClick={close}
+          >
+            <X size={28} />
+          </button>
+          {/* The click that opened the popover is the user gesture that
+              allows autoplay with sound */}
+          <video src="/zip-brand-launch.mp4" controls autoPlay playsInline />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            id={MOON_VIDEO_LINK_ID}
+            className="moon-link"
+            aria-label="Zip brand redesign launch video"
+            onClick={() => {
+              hoverState.moon = false;
+              onOpenChange(true);
+            }}
+            onPointerEnter={() => {
+              hoverState.moon = true;
+            }}
+            onPointerLeave={() => {
+              hoverState.moon = false;
+            }}
+          >
+            <BodyOutline outlineId={MOON_VIDEO_OUTLINE_ID} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent updatePositionStrategy="always">
+          <p>Zip brand redesign launch video</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default ZipVideoMoon;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -8,6 +8,8 @@
 export const hoverState = {
   sun: false,
   earth: false,
+  /** The moon's video-link overlay on /about */
+  moon: false,
   /** Name of the hovered link asteroid (constants.ts ASTEROIDS), or null */
   asteroid: null as string | null,
 };

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -4,6 +4,8 @@ import * as THREE from "three";
 import {
   ASTEROIDS,
   EARTH,
+  moonPosition,
+  MOON,
   planetPosition,
   rigState,
   type SolarPlanetConfig,
@@ -28,6 +30,10 @@ export const EARTH_ABOUT_RING_ID = "earth-about-ring";
 /** Group inside the /about ring holding Earth's hover-outline paths;
  *  Planet writes Earth's projected silhouette into every path under it. */
 export const EARTH_ABOUT_OUTLINE_ID = "earth-about-outline";
+/** The moon's video-link overlay on /about (rendered by Resume) and the
+ *  group holding its hover-outline paths (written by Moon). */
+export const MOON_VIDEO_LINK_ID = "moon-video-link";
+export const MOON_VIDEO_OUTLINE_ID = "moon-video-outline";
 export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;
 /** Group inside the anchor holding the hover-outline paths; Asteroid
  *  writes the projected silhouette into every path under it. */
@@ -63,6 +69,15 @@ const ANCHORS: BodyAnchorConfig[] = [
     // the letters ~27% clear of Earth's limb (1.3 grazed the surface)
     ringScale: 1.55,
     minSizePx: 140,
+    fadeInOnArrival: true,
+  },
+  {
+    // The moon's video link (the overlay only exists on /about)
+    domId: MOON_VIDEO_LINK_ID,
+    position: (t, out) => moonPosition(t, out),
+    radius: MOON.radius,
+    ringScale: 1.4,
+    minSizePx: 44,
     fadeInOnArrival: true,
   },
   ...ASTEROIDS.map(asteroidConfig),

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
+import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 
 import { EARTH, MOON, planetPosition } from "./constants";
 import { applyOffAxisSquash } from "./offAxisSquash";
+import { MOON_VIDEO_OUTLINE_ID } from "./BodyAnchors";
+import { writeSilhouette } from "./outline";
+import { createLogoBadgeTexture } from "../textures";
+import { hoverState } from "../../solarHover";
 import moonMapUrl from "../../assets/moon.jpg";
 
 /**
@@ -15,9 +20,19 @@ import moonMapUrl from "../../assets/moon.jpg";
  * Like Earth, the moon self-illuminates faintly (its own map as a dim
  * emissive) so the /about camera — which perches over the moon's far side
  * — still reads it when that face is turned away from the sun.
+ *
+ * On /about the moon doubles as a video link (the Zip brand-launch reel —
+ * see ZipVideoMoon): play-icon badges are decaled onto the surface, and
+ * hovering the DOM overlay brightens the moon and pulses its silhouette
+ * outline, matching the other link bodies.
  */
 /** Fade duration for the landing-intro reveal */
 const REVEAL_SECONDS = 0.8;
+
+/** Play badges around the equator: 3 at 120° apart, so from any camera
+ *  angle at least one is within 60° of facing the viewer (the moon's
+ *  self-spin is glacial — a single badge could hide for minutes). */
+const BADGE_YAWS = [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3];
 
 const moonWorldPos = new THREE.Vector3();
 
@@ -48,6 +63,52 @@ export default function Moon({
   }, []);
   useEffect(() => () => texture.dispose(), [texture]);
 
+  const geometry = useMemo(
+    () => new THREE.SphereGeometry(MOON.radius, 48, 48),
+    [],
+  );
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  // Play-icon stickers on the surface (same decal treatment as the
+  // asteroid badges), riding the moon's slow self-spin
+  const badgeMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        map: createLogoBadgeTexture("play"),
+        transparent: true,
+        depthWrite: false,
+        polygonOffset: true,
+        polygonOffsetFactor: -4,
+      }),
+    [],
+  );
+  useEffect(
+    () => () => {
+      badgeMaterial.map?.dispose();
+      badgeMaterial.dispose();
+    },
+    [badgeMaterial],
+  );
+
+  const badgeGeometries = useMemo(() => {
+    const target = new THREE.Mesh(geometry);
+    const r = MOON.radius;
+    const size = new THREE.Vector3(r * 0.95, r * 0.95, r * 0.8);
+    return BADGE_YAWS.map(
+      (yaw) =>
+        new DecalGeometry(
+          target,
+          new THREE.Vector3(Math.sin(yaw) * r, 0, Math.cos(yaw) * r),
+          new THREE.Euler(0, yaw, 0),
+          size,
+        ),
+    );
+  }, [geometry]);
+  useEffect(
+    () => () => badgeGeometries.forEach((g) => g.dispose()),
+    [badgeGeometries],
+  );
+
   const orbitLine = useMemo(() => {
     const points: THREE.Vector3[] = [];
     for (let i = 0; i <= 128; i++) {
@@ -64,7 +125,7 @@ export default function Moon({
   }, []);
   useEffect(() => () => orbitLine.dispose(), [orbitLine]);
 
-  useFrame(({ clock, camera }, delta) => {
+  useFrame(({ clock, camera, size }, delta) => {
     const t = clock.elapsedTime;
     if (earthGroup.current) {
       planetPosition(EARTH, t, earthGroup.current.position);
@@ -108,8 +169,22 @@ export default function Moon({
     if (surfaceMaterial.current) {
       surfaceMaterial.current.opacity = revealOpacity.current;
     }
+    badgeMaterial.opacity = revealOpacity.current;
     if (orbitMaterial.current) {
       orbitMaterial.current.opacity = orbitOpacity * revealOpacity.current;
+    }
+
+    // Video-link hover (the /about overlay): brighten the moonshine and
+    // hand the silhouette to the overlay's pulsing outline paths
+    const hovered = hoverState.moon;
+    if (surfaceMaterial.current) {
+      const ease = Math.min(delta * 6, 1);
+      surfaceMaterial.current.emissiveIntensity +=
+        ((hovered ? 0.55 : 0.22) - surfaceMaterial.current.emissiveIntensity) *
+        ease;
+    }
+    if (hovered && mesh.current) {
+      writeSilhouette(MOON_VIDEO_OUTLINE_ID, [mesh.current], camera, size);
     }
   });
 
@@ -126,8 +201,7 @@ export default function Moon({
       <group ref={moonGroup}>
         <group ref={squashWrapper}>
           <group ref={squashCounterRotate}>
-            <mesh ref={mesh}>
-              <sphereGeometry args={[MOON.radius, 48, 48]} />
+            <mesh ref={mesh} geometry={geometry}>
               <meshStandardMaterial
                 ref={surfaceMaterial}
                 map={texture}
@@ -138,6 +212,14 @@ export default function Moon({
                 emissiveIntensity={0.22}
                 transparent
               />
+              {/* Play-icon stickers, riding the spin with the surface */}
+              {badgeGeometries.map((badgeGeometry, i) => (
+                <mesh
+                  key={i}
+                  geometry={badgeGeometry}
+                  material={badgeMaterial}
+                />
+              ))}
             </mesh>
           </group>
         </group>

--- a/src/space3d/solar/Satellite.tsx
+++ b/src/space3d/solar/Satellite.tsx
@@ -128,10 +128,14 @@ export default function Satellite({
         new THREE.Euler(0, Math.PI / 2, 0),
         size,
       ),
+      // The backside badge is projected upside down (the extra Z roll):
+      // it comes around half a roll after the front one, so flipping it
+      // makes BOTH marks read right-side up at the moment they face the
+      // camera.
       new DecalGeometry(
         target,
         new THREE.Vector3(-bodyRadius, 0, 0),
-        new THREE.Euler(0, -Math.PI / 2, 0),
+        new THREE.Euler(0, -Math.PI / 2, Math.PI),
         size,
       ),
     ];

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -201,7 +201,11 @@ const RSS_MARK_PATH =
   "909 24h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727 0 15.909 " +
   "7.184 15.909 15.91z";
 
-export type AsteroidLogo = "github" | "linkedin" | "blog";
+/** A simple play triangle (Material Design play arrow), in a 24x24
+ *  viewBox — the moon's "watch the video" badge. */
+const PLAY_MARK_PATH = "M8 5v14l11-7z";
+
+export type AsteroidLogo = "github" | "linkedin" | "blog" | "play";
 
 const LOGO_MARKS: Record<
   AsteroidLogo,
@@ -211,6 +215,7 @@ const LOGO_MARKS: Record<
   // The square marks are scaled down so their corners stay inside the disc
   linkedin: { path: LINKEDIN_MARK_PATH, color: "#0a66c2", scale: 0.6 },
   blog: { path: RSS_MARK_PATH, color: "#f26522", scale: 0.6 },
+  play: { path: PLAY_MARK_PATH, color: "#412596", scale: 0.85 },
 };
 
 /** White badge disc with a brand mark, transparent outside the disc —


### PR DESCRIPTION
## 🛰️ Satellite badge flip
The backside GitHub decal is now projected with an extra half-turn about its own axis. Since it comes into view half a roll after the front badge, the flip makes **both marks read right-side up at the moment they face the camera** (previously the back one appeared inverted, per the screen recording).

## 🌕 The moon is now a link (on /about)
Same plumbing as the asteroid links:
- **Overlay** glued to the moon's projection by `BodyAnchors` (fades in once the camera settles), sitting above the résumé scroll container so it stays hoverable
- **Tooltip**: "Zip brand redesign launch video"
- **Hover**: the shared pulsing silhouette outline + a moonshine brighten
- **Play icons on the surface**: three play-arrow badges decaled around the equator, 120° apart — the moon's self-spin is glacial, so with a single badge the icon could hide for minutes; at 120° spacing one is always roughly camera-facing. They ride the spin like the asteroid stickers.

## 🎬 Video popover
Clicking the moon opens `public/zip-brand-launch.mp4` (**23 MB**, committed to the repo and served like `analog.wav`) in an **~80vw popover** (max-height capped so it fits short viewports):
- A `video-mode` class on `<body>` fades out **everything except the stars** — solar canvas, name letters, day/night switch, music player/toggle — and the résumé panel hides itself via lifted state
- Autoplays with sound (the click is the user gesture), standard controls
- Close via the ✕ button, clicking the backdrop, or Escape — everything fades back
- The moon overlay unmounts while the popover is open, so `BodyAnchors` has nothing to fight

## Verified
`tsc` + `lint` + `build`, plus a live check: clicking the moon opens the popover at exactly 80vw with `solar-canvas`/switch/panel hidden and stars visible; Escape restores everything; the play badge renders on the moon's surface.

## Note
- The 23 MB video makes this repo's largest file; `yarn deploy`'s hashed-asset caching doesn't apply to `public/` passthroughs, so it ships with the standard sync. If you'd rather host it on the CDN separately, easy to swap the `src`.