### PR TITLE
Three badges per body, all upright at their facing moment

### DIFF
--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -18,11 +18,12 @@ import { hoverState } from "../../solarHover";
  * BodyAnchors via the same planetPosition() the mesh uses, so the two
  * can't drift apart.
  *
- * `config.logo` projects a brand badge onto two opposite sides of the
- * rock's surface (DecalGeometry clips the sticker to the mesh, so it
- * follows the lumps and spins with them). Logo rocks spin about the
- * world-vertical axis only — the decals' texture-up stays world-up, so
- * the mark always reads (approximately) right-side up as it pans by.
+ * `config.logo` projects a brand badge onto three spots evenly spaced
+ * around the rock's spin circumference (DecalGeometry clips the sticker
+ * to the mesh, so it follows the lumps and spins with them). Logo rocks
+ * spin about the world-vertical axis only — the decals' texture-up stays
+ * world-up, so the mark always reads (approximately) right-side up as it
+ * pans by.
  *
  * `visible` fades the whole rock (materials' opacity eased per frame):
  * the asteroids are hidden in the landing view and fade in during the
@@ -30,6 +31,8 @@ import { hoverState } from "../../solarHover";
  */
 const FADE_IN_SECONDS = 3;
 const FADE_OUT_SECONDS = 1;
+/** Badge stickers every 120° around the yaw circumference */
+const BADGE_YAWS = [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3];
 
 export default function Asteroid({
   config,
@@ -86,30 +89,29 @@ export default function Asteroid({
   }, [config.radius]);
   useEffect(() => () => geometry.dispose(), [geometry]);
 
-  // Project the badge onto the surface from +z and -z. DecalGeometry wants
-  // a mesh to shoot at; an identity-transform temp mesh keeps the decal
-  // vertices in the rock's local space, so parenting the decals under the
-  // spinning mesh keeps them glued to the lumps they were cut from. The
-  // box is sized to swallow the full lump range (~0.78r..1.23r).
+  // Project the badge onto the surface at three spots evenly spaced
+  // around the spin circumference (the rock yaws about local Y, so the
+  // marks sweep past the camera every third of a turn). DecalGeometry
+  // wants a mesh to shoot at; an identity-transform temp mesh keeps the
+  // decal vertices in the rock's local space, so parenting the decals
+  // under the spinning mesh keeps them glued to the lumps they were cut
+  // from. Stickers are sized so neighbors 120° apart don't overlap (each
+  // wraps ~±49°), and the box depth swallows the lump range
+  // (~0.78r..1.23r).
   const decalGeometries = useMemo(() => {
     if (!config.logo) return null;
     const r = config.radius;
     const target = new THREE.Mesh(geometry);
-    const size = new THREE.Vector3(r * 1.82, r * 1.82, r * 1.6);
-    return [
-      new DecalGeometry(
-        target,
-        new THREE.Vector3(0, 0, r),
-        new THREE.Euler(0, 0, 0),
-        size,
-      ),
-      new DecalGeometry(
-        target,
-        new THREE.Vector3(0, 0, -r),
-        new THREE.Euler(0, Math.PI, 0),
-        size,
-      ),
-    ];
+    const size = new THREE.Vector3(r * 1.5, r * 1.5, r * 1.6);
+    return BADGE_YAWS.map(
+      (yaw) =>
+        new DecalGeometry(
+          target,
+          new THREE.Vector3(Math.sin(yaw) * r, 0, Math.cos(yaw) * r),
+          new THREE.Euler(0, yaw, 0),
+          size,
+        ),
+    );
   }, [config.logo, geometry, config.radius]);
   useEffect(
     () => () => decalGeometries?.forEach((g) => g.dispose()),

--- a/src/space3d/solar/Satellite.tsx
+++ b/src/space3d/solar/Satellite.tsx
@@ -24,9 +24,9 @@ import { hoverState } from "../../solarHover";
  * always point right. The beacon hangs off the rig, not the rolling
  * body, so it stays on top of the head.
  *
- * The GitHub badge is a pair of decals projected onto opposite sides of
- * the sphere (the same sticker treatment as the asteroids), glued to the
- * rolling body so the mark turns with the spin.
+ * The GitHub badge is a trio of decals evenly spaced around the sphere
+ * (the same sticker treatment as the asteroids), glued to the rolling
+ * body so the marks turn with the spin.
  */
 
 const FADE_IN_SECONDS = 3;
@@ -39,6 +39,8 @@ const BLINK_ON_FRACTION = 0.55;
 const HOVER_EMISSIVE = 0.9;
 /** Slow the body roll well below the config spin (a stately tumble) */
 const ROLL_SPEED_SCALE = 0.35;
+/** Badges every 120° around the roll circumference */
+const BADGE_ANGLES = [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3];
 
 const Z_AXIS = new THREE.Vector3(0, 0, 1);
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
@@ -111,9 +113,12 @@ export default function Satellite({
   );
   useEffect(() => () => bodyGeometry.dispose(), [bodyGeometry]);
 
-  // Badge decals on opposite sides of the sphere, perpendicular to the
-  // roll axis (local Z, the leg cone) so the marks sweep past the camera
-  // as the body rolls — one on each side, like the asteroid stickers.
+  // Badge decals evenly spaced around the roll circumference (the plane
+  // perpendicular to local Z, the leg cone) so a mark sweeps past the
+  // camera every third of a roll. Because each projector is the same base
+  // pose spun about the roll axis, ALL badges show the same orientation
+  // at the moment they face the camera — and the unflipped base reads
+  // upside down there, so the base pose carries a 180° texture roll.
   const badgeGeometries = useMemo(() => {
     const target = new THREE.Mesh(bodyGeometry);
     const size = new THREE.Vector3(
@@ -121,24 +126,25 @@ export default function Satellite({
       bodyRadius * 1.4,
       bodyRadius * 1.1,
     );
-    return [
-      new DecalGeometry(
+    // Look from +X toward the center, texture rolled 180°
+    const basePose = new THREE.Quaternion()
+      .setFromAxisAngle(Y_AXIS, Math.PI / 2)
+      .multiply(new THREE.Quaternion().setFromAxisAngle(Z_AXIS, Math.PI));
+    return BADGE_ANGLES.map((angle) => {
+      const pose = new THREE.Quaternion()
+        .setFromAxisAngle(Z_AXIS, angle)
+        .multiply(basePose);
+      return new DecalGeometry(
         target,
-        new THREE.Vector3(bodyRadius, 0, 0),
-        new THREE.Euler(0, Math.PI / 2, 0),
+        new THREE.Vector3(
+          Math.cos(angle) * bodyRadius,
+          Math.sin(angle) * bodyRadius,
+          0,
+        ),
+        new THREE.Euler().setFromQuaternion(pose),
         size,
-      ),
-      // The backside badge is projected upside down (the extra Z roll):
-      // it comes around half a roll after the front one, so flipping it
-      // makes BOTH marks read right-side up at the moment they face the
-      // camera.
-      new DecalGeometry(
-        target,
-        new THREE.Vector3(-bodyRadius, 0, 0),
-        new THREE.Euler(0, -Math.PI / 2, Math.PI),
-        size,
-      ),
-    ];
+      );
+    });
   }, [bodyGeometry, bodyRadius]);
   useEffect(
     () => () => badgeGeometries.forEach((g) => g.dispose()),


### PR DESCRIPTION
Follow-up to #73's badge work.

## 🛰️ Why BOTH satellite badges went upside down (and the real fix)
On a rolling body, spinning the same projector pose around the roll axis cancels each badge's phase offset — so **every badge shows the exact same orientation at the moment it faces the camera**. The two badges only *looked* different before because their projectors weren't built from a shared base pose. That shared facing-moment orientation read upside down, which is why flipping only the backside badge in #73 made them *both* inverted.

Fix: the base projector pose now carries a **180° texture roll**, and all badges are generated from it by spinning it around the roll axis — so however many badges there are, they all read right-side up as they sweep past the camera.

## 3️⃣ Two → three stickers, evenly spaced
- **Satellite**: three GitHub badges every 120° around the roll circumference (built generically from the base pose above).
- **Asteroids**: the ±z sticker pair becomes three, every 120° around the yaw circumference — same layout as the moon's play badges. Stickers sized down (1.82r → 1.5r across) so neighbors 120° apart don't overlap; the ~±49° wrap keeps clear seams.

Verified with `tsc`/`lint`/`build` and a live look: both rocks show multiple evenly-spaced marks wrapping the surface (with the new background-less badge textures from master). The upright-at-facing behavior is deterministic from the shared-pose construction — worth a quick spin-watch to confirm it matches your eye.