### PR TITLE
Scroll-scrubbed landing entry; blog asteroid rides lower

### DIFF
--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from "react";
-import { Link } from "react-router-dom";
+import React, { useEffect, useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { SunInternals } from "SunSvg";
 import { hoverState } from "./solarHover";
+import { scrollTransitionState } from "./scrollTransition";
 import { SUN_RADIUS_OFFSET, SUN_SIZE } from "./landingScene";
 
 // The solar system's 4s-delayed fadeIn is first-visit choreography (the
@@ -9,6 +10,13 @@ import { SUN_RADIUS_OFFSET, SUN_SIZE } from "./landingScene";
 // that delay when returning from /home would hide the whole system — and
 // the sun flying back into it — for 5 seconds.
 let hasPlayedIntro = false;
+
+/** Wheel travel (px) that scrubs the full landing→home camera swoop */
+const SCROLL_RANGE_PX = 1100;
+/** Touch swipes cover less distance than wheel flicks — amplify them */
+const TOUCH_SCROLL_MULTIPLIER = 2;
+/** Rough px-per-line for wheel events reported in lines (Firefox) */
+const WHEEL_LINE_PX = 16;
 
 const Landing = () => {
   const skipIntroDelay = hasPlayedIntro;
@@ -24,6 +32,59 @@ const Landing = () => {
     },
     [],
   );
+
+  // Scroll-scrubbed entry: the landing page has nothing to scroll, so
+  // wheel/touch deltas accumulate into a virtual progress that CameraRig
+  // renders as a pose between the landing and home views — stop
+  // scrolling and the camera parks mid-swoop; scroll back up and it
+  // retreats. Reaching the end commits the navigation to /home (from
+  // where the ordinary view transition is a no-op, since the camera is
+  // already there).
+  const navigate = useNavigate();
+  const navigated = useRef(false);
+  useEffect(() => {
+    scrollTransitionState.target = 0;
+    scrollTransitionState.progress = 0;
+
+    const advance = (deltaPx: number) => {
+      const s = scrollTransitionState;
+      s.target = Math.min(1, Math.max(0, s.target + deltaPx / SCROLL_RANGE_PX));
+      if (s.target >= 1 && !navigated.current) {
+        navigated.current = true;
+        void navigate("/home");
+      }
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      advance(e.deltaMode === 1 ? e.deltaY * WHEEL_LINE_PX : e.deltaY);
+    };
+    let lastTouchY: number | null = null;
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY;
+      if (y == null || lastTouchY == null) return;
+      // Nothing scrolls on this page — claim the gesture so iOS doesn't
+      // rubber-band the viewport while scrubbing
+      e.preventDefault();
+      advance((lastTouchY - y) * TOUCH_SCROLL_MULTIPLIER);
+      lastTouchY = y;
+    };
+
+    window.addEventListener("wheel", onWheel, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => {
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      // Leaving the page (scrub completion or the ENTER link): hand the
+      // camera back to the timed rig cleanly
+      scrollTransitionState.target = 0;
+      scrollTransitionState.progress = 0;
+    };
+  }, [navigate]);
 
   // The orbits and planets are the WebGL scene's (SolarScene); this SVG
   // only carries the clickable ENTER sun ring, which SunSvgAnchor glues

--- a/src/scrollTransition.ts
+++ b/src/scrollTransition.ts
@@ -1,0 +1,19 @@
+/**
+ * Scroll-scrubbed landing→home camera transition. The landing page has no
+ * scrollable content, so Landing accumulates wheel/touch deltas into a
+ * virtual `target` progress (0 = landing pose, 1 = home pose); CameraRig
+ * eases `progress` toward it each frame and poses the camera between the
+ * two view goals — so stopping mid-scroll parks the camera mid-swoop, and
+ * scrolling back retreats. Landing navigates to /home when the target
+ * reaches 1 and zeroes both fields on unmount.
+ *
+ * Lives in its own three-free module (like solarHover) so the main-chunk
+ * Landing page can import it without dragging three.js out of its lazy
+ * chunk.
+ */
+export const scrollTransitionState = {
+  /** Wheel/touch-accumulated goal, 0..1 (written by Landing) */
+  target: 0,
+  /** Frame-eased progress the camera actually renders (owned by CameraRig) */
+  progress: 0,
+};

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -4,6 +4,7 @@ import * as THREE from "three";
 
 import { EARTH, moonPosition, planetPosition, rigState } from "./constants";
 import { starPanState } from "../starPan";
+import { scrollTransitionState } from "../../scrollTransition";
 
 /**
  * Camera choreography, ported from hunt-codes-3. Landing hovers straight
@@ -81,6 +82,12 @@ const goalQuat = new THREE.Quaternion();
 const lookMatrix = new THREE.Matrix4();
 const oldForward = new THREE.Vector3();
 const invQuat = new THREE.Quaternion();
+const scrubFromPos = new THREE.Vector3();
+const scrubFromQuat = new THREE.Quaternion();
+const scrubToQuat = new THREE.Quaternion();
+
+/** How fast the rendered scrub progress chases the wheel target (per s) */
+const SCRUB_EASE_RATE = 6;
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
@@ -172,7 +179,7 @@ export default function CameraRig({ view }: { view: SolarView }) {
   const fromQuat = useRef(new THREE.Quaternion());
   const prevQuat = useRef<THREE.Quaternion | null>(null);
 
-  useFrame(({ camera, clock, size }) => {
+  useFrame(({ camera, clock, size }, delta) => {
     const t = clock.elapsedTime;
 
     if (view !== activeView.current) {
@@ -183,25 +190,55 @@ export default function CameraRig({ view }: { view: SolarView }) {
       fromQuat.current.copy(camera.quaternion);
     }
 
-    computeGoal(view, t, camera, size);
-
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
-    rigState.settled = p >= 1;
-    if (p < 1) {
-      // Movement and rotation ride the same eased progress: the position
-      // lerps to the perch while the orientation slerps to the arrival
-      // pose, so the whole spin is spread evenly across the transition
-      // (lerping a look POINT instead whipped the view around wherever
-      // the point's chord passed near the camera — spin first, then zoom)
-      const e = easeInOutCubic(p);
-      camera.position.lerpVectors(fromPos.current, goalPos, e);
+
+    // Scroll scrub (Landing writes scrollTransitionState): once settled on
+    // the landing view, wheel progress poses the camera part-way along the
+    // landing→home swoop — chase the target so it glides, and park wherever
+    // the user stops. The timed transition still owns arrival swoops (the
+    // scrub only engages after it settles), and when the scrub completes
+    // Landing navigates, making the ordinary home transition a no-op.
+    const scrub = scrollTransitionState;
+    if (view === "landing" && p >= 1) {
+      scrub.progress +=
+        (scrub.target - scrub.progress) * Math.min(1, delta * SCRUB_EASE_RATE);
+      if (scrub.target === 0 && scrub.progress < 0.001) scrub.progress = 0;
+    }
+    const scrubbing = view === "landing" && p >= 1 && scrub.progress > 0;
+
+    if (scrubbing) {
+      // Pose between the two view goals by the eased scrub progress —
+      // same lerp+slerp pairing as the timed transition below
+      const e = easeInOutCubic(scrub.progress);
+      computeGoal("landing", t, camera, size);
+      scrubFromPos.copy(goalPos);
       lookMatrix.lookAt(goalPos, goalLook, UP);
-      goalQuat.setFromRotationMatrix(lookMatrix);
-      camera.quaternion.slerpQuaternions(fromQuat.current, goalQuat, e);
+      scrubFromQuat.setFromRotationMatrix(lookMatrix);
+      computeGoal("home", t, camera, size);
+      lookMatrix.lookAt(goalPos, goalLook, UP);
+      scrubToQuat.setFromRotationMatrix(lookMatrix);
+      camera.position.lerpVectors(scrubFromPos, goalPos, e);
+      camera.quaternion.slerpQuaternions(scrubFromQuat, scrubToQuat, e);
+      rigState.settled = false;
     } else {
-      // fully arrived: track the (possibly moving) goal exactly
-      camera.position.copy(goalPos);
-      camera.lookAt(goalLook);
+      computeGoal(view, t, camera, size);
+      rigState.settled = p >= 1;
+      if (p < 1) {
+        // Movement and rotation ride the same eased progress: the position
+        // lerps to the perch while the orientation slerps to the arrival
+        // pose, so the whole spin is spread evenly across the transition
+        // (lerping a look POINT instead whipped the view around wherever
+        // the point's chord passed near the camera — spin first, then zoom)
+        const e = easeInOutCubic(p);
+        camera.position.lerpVectors(fromPos.current, goalPos, e);
+        lookMatrix.lookAt(goalPos, goalLook, UP);
+        goalQuat.setFromRotationMatrix(lookMatrix);
+        camera.quaternion.slerpQuaternions(fromQuat.current, goalQuat, e);
+      } else {
+        // fully arrived: track the (possibly moving) goal exactly
+        camera.position.copy(goalPos);
+        camera.lookAt(goalLook);
+      }
     }
 
     // Star parallax: fold this frame's camera rotation into a pixel-space

--- a/src/space3d/solar/Sun.tsx
+++ b/src/space3d/solar/Sun.tsx
@@ -5,6 +5,7 @@ import * as THREE from "three";
 import { SUN_RADIUS, sunState } from "./constants";
 import { SUN_SIZE, SUN_SURFACE_RADIUS } from "../../landingScene";
 import { hoverState } from "../../solarHover";
+import { scrollTransitionState } from "../../scrollTransition";
 import { createSunGlowTexture } from "../textures";
 import {
   createSunCoronaMaterial,
@@ -153,12 +154,16 @@ function EnterRing({
       0,
       1,
     );
+    // Scroll-scrubbing toward /home: fade the label out over the first
+    // ~40% of the scrub so it doesn't hang mid-swoop (and fade it back
+    // if the visitor scrolls up)
+    const scrubFade = 1 - Math.min(1, scrollTransitionState.progress * 2.5);
     const base = isNightMode ? ENTER_TEXT_COLOR : ENTER_DAY_COLOR;
     const target = hoverState.sun ? ENTER_HOVER_COLOR : base;
     const ease = Math.min(1, delta * 10);
     for (const { material } of letters) {
       material.color.lerp(target, ease);
-      material.opacity = opacity.current;
+      material.opacity = opacity.current * scrubFade;
     }
   });
 

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -116,7 +116,9 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     orbitSpeed: EARTH.orbitSpeed,
     orbitPhase: EARTH.orbitPhase + 0.35,
     spinSpeed: 0.2 * SPEED_SCALE,
-    yOffset: ASTEROID_Y,
+    // Floats lower than its siblings: on the home view it reads nestled
+    // down near the sun's limb instead of high among the other links
+    yOffset: ASTEROID_Y - 1.2,
     logo: "blog",
   },
   {


### PR DESCRIPTION
## 🖱️ Scroll-scrubbed landing → home
The landing page has no scrollable content, so instead of a scroll library (GSAP/Lenis would be overkill with no real scroll area), wheel/touch deltas accumulate into a **virtual progress** in a shared mutable module ([`scrollTransition.ts`](../blob/master/src/scrollTransition.ts) — same three-free pattern as `solarHover`/`starPan`):

- **Scroll down** → the camera poses part-way along the landing→home swoop (same eased lerp + slerp as the timed transition, blended between the two live view goals)
- **Stop** → the camera parks exactly where you left it (a gentle per-frame chase smooths jumpy wheel deltas)
- **Scroll back up** → the camera retreats toward the landing pose
- **Reach the end (~1100px of wheel travel)** → navigates to `/home`; the ordinary view transition is a no-op since the camera is already at the perch

Details:
- The **ENTER label fades out** over the first ~40% of the scrub (and back in if you retreat); clicking ENTER mid-scrub still works — the timed swoop picks up from the scrubbed pose
- The scrub only engages once the timed rig has settled on the landing view, so the return swoop from /home can't be yanked mid-flight
- **Touch scrubs too** (2× amplified; `preventDefault` stops iOS rubber-banding the fixed page); Firefox line-mode wheel deltas normalized
- Star parallax keeps accumulating during the scrub, so the starfield sweeps with the camera

## 🪨 Blog asteroid
Floats 1.2 world units lower than its siblings (`yOffset` in `constants.ts`) — on the home view it now reads nestled down by the sun's limb instead of high among the other links.

## Verified
`tsc` / `lint` / `build`, plus live: synthetic wheel events to 50% parked the camera mid-swoop with the URL still on `/`; continuing to 100% navigated to `/home` with no visible snap; the blog rock sits low by the limb.