### PR TITLE
Scroll journey across all views; scroll hint; clickable-body halos

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -413,10 +413,51 @@ p {
   .interest-pill,
   .App-background_day,
   .body-outline-pulse,
+  .landing-scroll-hint,
   .svg-generator-spinner,
   .svg-generator-loading-dots span,
   .svg-generator-svg-wrapper svg {
     animation: none !important;
+  }
+}
+
+// Bouncing "you can scroll" chevron on the landing page (Landing.tsx):
+// appears a beat after the intro choreography, disappears once the
+// visitor starts scrubbing
+.landing-scroll-hint {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  // The keyframes carry the same X-centering; this keeps it centered
+  // under prefers-reduced-motion (animation: none)
+  transform: translateX(-50%);
+  z-index: 5;
+  color: rgba(232, 230, 245, 0.75);
+  animation: hint-bounce 2.2s ease-in-out infinite;
+  transition: opacity 0.8s ease;
+  opacity: 1;
+
+  &:hover {
+    color: $purp-light;
+  }
+
+  &.hint-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.App.day .landing-scroll-hint {
+  color: $purp;
+}
+
+@keyframes hint-bounce {
+  0%,
+  100% {
+    transform: translate(-50%, 0);
+  }
+  50% {
+    transform: translate(-50%, 9px);
   }
 }
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 import { GitHub, Linkedin, Mail } from "react-feather";
 import { ArrowLeftCircleIcon } from "lucide-react";
 import useWindowSize from "./useWindowSize";
+import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
 import RocketCockpit from "./RocketCockpit";
 
@@ -35,6 +36,10 @@ const isChromium = navigator.userAgent.includes("Chrome");
 
 const Home = () => {
   const [logoOpacity, setLogoOpacity] = useState(0);
+
+  // Scroll-scrubbed travel: up retreats toward the landing view, down
+  // continues out to /about (scrollTransition.ts)
+  useScrollJourney(1);
 
   const size = useWindowSize();
   const isSmall = size === "sm";

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,8 +1,16 @@
-import React, { useEffect, useRef } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ChevronDown } from "react-feather";
+import cx from "classnames";
 import { SunInternals } from "SunSvg";
 import { hoverState } from "./solarHover";
-import { scrollTransitionState } from "./scrollTransition";
+import useScrollJourney from "./useScrollJourney";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 import { SUN_RADIUS_OFFSET, SUN_SIZE } from "./landingScene";
 
 // The solar system's 4s-delayed fadeIn is first-visit choreography (the
@@ -11,12 +19,12 @@ import { SUN_RADIUS_OFFSET, SUN_SIZE } from "./landingScene";
 // the sun flying back into it — for 5 seconds.
 let hasPlayedIntro = false;
 
-/** Wheel travel (px) that scrubs the full landing→home camera swoop */
-const SCROLL_RANGE_PX = 1100;
-/** Touch swipes cover less distance than wheel flicks — amplify them */
-const TOUCH_SCROLL_MULTIPLIER = 2;
-/** Rough px-per-line for wheel events reported in lines (Firefox) */
-const WHEEL_LINE_PX = 16;
+const SCROLL_HINT_TEXT = "Scroll or click around to explore the solar system";
+// The scroll hint appears a beat after the landing choreography finishes:
+// the first visit's intro runs ~5s (stars, then the 4s-delayed system
+// fade); return visits skip the delay
+const HINT_DELAY_FIRST_VISIT_MS = 7000;
+const HINT_DELAY_RETURN_MS = 2500;
 
 const Landing = () => {
   const skipIntroDelay = hasPlayedIntro;
@@ -33,89 +41,73 @@ const Landing = () => {
     [],
   );
 
-  // Scroll-scrubbed entry: the landing page has nothing to scroll, so
-  // wheel/touch deltas accumulate into a virtual progress that CameraRig
-  // renders as a pose between the landing and home views — stop
-  // scrolling and the camera parks mid-swoop; scroll back up and it
-  // retreats. Reaching the end commits the navigation to /home (from
-  // where the ordinary view transition is a no-op, since the camera is
-  // already there).
-  const navigate = useNavigate();
-  const navigated = useRef(false);
+  // Scroll-scrubbed entry (scrollTransition.ts): wheel/touch progress
+  // poses the camera along the landing→home→about journey; `engaged`
+  // flips once the visitor starts scrubbing (and hides the hint below)
+  const engaged = useScrollJourney(0);
+
+  const [hintReady, setHintReady] = useState(false);
   useEffect(() => {
-    scrollTransitionState.target = 0;
-    scrollTransitionState.progress = 0;
-
-    const advance = (deltaPx: number) => {
-      const s = scrollTransitionState;
-      s.target = Math.min(1, Math.max(0, s.target + deltaPx / SCROLL_RANGE_PX));
-      if (s.target >= 1 && !navigated.current) {
-        navigated.current = true;
-        void navigate("/home");
-      }
-    };
-
-    const onWheel = (e: WheelEvent) => {
-      advance(e.deltaMode === 1 ? e.deltaY * WHEEL_LINE_PX : e.deltaY);
-    };
-    let lastTouchY: number | null = null;
-    const onTouchStart = (e: TouchEvent) => {
-      lastTouchY = e.touches[0]?.clientY ?? null;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      const y = e.touches[0]?.clientY;
-      if (y == null || lastTouchY == null) return;
-      // Nothing scrolls on this page — claim the gesture so iOS doesn't
-      // rubber-band the viewport while scrubbing
-      e.preventDefault();
-      advance((lastTouchY - y) * TOUCH_SCROLL_MULTIPLIER);
-      lastTouchY = y;
-    };
-
-    window.addEventListener("wheel", onWheel, { passive: true });
-    window.addEventListener("touchstart", onTouchStart, { passive: true });
-    window.addEventListener("touchmove", onTouchMove, { passive: false });
-    return () => {
-      window.removeEventListener("wheel", onWheel);
-      window.removeEventListener("touchstart", onTouchStart);
-      window.removeEventListener("touchmove", onTouchMove);
-      // Leaving the page (scrub completion or the ENTER link): hand the
-      // camera back to the timed rig cleanly
-      scrollTransitionState.target = 0;
-      scrollTransitionState.progress = 0;
-    };
-  }, [navigate]);
+    const timer = setTimeout(
+      () => setHintReady(true),
+      skipIntroDelay ? HINT_DELAY_RETURN_MS : HINT_DELAY_FIRST_VISIT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [skipIntroDelay]);
 
   // The orbits and planets are the WebGL scene's (SolarScene); this SVG
   // only carries the clickable ENTER sun ring, which SunSvgAnchor glues
   // to the projected 3D sun each frame.
   return (
-    <div className="landing-page">
-      {/* The page's only visible text is drawn in WebGL — give crawlers
-          and screen readers something to land on */}
-      <h1 className="sr-only">Andrew Hunt — Frontend Engineer in New York</h1>
-      <svg
-        id="solar-system"
-        className={skipIntroDelay ? "no-intro-delay" : undefined}
-        viewBox="0 0 600 600"
-        style={{ display: "block" }}
-      >
-        <Link
-          to="/home"
-          aria-label="Enter Andrew Hunt's home page"
-          onPointerEnter={() => {
-            hoverState.sun = true;
-          }}
-          onPointerLeave={() => {
-            hoverState.sun = false;
-          }}
+    <>
+      <div className="landing-page">
+        {/* The page's only visible text is drawn in WebGL — give crawlers
+            and screen readers something to land on */}
+        <h1 className="sr-only">Andrew Hunt — Frontend Engineer in New York</h1>
+        <svg
+          id="solar-system"
+          className={skipIntroDelay ? "no-intro-delay" : undefined}
+          viewBox="0 0 600 600"
+          style={{ display: "block" }}
         >
-          {/* The "ENTER" label itself is drawn by the WebGL sun; this SVG
-              supplies the clickable disc the label rings */}
-          <SunInternals size={SUN_SIZE} radiusOffset={SUN_RADIUS_OFFSET} />
-        </Link>
-      </svg>
-    </div>
+          <Link
+            to="/home"
+            aria-label="Enter Andrew Hunt's home page"
+            onPointerEnter={() => {
+              hoverState.sun = true;
+            }}
+            onPointerLeave={() => {
+              hoverState.sun = false;
+            }}
+          >
+            {/* The "ENTER" label itself is drawn by the WebGL sun; this SVG
+                supplies the clickable disc the label rings */}
+            <SunInternals size={SUN_SIZE} radiusOffset={SUN_RADIUS_OFFSET} />
+          </Link>
+        </svg>
+      </div>
+      {/* Gentle nudge that the page scrolls; disappears once it has done
+          its job (the visitor scrubs) */}
+      <TooltipProvider delayDuration={100}>
+        <Tooltip disableHoverableContent>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cx(
+                "landing-scroll-hint",
+                (!hintReady || engaged) && "hint-hidden",
+              )}
+              aria-label={SCROLL_HINT_TEXT}
+            >
+              <ChevronDown size={30} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{SCROLL_HINT_TEXT}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </>
   );
 };
 

--- a/src/scrollTransition.ts
+++ b/src/scrollTransition.ts
@@ -1,19 +1,32 @@
 /**
- * Scroll-scrubbed landing→home camera transition. The landing page has no
- * scrollable content, so Landing accumulates wheel/touch deltas into a
- * virtual `target` progress (0 = landing pose, 1 = home pose); CameraRig
- * eases `progress` toward it each frame and poses the camera between the
- * two view goals — so stopping mid-scroll parks the camera mid-swoop, and
- * scrolling back retreats. Landing navigates to /home when the target
- * reaches 1 and zeroes both fields on unmount.
+ * Scroll-scrubbed camera journey across the site's three views:
+ * landing (0) → home (1) → about (2). The pages have no scrollable
+ * content (the /about résumé being the exception — it keeps native
+ * scroll and no journey handlers), so useScrollJourney accumulates
+ * wheel/touch deltas into the `target` stop value; CameraRig eases
+ * `progress` toward it each frame and poses the camera along the
+ * between-view swoops. Stopping mid-scroll parks the camera mid-swoop;
+ * scrolling back retreats. When the RENDERED progress reaches a
+ * different stop, the hook commits the matching route — and CameraRig
+ * recognizes the scroll-committed arrival and skips its timed swoop
+ * (restarting it was the "full re-animation" bug).
  *
- * Lives in its own three-free module (like solarHover) so the main-chunk
- * Landing page can import it without dragging three.js out of its lazy
- * chunk.
+ * Lives in its own three-free module (like solarHover) so main-chunk
+ * pages can import it without dragging three.js out of its lazy chunk.
  */
 export const scrollTransitionState = {
-  /** Wheel/touch-accumulated goal, 0..1 (written by Landing) */
+  /** Wheel/touch-accumulated goal, in stop units 0..2 (useScrollJourney) */
   target: 0,
   /** Frame-eased progress the camera actually renders (owned by CameraRig) */
   progress: 0,
+  /** True once CameraRig has adopted the mounted view as the journey
+   *  position — route commits must wait for it (a fresh page load starts
+   *  with stale zeros here while the three.js chunk loads) */
+  initialized: false,
+  /** Mirror of the rig's timed-transition settled state: scroll input is
+   *  ignored while a link-triggered swoop owns the camera */
+  rigSettled: false,
 };
+
+/** Journey stop for each solar view / route */
+export const JOURNEY_STOPS = { landing: 0, home: 1, about: 2 } as const;

--- a/src/space3d/solar/Asteroid.tsx
+++ b/src/space3d/solar/Asteroid.tsx
@@ -9,6 +9,7 @@ import { asteroidOutlineId } from "./BodyAnchors";
 import { writeSilhouette } from "./outline";
 import { createLogoBadgeTexture, createPlanetTexture } from "../textures";
 import { hoverState } from "../../solarHover";
+import InteractiveGlow from "./InteractiveGlow";
 
 /**
  * A small rocky link-asteroid: a smooth-shaded icosphere with gentle
@@ -180,6 +181,8 @@ export default function Asteroid({
 
   return (
     <group ref={group}>
+      {/* clickable-body affordance halo, riding the landing fade */}
+      <InteractiveGlow radius={config.radius} opacityRef={opacity} />
       <mesh ref={mesh} geometry={geometry}>
         {/* transparent so the landing->home fade-in can drive opacity;
             the white emissive is the hover brighten (intensity eased

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -4,7 +4,7 @@ import * as THREE from "three";
 
 import { EARTH, moonPosition, planetPosition, rigState } from "./constants";
 import { starPanState } from "../starPan";
-import { scrollTransitionState } from "../../scrollTransition";
+import { JOURNEY_STOPS, scrollTransitionState } from "../../scrollTransition";
 import { journeyState } from "../../rocketJourney";
 import { SYNTH_CAM_HEIGHT, SYNTH_ORIGIN } from "../../synthSpec";
 
@@ -207,9 +207,23 @@ export default function CameraRig({ view }: { view: SolarView }) {
   const fromQuat = useRef(new THREE.Quaternion());
   const prevQuat = useRef<THREE.Quaternion | null>(null);
   const journeyHandoff = useRef(false);
+  const journeyAdopted = useRef(false);
 
   useFrame(({ camera, clock, size }, delta) => {
     const t = clock.elapsedTime;
+    const scrub = scrollTransitionState;
+    // The synth system sits outside the scroll journey — no stop to
+    // adopt or scrub toward; its view changes always take the timed swoop
+    const stop = view === "synth" ? null : JOURNEY_STOPS[view];
+
+    // First frame: adopt the mounted view as the journey position (fresh
+    // page loads start with the module's stale zeros)
+    if (!journeyAdopted.current && stop !== null) {
+      journeyAdopted.current = true;
+      scrub.target = stop;
+      scrub.progress = stop;
+      scrub.initialized = true;
+    }
 
     // The rocket joyride (RocketJourney, mounted before this so it runs
     // earlier in the frame) owns the camera while active. Track the view
@@ -221,6 +235,9 @@ export default function CameraRig({ view }: { view: SolarView }) {
       activeView.current = view;
       journeyHandoff.current = true;
       rigState.settled = false;
+      // The ride owns the camera — useScrollJourney must ignore wheel
+      // input until the post-ride swoop settles
+      scrub.rigSettled = false;
       prevQuat.current = null;
       return;
     }
@@ -232,38 +249,61 @@ export default function CameraRig({ view }: { view: SolarView }) {
     }
 
     if (view !== activeView.current) {
-      // view changed: swoop from wherever the camera is right now
+      // A hop to or from the synth system never comes from the scrub —
+      // the journey's parked progress says nothing about the camera there
+      const fromSynth = activeView.current === "synth";
       activeView.current = view;
-      transitionStart.current = t;
-      fromPos.current.copy(camera.position);
-      fromQuat.current.copy(camera.quaternion);
+      if (
+        stop !== null &&
+        !fromSynth &&
+        Math.abs(scrub.progress - stop) < 0.35
+      ) {
+        // Scroll-committed arrival: the scrub carried the camera here.
+        // Starting the timed swoop too would replay the transition from
+        // wherever the eased progress happened to be — the "full
+        // re-animation on arrival" bug — so let the scrub glide in (or
+        // ride straight through, if the target is already past this stop).
+      } else {
+        // Link navigation (ENTER, Home, ABOUT ME, synth): timed swoop from
+        // the current pose; the journey teleports to the destination stop
+        transitionStart.current = t;
+        fromPos.current.copy(camera.position);
+        fromQuat.current.copy(camera.quaternion);
+        if (stop !== null) {
+          scrub.target = stop;
+          scrub.progress = stop;
+        }
+      }
     }
 
     const p = Math.min(1, (t - transitionStart.current) / TRANSITION_SECONDS);
+    scrub.rigSettled = p >= 1;
 
-    // Scroll scrub (Landing writes scrollTransitionState): once settled on
-    // the landing view, wheel progress poses the camera part-way along the
-    // landing→home swoop — chase the target so it glides, and park wherever
-    // the user stops. The timed transition still owns arrival swoops (the
-    // scrub only engages after it settles), and when the scrub completes
-    // Landing navigates, making the ordinary home transition a no-op.
-    const scrub = scrollTransitionState;
-    if (view === "landing" && p >= 1) {
+    // Scroll journey (useScrollJourney writes the target): once no timed
+    // swoop owns the camera, chase the wheel target so the scrub glides,
+    // parking wherever the visitor stops.
+    if (p >= 1) {
       scrub.progress +=
         (scrub.target - scrub.progress) * Math.min(1, delta * SCRUB_EASE_RATE);
-      if (scrub.target === 0 && scrub.progress < 0.001) scrub.progress = 0;
+      if (Math.abs(scrub.target - scrub.progress) < 0.001) {
+        scrub.progress = scrub.target;
+      }
     }
-    const scrubbing = view === "landing" && p >= 1 && scrub.progress > 0;
+    const scrubbing =
+      p >= 1 && stop !== null && Math.abs(scrub.progress - stop) > 1e-4;
 
     if (scrubbing) {
-      // Pose between the two view goals by the eased scrub progress —
-      // same lerp+slerp pairing as the timed transition below
-      const e = easeInOutCubic(scrub.progress);
-      computeGoal("landing", t, camera, size);
+      // Pose along the journey: progress 0..1 blends landing→home, 1..2
+      // blends home→about — same eased lerp+slerp pairing as the timed
+      // transition below, applied per segment
+      const j = THREE.MathUtils.clamp(scrub.progress, 0, 2);
+      const seg = Math.min(Math.floor(j), 1);
+      const e = easeInOutCubic(j - seg);
+      computeGoal(seg === 0 ? "landing" : "home", t, camera, size);
       scrubFromPos.copy(goalPos);
       lookMatrix.lookAt(goalPos, goalLook, UP);
       scrubFromQuat.setFromRotationMatrix(lookMatrix);
-      computeGoal("home", t, camera, size);
+      computeGoal(seg === 0 ? "home" : "about", t, camera, size);
       lookMatrix.lookAt(goalPos, goalLook, UP);
       scrubToQuat.setFromRotationMatrix(lookMatrix);
       camera.position.lerpVectors(scrubFromPos, goalPos, e);

--- a/src/space3d/solar/InteractiveGlow.tsx
+++ b/src/space3d/solar/InteractiveGlow.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+import { createInteractiveGlowTexture } from "../textures";
+
+/**
+ * Always-on "you can click this" halo for the interactive bodies (the
+ * link asteroids, the satellite, Earth's /about link, the moon's video
+ * link): an additive purple sprite in the site's accent color — distinct
+ * from the bodies' natural palette — that breathes gently so it reads as
+ * an affordance rather than atmosphere. Bodies pass their fade/reveal
+ * ref so the halo follows their opacity, and `enabled` gates the
+ * view-scoped links (Earth is only clickable on home, the moon on
+ * about).
+ */
+
+/** Sprite width as a multiple of the body's radius */
+const HALO_SCALE = 3.4;
+const PULSE_SPEED = 1.6;
+const ENABLE_FADE_PER_SECOND = 2;
+
+const prefersReducedMotion =
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export default function InteractiveGlow({
+  radius,
+  opacityRef,
+  enabled = true,
+  strength = 0.45,
+}: {
+  radius: number;
+  /** The body's own fade/reveal opacity (0..1), followed per frame */
+  opacityRef?: React.MutableRefObject<number>;
+  /** View-scoped links (Earth, the moon) turn the halo off elsewhere */
+  enabled?: boolean;
+  strength?: number;
+}) {
+  const texture = useMemo(() => createInteractiveGlowTexture(), []);
+  const material = useMemo(
+    () =>
+      new THREE.SpriteMaterial({
+        map: texture,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        opacity: 0,
+      }),
+    [texture],
+  );
+  const enableEase = useRef(enabled ? 1 : 0);
+
+  useEffect(
+    () => () => {
+      material.dispose();
+      texture.dispose();
+    },
+    [material, texture],
+  );
+
+  useFrame(({ clock }, delta) => {
+    enableEase.current = THREE.MathUtils.clamp(
+      enableEase.current + (enabled ? delta : -delta) * ENABLE_FADE_PER_SECOND,
+      0,
+      1,
+    );
+    const pulse = prefersReducedMotion
+      ? 1
+      : 0.8 + 0.2 * Math.sin(clock.elapsedTime * PULSE_SPEED);
+    material.opacity =
+      strength * pulse * enableEase.current * (opacityRef?.current ?? 1);
+  });
+
+  return (
+    <sprite
+      material={material}
+      scale={[radius * HALO_SCALE, radius * HALO_SCALE, 1]}
+    />
+  );
+}

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -9,6 +9,7 @@ import { MOON_VIDEO_OUTLINE_ID } from "./BodyAnchors";
 import { writeSilhouette } from "./outline";
 import { createLogoBadgeTexture } from "../textures";
 import { hoverState } from "../../solarHover";
+import InteractiveGlow from "./InteractiveGlow";
 import moonMapUrl from "../../assets/moon.jpg";
 
 /**
@@ -40,11 +41,14 @@ export default function Moon({
   orbitColor,
   orbitOpacity,
   revealed = true,
+  linkActive = false,
 }: {
   orbitColor: string;
   orbitOpacity: number;
   /** Fades the moon + its orbit ring in (landing intro) */
   revealed?: boolean;
+  /** The video link only exists on /about — gate the clickable halo */
+  linkActive?: boolean;
 }) {
   const earthGroup = useRef<THREE.Group>(null);
   const moonGroup = useRef<THREE.Group>(null);
@@ -199,6 +203,12 @@ export default function Moon({
         />
       </lineLoop>
       <group ref={moonGroup}>
+        {/* clickable-body affordance halo (video link, /about only) */}
+        <InteractiveGlow
+          radius={MOON.radius}
+          opacityRef={revealOpacity}
+          enabled={linkActive}
+        />
         <group ref={squashWrapper}>
           <group ref={squashCounterRotate}>
             <mesh ref={mesh} geometry={geometry}>

--- a/src/space3d/solar/Planet.tsx
+++ b/src/space3d/solar/Planet.tsx
@@ -9,6 +9,7 @@ import { hoverState } from "../../solarHover";
 import { EARTH_ABOUT_OUTLINE_ID } from "./BodyAnchors";
 import { writeSilhouette } from "./outline";
 import AboutRing from "./AboutRing";
+import InteractiveGlow from "./InteractiveGlow";
 import earthMapUrl from "../../assets/earth.jpg";
 
 /**
@@ -207,7 +208,17 @@ export default function Planet({
         {/* Curved "ABOUT ME" link label, billboarded around Earth. Lives in
             the group (not the squash wrapper) so it stays put over Earth. */}
         {config.kind === "earth" && (
-          <AboutRing active={aboutActive} isNightMode={isNightMode} />
+          <>
+            <AboutRing active={aboutActive} isNightMode={isNightMode} />
+            {/* clickable-body affordance halo (the /about link, home only;
+                a lighter touch than the small rocks — Earth is big) */}
+            <InteractiveGlow
+              radius={config.radius}
+              opacityRef={revealOpacity}
+              enabled={aboutActive}
+              strength={0.3}
+            />
+          </>
         )}
       </group>
     </>

--- a/src/space3d/solar/Satellite.tsx
+++ b/src/space3d/solar/Satellite.tsx
@@ -8,6 +8,7 @@ import { asteroidOutlineId } from "./BodyAnchors";
 import { writeSilhouette } from "./outline";
 import { createLogoBadgeTexture } from "../textures";
 import { hoverState } from "../../solarHover";
+import InteractiveGlow from "./InteractiveGlow";
 
 /**
  * The GitHub link body: a Sputnik-style satellite — a polished metal
@@ -237,10 +238,12 @@ export default function Satellite({
 
   return (
     <group ref={group}>
+      {/* clickable-body affordance halo, riding the landing fade */}
+      <InteractiveGlow radius={config.radius} opacityRef={opacity} />
       <group ref={rig}>
         <group ref={body}>
           <mesh material={materials.body} geometry={bodyGeometry} />
-          {/* GitHub badge stickers, one per side, rolling with the body */}
+          {/* GitHub badge stickers, rolling with the body */}
           {badgeGeometries.map((badgeGeometry, i) => (
             <mesh key={i} geometry={badgeGeometry} material={materials.badge} />
           ))}

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -113,6 +113,7 @@ const SolarScene = ({
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.28 : 0.2}
         revealed={planetsRevealed}
+        linkActive={view === "about"}
       />
       {/* Link bodies — home view only: on landing they'd read as clutter
           around the sun, and on /about their DOM overlays don't exist, so

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -165,6 +165,24 @@ export function createSunGlowTexture(): THREE.CanvasTexture {
   return asTexture(canvas);
 }
 
+/** Soft purple halo marking a body as clickable (InteractiveGlow) — the
+ *  site's accent color, distinct from the bodies' natural palette. */
+export function createInteractiveGlowTexture(): THREE.CanvasTexture {
+  const size = 128;
+  const canvas = createCanvas(size, size);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return asTexture(canvas);
+
+  const c = size / 2;
+  const gradient = ctx.createRadialGradient(c, c, 0, c, c, c);
+  gradient.addColorStop(0, "rgba(158, 128, 249, 0.6)");
+  gradient.addColorStop(0.45, "rgba(158, 128, 249, 0.22)");
+  gradient.addColorStop(1, "rgba(158, 128, 249, 0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  return asTexture(canvas);
+}
+
 /** The GitHub mark (Octocat silhouette), from simple-icons (CC0), in a
  *  24x24 viewBox. */
 const GITHUB_MARK_PATH =

--- a/src/useScrollJourney.ts
+++ b/src/useScrollJourney.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { scrollTransitionState } from "./scrollTransition";
+
+/** Wheel travel (px) that scrubs one full between-view swoop */
+const SCROLL_RANGE_PX = 1100;
+/** Touch swipes cover less distance than wheel flicks — amplify them */
+const TOUCH_SCROLL_MULTIPLIER = 2;
+/** Rough px-per-line for wheel events reported in lines (Firefox) */
+const WHEEL_LINE_PX = 16;
+/** The journey spans landing (0) → home (1) → about (2) */
+const MAX_STOP = 2;
+/** Commit the route once the rendered camera is this close to a stop */
+const COMMIT_EPSILON = 0.02;
+
+const ROUTES = ["/", "/home", "/about"];
+
+/**
+ * Scroll-scrubbed travel between the site's views (see
+ * scrollTransition.ts). Mounted by the landing page (stop 0) and home
+ * page (stop 1) — not /about, whose résumé needs native scrolling.
+ * Accumulates wheel/touch deltas into the journey target and commits the
+ * matching route when the RENDERED progress reaches a different stop —
+ * keyed to the camera, not the wheel, so a fast fling can't navigate
+ * while the swoop is still mid-flight (that restarted the transition).
+ *
+ * Returns whether the visitor has scrubbed away from this page's stop
+ * (the landing page hides its scroll hint once they have).
+ */
+export default function useScrollJourney(stop: 0 | 1) {
+  const navigate = useNavigate();
+  const [engaged, setEngaged] = useState(false);
+
+  useEffect(() => {
+    const s = scrollTransitionState;
+    // NOTE: no state reset on mount or unmount — the journey persists
+    // across route hops so a continuous scroll rides straight through
+    // (CameraRig adopts the view's stop on fresh page loads instead).
+    const committed = { current: null as number | null };
+
+    let raf = 0;
+    const watchProgress = () => {
+      raf = requestAnimationFrame(watchProgress);
+      if (!s.initialized) return;
+      const near = Math.round(s.progress);
+      if (
+        near !== stop &&
+        near !== committed.current &&
+        Math.abs(s.progress - near) < COMMIT_EPSILON
+      ) {
+        committed.current = near;
+        void navigate(ROUTES[near]);
+      }
+    };
+    raf = requestAnimationFrame(watchProgress);
+
+    const advance = (deltaPx: number) => {
+      // A link-triggered swoop owns the camera; don't fight it
+      if (!s.initialized || !s.rigSettled) return;
+      s.target = Math.min(
+        MAX_STOP,
+        Math.max(0, s.target + deltaPx / SCROLL_RANGE_PX),
+      );
+      if (Math.abs(s.target - stop) > 0.03) setEngaged(true);
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      advance(e.deltaMode === 1 ? e.deltaY * WHEEL_LINE_PX : e.deltaY);
+    };
+    let lastTouchY: number | null = null;
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY;
+      if (y == null || lastTouchY == null) return;
+      // Nothing scrolls on these pages — claim the gesture so iOS
+      // doesn't rubber-band the viewport while scrubbing
+      e.preventDefault();
+      advance((lastTouchY - y) * TOUCH_SCROLL_MULTIPLIER);
+      lastTouchY = y;
+    };
+
+    window.addEventListener("wheel", onWheel, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [navigate, stop]);
+
+  return engaged;
+}


### PR DESCRIPTION
Follow-up to #76, fixing its two bugs and adding the three requested features.

## 🐛 1. Arrival re-animation — root cause + fix
Navigation fired when the wheel **target** hit the end while the eased camera **progress** lagged behind — so on a fast fling the route change restarted the timed swoop from wherever the camera actually was (near the landing pose = "full re-animation"). Two-part fix:
- Routes now commit only when the **rendered progress** reaches a stop (a rAF watcher in the hook), so the camera is already at the destination pose
- `CameraRig` distinguishes **scroll-committed arrivals** (progress near the new view's stop → skip the timed swoop, let the scrub glide in) from **link navigations** (ENTER / Home / ABOUT ME → timed swoop as before, journey teleports to the destination)

## 🧭 2 & 4. The scrub is now a three-stop journey
`landing (0) → home (1) → about (2)`, via a shared `useScrollJourney` hook mounted on the landing and home pages:
- **On /home, scroll up** retreats toward the landing view (committing `/` on arrival); **scroll down** continues out to `/about`
- A single continuous fling from landing rides straight through home to about — the journey state survives route hops (the URL updates as you pass each stop)
- **/about keeps native scrolling** for the résumé — no journey handlers there; the Home link swoops back (which resyncs the journey)
- Fresh page loads adopt the mounted view's stop on the rig's first frame, and route commits wait for that — no early-navigation races while the three.js chunk loads

## ⌄ 3. Landing scroll hint
A subtly bouncing chevron fades in after the intro choreography (~7s first visit, ~2.5s on returns), hides once you start scrubbing, and tooltips **"Scroll or click around to explore the solar system"**. Covered by the shared `prefers-reduced-motion` block (with static centering preserved).

## ✨ 5. Clickable-body halos
Every interactive body — the blog/LinkedIn asteroids, the GitHub satellite, **Earth** (home view) and the **moon** (about view) — gets a gentle breathing purple halo (`InteractiveGlow`, additive sprite in the site accent color) so links read apart from the scenery. Halos follow each body's fade/reveal opacity; the view-scoped ones (Earth/moon) ease in and out with their views; the pulse freezes under reduced motion. The sun's corona remains its own affordance.

## Verified
`tsc` / `lint` / `build`, plus live: a full-speed fling from landing committed `/home` only after the camera arrived (no re-animation); scrolling up from home returned to the landing view (chevron visible); a continuous fling rode landing → home → `/about` with the moon's halo showing on arrival.