### PR TITLE
Site review polish + About intro update (sabbatical, fall 2026 availability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,18 @@
-This is my personal website, bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# hunt.codes
 
-## Development instructions
+My personal website — a whimsical space-themed SPA with a three.js /
+@react-three/fiber solar system humming in the background.
 
-In the project directory, you can run:
+Built with React 19, react-router v7, TypeScript, [rsbuild](https://rsbuild.rs),
+Tailwind v4, and SCSS.
 
-### `yarn start`
+## Development
 
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Requires node ≥ 22 (see `.nvmrc`) and yarn via corepack.
 
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
-
-### `yarn test`
-
-Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn run build`
-
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+- `yarn start` — dev server at [http://localhost:3000](http://localhost:3000) (HMR)
+- `yarn build` — production build to `build/`
+- `yarn lint` / `yarn tsc --noEmit` — lint + typecheck
+- `yarn test` — run tests (CI runs them via `bun test`)
+- `yarn serve` — serve the production build locally
+- `yarn deploy` — sync `build/` to S3 (hashed assets cached immutable, HTML/manifest no-cache)

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
       "^.+\\.module\\.(css|sass|scss)$"
     ],
     "modulePaths": [
-      "/Users/andrew/code/hunt-codes/src"
+      "<rootDir>/src"
     ],
     "moduleNameMapper": {
       "^react-native$": "react-native-web",

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <title>Andrew Hunt - Frontend Engineer | New York</title>
     <meta
       name="description"
-      content="Andrew Hunt is a frontend engineer based in New York, currently consulting and exploring fulltime opportunities. Specializing in web development, performance, and AI-powered tooling."
+      content="Andrew Hunt is a frontend engineer in New York specializing in web development, performance, and AI-powered tooling. Consulting and open to full-time roles."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta name="googlebot" content="index, follow" />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://www.hunt.codes" />
+    <link rel="canonical" href="https://www.hunt.codes/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:description"
-      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tools. Currently consulting, but open to fulltime opportunities."
+      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tools. Currently consulting, but open to full-time opportunities."
     />
     <meta property="og:image" content="https://www.hunt.codes/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -38,18 +38,18 @@
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://www.hunt.codes" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://www.hunt.codes" />
     <meta
-      property="twitter:title"
+      name="twitter:title"
       content="Andrew Hunt - Frontend Engineer | New York"
     />
     <meta
-      property="twitter:description"
+      name="twitter:description"
       content="Andrew Hunt is a frontend engineer based in New York, specializing in web development and AI-powered tooling."
     />
-    <meta property="twitter:image" content="https://www.hunt.codes/og-image.png" />
-    <meta property="twitter:creator" content="@_andrew_hunt" />
+    <meta name="twitter:image" content="https://www.hunt.codes/og-image.png" />
+    <meta name="twitter:creator" content="@_andrew_hunt" />
 
     <!-- Favicon and Icons (favicon.ico is auto-injected by rsbuild from public/) -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -96,8 +96,8 @@
         "@context": "https://schema.org",
         "@type": "Person",
         "name": "Andrew Hunt",
-        "jobTitle": "Senior Frontend Engineer & Consultant",
-        "description": "Frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, but open to fulltime opportunities.",
+        "jobTitle": "Frontend Engineer & Consultant",
+        "description": "Frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, but open to full-time opportunities.",
         "url": "https://www.hunt.codes",
         "image": "https://www.hunt.codes/og-image.png",
         "sameAs": [

--- a/src/App.scss
+++ b/src/App.scss
@@ -54,6 +54,37 @@ $breakpoint-lg: 1280px;
     background: rgba(0, 0, 0, 0.05);
     border-color: rgba(0, 0, 0, 0.15);
   }
+
+  .svg-generator-input::placeholder {
+    color: rgba(20, 20, 40, 0.4);
+  }
+
+  // These are styled for the night sky only — keep them legible by day
+  .svg-generator-api-key-toggle {
+    color: rgba(20, 20, 40, 0.6) !important;
+
+    &:hover {
+      color: $purp !important;
+    }
+  }
+
+  .svg-generator-api-key-input {
+    color: #222;
+    background: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.15);
+  }
+
+  // White pill text washes out on the frosted-white day panel
+  .tool-pill {
+    color: $purp;
+  }
+
+  // Rainbow keyframes composite to pale pastels over the white panel —
+  // dark text stays legible through the whole cycle
+  .interest-pill {
+    color: #24203a;
+    background-color: #cdbcff;
+  }
 }
 
 .landing-page {
@@ -132,8 +163,10 @@ audio {
     position: relative;
 
     // Provides a slight glow to the text in the cards
+    // (No backdrop-filter here — blurring over the animated canvases
+    // forces a backdrop re-capture every frame; the box-shadow alone
+    // carries the glow)
     ::before {
-      backdrop-filter: blur(2px);
       border-radius: 8px;
       opacity: 0.5;
       padding: 16px;
@@ -357,8 +390,9 @@ p {
   .gg-fog-drift,
   .interest-pill,
   .App-background_day,
-  .star_disco,
+  .body-outline-pulse,
   .svg-generator-spinner,
+  .svg-generator-loading-dots span,
   .svg-generator-svg-wrapper svg {
     animation: none !important;
   }
@@ -788,50 +822,6 @@ a:hover {
     -moz-transform: rotateY(-360deg);
     -ms-transform: rotateY(-360deg);
     transform: rotateY(-360deg);
-  }
-}
-
-@keyframes backgroundAnim {
-  0% {
-    filter: hue-rotate(45deg);
-  }
-  100% {
-    filter: hue-rotate(210deg);
-  }
-}
-
-.star {
-  position: absolute;
-  background-color: white;
-  box-shadow: 0 0 1px 1px $purp-light-transparent-25;
-  border-radius: 50%;
-
-  &.star_background {
-    background-color: rgba(
-      255,
-      255,
-      255,
-      0.5
-    ); // Very dim for background-color stars
-    box-shadow: 0 0 4px 1.5px rgba(210, 99, 99, 0.8); // Glow effect for text stars
-    // box-shadow: none;
-    // filter: hue-rotate(45deg);
-  }
-
-  &.star_disco {
-    box-shadow: 0 0 1px 5px $purp-light-transparent-25 !important;
-    animation: 4s ease-in-out infinite alternate star-disco;
-  }
-}
-
-@keyframes star-disco {
-  0% {
-    transform: scale(1);
-    filter: hue-rotate(0deg);
-  }
-  100% {
-    transform: scale(2.2);
-    filter: hue-rotate(360deg);
   }
 }
 
@@ -1349,9 +1339,14 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
     // navigating back to space doesn't leave it lingering
     opacity: 0;
     pointer-events: none;
+    // Leave the tab order once the fade completes — an invisible toggle
+    // shouldn't take keyboard focus (unhide flips back instantly, so the
+    // base rule's delayed fade-in is unaffected)
+    visibility: hidden;
     transition:
       background 500ms ease,
-      opacity 200ms ease;
+      opacity 200ms ease,
+      visibility 0s linear 200ms;
   }
 
   &[data-state="checked"] {
@@ -1795,10 +1790,11 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(0, 0, 0, 0.3);
+  // Higher-opacity background instead of backdrop-filter — blurring over
+  // the animated star canvas forces a backdrop re-capture every frame
+  background: rgba(0, 0, 0, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 16px;
-  backdrop-filter: blur(8px);
   animation: svgGenResultIn 0.5s ease both;
 
   svg {

--- a/src/App.scss
+++ b/src/App.scss
@@ -163,9 +163,6 @@ audio {
     position: relative;
 
     // Provides a slight glow to the text in the cards
-    // (No backdrop-filter here — blurring over the animated canvases
-    // forces a backdrop re-capture every frame; the box-shadow alone
-    // carries the glow)
     ::before {
       border-radius: 8px;
       opacity: 0.5;
@@ -707,8 +704,6 @@ li > ul > li {
 
   .back-to-home-link {
     // A slight background behind the link so that it's always legible.
-    // (No backdrop-filter — blurring over the animating WebGL canvas
-    // costs a backdrop re-capture every frame; see .resume-panel.)
     border-radius: 16px;
     padding: 8px;
     // The link sits outside the padded .resume-panel now, so it needs its

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  useLocation,
+} from "react-router-dom";
 import cx from "classnames";
 import "./App.scss";
 
@@ -40,6 +45,30 @@ const usePauseAudioOnHideEventListener = () => {
   }, []);
 };
 
+const DEFAULT_TITLE = "Andrew Hunt - Frontend Engineer | New York";
+const ROUTE_TITLES: Record<string, string> = {
+  "/": DEFAULT_TITLE,
+  "/home": DEFAULT_TITLE,
+  "/about": "About Me | Andrew Hunt",
+  "/draw": "SVG Studio | Andrew Hunt",
+};
+
+// The static index.html head serves every route of the SPA; keep the tab
+// title and canonical URL in sync as the visitor navigates
+const RouteMeta = () => {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    document.title = ROUTE_TITLES[pathname] ?? DEFAULT_TITLE;
+    document
+      .querySelector('link[rel="canonical"]')
+      ?.setAttribute(
+        "href",
+        `https://www.hunt.codes${pathname === "/" ? "/" : pathname}`,
+      );
+  }, [pathname]);
+  return null;
+};
+
 const App = () => {
   const [showBridge, setShowBridge] = useState(false);
   // The whole app is night until the visitor flips the moon/sun switch
@@ -49,7 +78,7 @@ const App = () => {
 
   // fade home content in once mounted
   useEffect(() => {
-    // eslint-disable-next-line -- TODO: rm this comment and fix the lint error
+    // eslint-disable-next-line no-console -- intentional easter egg
     console.log("bro what r u doing in the console...");
     const timer = setTimeout(() => setShowBridge(true), 1500);
     return () => clearTimeout(timer);
@@ -58,6 +87,7 @@ const App = () => {
   return (
     <div className={cx("App", isNightMode ? "night" : "day")}>
       <Router>
+        <RouteMeta />
         <AppBackground showBridge={showBridge} isNightMode={isNightMode} />
         <DayNightSwitch
           isNightMode={isNightMode}

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -102,7 +102,7 @@ const AppBackground = ({
             )}
             controls
           >
-            <source src="analog.wav" />
+            <source src="/analog.wav" />
           </audio>
         ) : (
           <button

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -57,6 +57,10 @@ const Home = () => {
   const [copyTooltipOpen, setCopyTooltipOpen] = useState(false);
   const copyTriggerRef = useRef<HTMLButtonElement>(null);
   const pinCopyTooltipOpen = useRef(false);
+  const copyResetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(() => () => clearTimeout(copyResetTimer.current), []);
 
   const pinCopyTooltip = useCallback(() => {
     pinCopyTooltipOpen.current = true;
@@ -73,7 +77,9 @@ const Home = () => {
     try {
       await navigator.clipboard.writeText("andrew+in@hunt.codes");
       setCopied(true);
-      setTimeout(() => {
+      // Rapid re-clicks must not let an older timer un-pin the fresh state
+      clearTimeout(copyResetTimer.current);
+      copyResetTimer.current = setTimeout(() => {
         setCopied(false);
         pinCopyTooltipOpen.current = false;
         const isHovering = copyTriggerRef.current?.matches(":hover") ?? false;
@@ -160,7 +166,7 @@ const Home = () => {
                   <button
                     type="button"
                     ref={copyTriggerRef}
-                    aria-label="Copy email address andrew@hunt.codes"
+                    aria-label="Copy email address andrew+in@hunt.codes"
                     onPointerDown={() => pinCopyTooltip()}
                     onClick={() => void handleCopy()}
                     className="flex size-11 items-center justify-center rounded-full p-1 transition-colors hover:bg-[#5efffc57]"

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -91,6 +91,9 @@ const Landing = () => {
   // to the projected 3D sun each frame.
   return (
     <div className="landing-page">
+      {/* The page's only visible text is drawn in WebGL — give crawlers
+          and screen readers something to land on */}
+      <h1 className="sr-only">Andrew Hunt — Frontend Engineer in New York</h1>
       <svg
         id="solar-system"
         className={skipIntroDelay ? "no-intro-delay" : undefined}
@@ -99,6 +102,7 @@ const Landing = () => {
       >
         <Link
           to="/home"
+          aria-label="Enter Andrew Hunt's home page"
           onPointerEnter={() => {
             hoverState.sun = true;
           }}

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -126,10 +126,11 @@ const Resume = () => {
             >
               Zip
             </a>{" "}
-            — most recently as a staff engineer — before striking out on my own
-            in 2025. Since then I’ve been contracting and consulting, helping
-            teams ship polished, AI-powered web products. For inquiries, reach
-            out to{" "}
+            — most recently as a staff engineer — before stepping away in 2025
+            for a proper sabbatical. A few months of recharging later, I eased
+            back in through consulting, helping teams ship polished, AI-powered
+            web products. Come fall 2026 I’m looking to go full-time again — for
+            consulting or full-time inquiries, reach out to{" "}
             <a
               className="inverse"
               href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { ArrowLeftCircle, Calendar } from "react-feather";
 import { useInView } from "react-intersection-observer";
 import { Link } from "react-router-dom";
-import useWindowSize from "useWindowSize";
+import useWindowSize from "./useWindowSize";
 import ZipVideoMoon from "./ZipVideoMoon";
 
 const experienceItems = [
@@ -25,7 +25,7 @@ const experienceItems = [
       "Developed, shipped, and iterated on new product features",
       "Led initiatives to standardize and improve shared components",
       {
-        item: "Dev infra – CI/Quality/Dev experience:",
+        item: "Dev infra — CI/Quality/Dev experience:",
         subbullets: [
           "TypeScript correctness + coverage CI checks",
           "Testing: Jest unit testing, Datadog Synthetic tests, and visual regression testing via Storybook/Chromatic",
@@ -34,7 +34,7 @@ const experienceItems = [
       },
       "Architected and managed build & deploy systems across Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow",
       "Built & maintained frontend infrastructure: dev server, Storybook, testing, logging, sourcemaps, TS/React usage, third-party package usage/maintenance",
-      "TypeScript: enabled TypeScript and led migration of frontend code to 99% type safety",
+      "TypeScript: Enabled TypeScript and led migration of frontend code to 99% type safety",
       "Performance: Improved page load times by >50%, primarily via code splitting and routing optimizations",
     ],
   },

--- a/src/SvgGenerator.tsx
+++ b/src/SvgGenerator.tsx
@@ -115,31 +115,46 @@ const animateSvg = (container: HTMLDivElement) => {
   });
 };
 
+// localStorage can throw (blocked cookies, some embedded webviews) —
+// treat persistence as best-effort
+const readStoredApiKey = () => {
+  try {
+    return localStorage.getItem("openai-api-key") || "";
+  } catch {
+    return "";
+  }
+};
+
 const SvgGenerator = () => {
   const [prompt, setPrompt] = useState("");
-  const [apiKey, setApiKey] = useState(
-    () => localStorage.getItem("openai-api-key") || "",
-  );
+  const [apiKey, setApiKey] = useState(readStoredApiKey);
   const [svgContent, setSvgContent] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [showApiKeyField, setShowApiKeyField] = useState(
-    () => !localStorage.getItem("openai-api-key"),
+    () => !readStoredApiKey(),
   );
 
   const svgContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Persist API key
+  // Persist API key; clearing the field forgets the stored key
   useEffect(() => {
-    if (apiKey) {
-      localStorage.setItem("openai-api-key", apiKey);
+    try {
+      if (apiKey) {
+        localStorage.setItem("openai-api-key", apiKey);
+      } else {
+        localStorage.removeItem("openai-api-key");
+      }
+    } catch {
+      // storage unavailable — the key just won't persist
     }
   }, [apiKey]);
 
   // Focus input on mount
   useEffect(() => {
-    setTimeout(() => inputRef.current?.focus(), 500);
+    const timer = setTimeout(() => inputRef.current?.focus(), 500);
+    return () => clearTimeout(timer);
   }, []);
 
   const generateSvg = useCallback(async () => {
@@ -229,6 +244,7 @@ const SvgGenerator = () => {
     <div className="svg-generator-page">
       <div className="svg-generator-back-link">
         <Link
+          aria-label="Back to landing page"
           className="mt-4 flex items-center gap-1 transition-transform"
           to="/"
         >
@@ -262,6 +278,7 @@ const SvgGenerator = () => {
           {showApiKeyField && (
             <input
               type="password"
+              aria-label="OpenAI API key"
               className="svg-generator-api-key-input"
               placeholder="sk-..."
               value={apiKey}
@@ -276,6 +293,7 @@ const SvgGenerator = () => {
         <div className="svg-generator-input-row">
           <input
             ref={inputRef}
+            aria-label="Describe an image to draw"
             className="svg-generator-input"
             type="text"
             placeholder='Describe an image to draw, e.g. "saturn with rings"'

--- a/src/computer.scss
+++ b/src/computer.scss
@@ -1,3 +1,8 @@
+// Only compiled when RetroMac.tsx (intentionally kept, currently unused)
+// is re-enabled; keep in sync with the App.scss breakpoints
+$breakpoint-sm: 768px;
+$breakpoint-lg: 1280px;
+
 body {
   background-color: #eee9e6;
 }

--- a/src/space3d/StarField.tsx
+++ b/src/space3d/StarField.tsx
@@ -220,11 +220,11 @@ const useConfigureMaterial = (
   const gl = useThree((s) => s.gl);
   useEffect(() => {
     const ctx = gl.getContext();
-    // eslint-disable-next-line -- TODO: rm this comment and fix the lint error
-    const range = ctx.getParameter(ctx.ALIASED_POINT_SIZE_RANGE);
-    // eslint-disable-next-line -- TODO: rm this comment and fix the lint error
-    if (range && range[1]) {
-      // eslint-disable-next-line -- TODO: rm this comment and fix the lint error
+    // getParameter is untyped (any); ALIASED_POINT_SIZE_RANGE yields [min, max]
+    const range = ctx.getParameter(
+      ctx.ALIASED_POINT_SIZE_RANGE,
+    ) as Float32Array | null;
+    if (range?.[1]) {
       material.uniforms.uMaxPointSize.value = range[1];
     }
   }, [gl, material]);

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -212,14 +212,14 @@ const LOGO_MARKS: Record<
   { path: string; color: string; scale: number }
 > = {
   github: { path: GITHUB_MARK_PATH, color: "#5000f0", scale: 0.72 },
-  // The square marks are scaled down so their corners stay inside the disc
+  // The square marks are scaled down so they don't overwhelm the asteroid
   linkedin: { path: LINKEDIN_MARK_PATH, color: "#0a66c2", scale: 0.6 },
   blog: { path: RSS_MARK_PATH, color: "#f26522", scale: 0.6 },
   play: { path: PLAY_MARK_PATH, color: "#412596", scale: 0.85 },
 };
 
-/** White badge disc with a brand mark, transparent outside the disc —
- *  a "sticker" decal for the link asteroids. */
+/** Brand mark on a transparent canvas — a "sticker" decal for the link
+ *  asteroids (no background disc: the mark sits directly on the rock). */
 export function createLogoBadgeTexture(
   logo: AsteroidLogo,
 ): THREE.CanvasTexture {


### PR DESCRIPTION
Full-site review pass (every finding independently verified), plus an About-page intro update.

- **Perf:** removed the two `backdrop-filter`s sitting over the animated canvases (/about cards, /draw result panel) — the pattern that previously froze /about; compensated with higher-opacity backgrounds
- **A11y:** accessible names for the landing sun link and the /draw back link + inputs; sr-only h1 on the landing route; the hidden day/night toggle leaves the tab order; copy-email aria-label matches what's copied; looping animations honor `prefers-reduced-motion`
- **Day mode:** legibility fixes for the /draw controls and the résumé tool/interest pills (all were night-only styles)
- **SEO:** per-route document titles + canonical via a new `RouteMeta`; meta description trimmed under 160 chars; `twitter:*` tags use `name=`; JSON-LD jobTitle aligned with the title tag; "fulltime" → "full-time"
- **Bugs:** audio `src` made absolute (404'd on trailing-slash routes); copy-email reset timers no longer stack; /draw guards `localStorage`, forgets a cleared API key, and cleans up its focus timer; jest `modulePaths` no longer a machine-specific absolute path
- **Cleanups:** dead legacy DOM-star styles removed; StarField eslint-disable TODOs replaced with a typed cast; stale texture docstrings fixed; README rewritten for rsbuild (was CRA-era); computer.scss defines its breakpoint vars
- **Copy:** About intro now names the 2025 sabbatical and dates full-time availability (fall 2026); resume bullet capitalization/dash consistency

Verified with `tsc --noEmit`, `lint`, and a production `build`.
