### PR TITLE
Improve mobile web experience

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     <!-- Viewport and Theme -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
     />
     <meta name="theme-color" content="#000000" />
     <meta name="msapplication-TileColor" content="#000000" />

--- a/src/App.scss
+++ b/src/App.scss
@@ -106,6 +106,31 @@ audio {
     }
   }
 }
+
+// The music toggle and the player it becomes sit in the bottom-left
+// corner: keep them clear of the home indicator / rounded corners now
+// that viewport-fit=cover lets the page extend under them
+.music-toggle,
+audio {
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  left: calc(1rem + env(safe-area-inset-left, 0px));
+}
+
+// On narrow screens the résumé panel scrolls right under the toggle, so
+// it needs its own scrim to stay legible (no backdrop-filter — same rule
+// as everything else over the canvases). Over the plain backgrounds the
+// pill all but disappears; padding + negative margin also grow the tap
+// target without moving the label.
+.music-toggle {
+  padding: 6px 10px;
+  margin: -6px -10px;
+  border-radius: 999px;
+  background: rgba(8, 6, 28, 0.75);
+}
+
+.App.day .music-toggle {
+  background: rgba(255, 255, 255, 0.75);
+}
 .resume-divider {
   width: 100%;
   height: 1px;
@@ -390,7 +415,8 @@ p {
 
 .homePageBackLink {
   position: absolute;
-  left: 16px;
+  top: env(safe-area-inset-top, 0px);
+  left: calc(16px + env(safe-area-inset-left, 0px));
   z-index: 5;
 
   > a {
@@ -410,7 +436,7 @@ p {
   position: absolute;
   left: 24px;
   right: 24px;
-  top: 40px;
+  top: calc(40px + env(safe-area-inset-top, 0px));
   width: calc(100% - 48px);
   transition:
     fill 3s ease,
@@ -614,8 +640,22 @@ li > ul > li {
     display: unset;
   }
 
+  // The "things I care about" cards: two columns leave ~2 words per line
+  // at phone widths — stack them instead
+  .hor-list {
+    grid-template-columns: 1fr;
+  }
+
+  .resume-panel {
+    // A little less side padding buys the monospace body text real column
+    // width on phones
+    padding: 24px 20px 56px;
+  }
+
   .homeInfoContainer {
-    transition: color 1000ms ease-in-out;
+    transition:
+      color 1000ms ease-in-out,
+      opacity 1000ms ease;
     left: 20px;
     right: 20px;
     margin: auto;
@@ -623,16 +663,71 @@ li > ul > li {
     width: unset;
     max-width: min(360px, calc(100vw - 40px));
     top: unset;
-    bottom: 184px;
+    bottom: calc(184px + env(safe-area-inset-bottom, 0px));
     min-width: 300px;
     transform: unset;
+    // Breathing room for the ::before scrim below
+    padding: 16px 8px;
+
+    // The home camera freezes an asteroid right behind this box, and the
+    // sun's glow creeps up under it: a soft scrim keeps the links and
+    // typed line legible. It fades out on every edge (two masked
+    // gradients, the gg-fog pattern) so it never reads as a hard panel;
+    // no backdrop-filter, as ever, over the animated canvases.
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      mask-image:
+        linear-gradient(
+          to bottom,
+          transparent,
+          black 20%,
+          black 80%,
+          transparent
+        ),
+        linear-gradient(
+          to right,
+          transparent,
+          black 12%,
+          black 88%,
+          transparent
+        );
+      mask-composite: intersect;
+      -webkit-mask-image:
+        linear-gradient(
+          to bottom,
+          transparent,
+          black 20%,
+          black 80%,
+          transparent
+        ),
+        linear-gradient(
+          to right,
+          transparent,
+          black 12%,
+          black 88%,
+          transparent
+        );
+      -webkit-mask-composite: destination-in;
+    }
+  }
+
+  .App.night .homeInfoContainer::before {
+    background: rgba(2, 2, 12, 0.78);
+  }
+
+  .App.day .homeInfoContainer::before {
+    background: rgba(255, 252, 250, 0.78);
   }
 
   .sm-screen-summary-line {
     position: fixed;
     // Tucked just under the "andrewhunt" name letters (their box ends
-    // ~109px down at iPhone widths)
-    top: 120px;
+    // ~109px down at iPhone widths); tracks the same safe-area shift as
+    // .nameTitle
+    top: calc(120px + env(safe-area-inset-top, 0px));
     width: 100%;
     text-align: center;
     font-size: 20px;
@@ -643,7 +738,7 @@ li > ul > li {
   .nameTitle {
     left: 16px;
     right: 16px;
-    top: 40px;
+    top: calc(40px + env(safe-area-inset-top, 0px));
     width: calc(100% - 32px);
   }
 
@@ -776,6 +871,15 @@ a:hover {
 #solar-system a:hover,
 .earth-about-ring:hover {
   text-decoration: none;
+}
+
+// Tapping a body link on mobile flashes the OS's grey highlight circle
+// over the artwork; the purple hover/focus outline is the tap feedback
+#solar-system a,
+.earth-about-ring,
+.asteroid-link,
+.moon-link {
+  -webkit-tap-highlight-color: transparent;
 }
 
 @keyframes spin {
@@ -1327,7 +1431,11 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
 
 .day-night-switch {
   // Positioned by the Tailwind classes on the component (fixed top-right);
-  // fixed also serves as the containing block for the absolute layers below
+  // fixed also serves as the containing block for the absolute layers below.
+  // viewport-fit=cover extends the page under notches/rounded corners, so
+  // nudge the toggle inside the safe area on phones.
+  top: calc(1rem + env(safe-area-inset-top, 0px));
+  right: calc(3rem + env(safe-area-inset-right, 0px));
   width: $dns-width;
   height: $dns-height;
   border-radius: $dns-height;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,15 @@ const App = () => {
 
   usePauseAudioOnHideEventListener();
 
+  // Tint the mobile browser chrome (iOS Safari tab bar, Android status
+  // bar) to match the active palette; day matches the top of the
+  // App-background_day gradient
+  useEffect(() => {
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", isNightMode ? "#000000" : "#ffc2d9");
+  }, [isNightMode]);
+
   // fade home content in once mounted
   useEffect(() => {
     // eslint-disable-next-line -- TODO: rm this comment and fix the lint error

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -57,7 +57,7 @@ const asteroidConfig = (asteroid: SolarPlanetConfig): BodyAnchorConfig => ({
   position: (t, out) => planetPosition(asteroid, t, out),
   radius: asteroid.radius,
   ringScale: 1.4,
-  minSizePx: 36,
+  minSizePx: 44,
 });
 
 const ANCHORS: BodyAnchorConfig[] = [


### PR DESCRIPTION
Tested the landing, home, and about pages at 375×812 in both night and day palettes.

## What changed

**/about (résumé)**
- The "things I care about" cards were a 2-column grid at phone widths, leaving ~2 words per line — they now stack in a single column below 768px, and the panel's side padding drops from 32px to 20px so the monospace body text gets a real column width.

**/home**
- The home camera freezes an asteroid directly behind the social icons + typed line on phones, with the sun's glow creeping up beneath. Added a soft scrim behind the info block that fades out on every edge (masked gradients, same pattern as the fog layers) so it never reads as a hard panel. No `backdrop-filter`, per the perf rule.
- The `sm` breakpoint's `transition: color` override was silently dropping the block's opacity fade-in — the fade now survives on mobile.

**Music toggle ("Enable space jams")**
- On narrow screens the résumé panel scrolls directly under it; it now has a translucent pill background (mode-aware) and a slightly larger tap target. Over the plain backgrounds the pill all but disappears.

**Notches & safe areas**
- `viewport-fit=cover` in the viewport meta (kills the white letterbox bars beside the notch in landscape), with `env(safe-area-inset-*)` offsets for the day/night switch, name title, back link, music toggle/audio player, summary line, and home info block. All `env()` uses fall back to `0px`, so nothing moves on desktop.

**Touch polish**
- Asteroid link overlays now floor at 44px (was 36px), matching the touch-target guideline.
- The grey mobile tap-highlight flash is suppressed on the 3D body links (ENTER sun, Earth ring, asteroids, moon) — the purple outline is the tap feedback.
- `<meta name="theme-color">` now follows the day/night toggle so mobile browser chrome matches the palette (day uses the top stop of the day gradient).

## Testing
- Landing: ENTER sun renders centered at mobile width; wheel scrub and synthetic touch-swipe both commit navigation to /home.
- Home: verified scrim legibility over the frozen asteroid + sun in night and day modes.
- About: single-column cards, pills, experience/education sections, and music-toggle pill checked top to bottom in both modes.
- `tsc --noEmit`, `lint`, and `build` all pass.