### PR TITLE
Space synth studio: 808 pad warps to a knob-planet solar system (/synth)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1244,6 +1244,13 @@ body.rocket-journey #rocket-cockpit {
   }
 }
 
+// Stepper planets (the wave selector) click through their options
+// rather than dragging a scale
+.synth-knob--stepper,
+.synth-knob--stepper:active {
+  cursor: pointer;
+}
+
 .synth-knob-arc {
   position: absolute;
   inset: 0;

--- a/src/App.scss
+++ b/src/App.scss
@@ -1105,7 +1105,11 @@ body.rocket-journey {
   audio,
   .music-toggle,
   .asteroid-link,
-  .earth-about-ring {
+  .earth-about-ring,
+  .synthBackLink,
+  .synth-knob,
+  .synth-sun-button,
+  .synth-hint {
     opacity: 0 !important;
     pointer-events: none !important;
     // visibility (delayed past the fade) also pulls the hidden controls
@@ -1198,6 +1202,132 @@ body.rocket-journey #rocket-cockpit {
   100% {
     opacity: 0;
   }
+}
+
+// ─── Space synth (/synth) ────────────────
+// DOM overlays for the synth solar system: each knob planet gets a
+// button that SynthSystem glues to the planet's projection every frame
+// (the BodyAnchors pattern). Hidden until the first frame places them.
+.synthBackLink {
+  position: absolute;
+  left: 16px;
+  z-index: 5;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 16px;
+    padding: 4px;
+    color: $purp-light;
+  }
+}
+
+.App.day .synthBackLink button {
+  color: $purp;
+}
+
+.synth-knob {
+  position: fixed;
+  visibility: hidden;
+  z-index: 3;
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: grab;
+  touch-action: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.synth-knob-arc {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+
+  circle {
+    fill: none;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .synth-knob-track {
+    stroke: rgba(255, 255, 255, 0.18);
+    stroke-width: 2px;
+  }
+
+  .synth-knob-value {
+    stroke-width: 3px;
+    stroke-linecap: round;
+  }
+}
+
+.App.day .synth-knob-arc .synth-knob-track {
+  stroke: rgba(20, 20, 40, 0.28);
+}
+
+.synth-knob-label {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 8px);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+  color: #e8e6f5;
+}
+
+.App.day .synth-knob-label {
+  color: #2a2140;
+}
+
+// The sun's overlay doubles as the arpeggiator's play/pause switch
+.synth-sun-button {
+  position: fixed;
+  visibility: hidden;
+  z-index: 3;
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.synth-sun-glyph {
+  color: #ffffff;
+  font-size: 20px;
+  text-shadow: 0 0 12px #c26bff;
+}
+
+.synth-hint {
+  position: fixed;
+  // Clear of the music toggle (bottom-left) on narrow screens, where
+  // the wrapped hint would otherwise sit right on top of it
+  bottom: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  width: max-content;
+  max-width: 92vw;
+  font-size: 13px;
+  text-align: center;
+  color: rgba(232, 230, 245, 0.7);
+
+  @media (min-width: $breakpoint-md) {
+    bottom: 16px;
+  }
+}
+
+.App.day .synth-hint {
+  color: rgba(30, 22, 60, 0.7);
 }
 
 .resume-inner-container {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import "./App.scss";
 
 import Home from "./Home";
 import Resume from "./Resume";
+import Synth from "./Synth";
 import SvgGenerator from "./SvgGenerator";
 import AppBackground from "AppBackground";
 import DayNightSwitch from "DayNightSwitch";
@@ -106,6 +107,7 @@ const App = () => {
           <Route path="/" element={<Landing />} />
           <Route path="/home" element={<Home />} />
           <Route path="/about" element={<Resume />} />
+          <Route path="/synth" element={<Synth />} />
           <Route path="/draw" element={<SvgGenerator />} />
         </Routes>
       </Router>

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -1,5 +1,13 @@
-import React, { useState, useEffect, memo, lazy, Suspense } from "react";
-import { useLocation } from "react-router-dom";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  memo,
+  lazy,
+  Suspense,
+} from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import cx from "classnames";
 
 import GoldenGate from "./gg-bridge.png";
@@ -53,11 +61,21 @@ const AppBackground = ({
 }) => {
   const size = useWindowSize();
   const location = useLocation();
+  const navigate = useNavigate();
+  // Stable identity (Space3DBackground is memo'd against this component's
+  // 200ms ticker re-renders) that also swallows navigate's promise
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+  const journeyNavigate = useCallback((to: string) => {
+    void navigateRef.current(to);
+  }, []);
 
   const isHomePage = location.pathname.includes("home");
   // /draw shares the about-page background (Earth + moon in the 3D scene)
   const isAboutPage =
     location.pathname.includes("about") || location.pathname.includes("draw");
+  // The synth solar system (the 808-pad easter egg's destination)
+  const isSynthPage = location.pathname.includes("synth");
   const isLanding = location.pathname === "/" || location.pathname === "";
   const [musicEnabled, setMusicEnabled] = useState(false);
 
@@ -170,6 +188,8 @@ const AppBackground = ({
             isLanding={isLanding}
             isHomePage={isHomePage}
             isAboutPage={isAboutPage}
+            isSynthPage={isSynthPage}
+            onJourneyNavigate={journeyNavigate}
           />
         </Suspense>
       </BackgroundErrorBoundary>

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -13,6 +13,7 @@ import cx from "classnames";
 import GoldenGate from "./gg-bridge.png";
 import GoldenGateFog from "./GoldenGateFog";
 import useWindowSize from "useWindowSize";
+import { onSynthNote } from "./synthAudio";
 import { MusicIcon } from "lucide-react";
 // import RetroMac from "./RetroMac";
 
@@ -85,11 +86,20 @@ const AppBackground = ({
     // The nameTitle SVG this drives only renders off the landing page, so
     // don't fire a 5x/sec state update + re-render on the landing route.
     if (isLanding) return;
+    // On /synth the ticker keeps time with the music instead of the
+    // clock: every audible note — arp step or keyboard press — advances
+    // the highlighted letter (and silence holds it still). Everywhere
+    // else the plain 200ms march stays.
+    if (isSynthPage) {
+      return onSynthNote(() => {
+        setHighlightedCharIdx((idx) => (idx + 1) % nameArr.length);
+      });
+    }
     const interval = setInterval(() => {
       setHighlightedCharIdx((idx) => (idx + 1) % nameArr.length);
     }, 200);
     return () => clearInterval(interval);
-  }, [isLanding]);
+  }, [isLanding, isSynthPage]);
 
   // Start playback as soon as the player mounts — i.e. right after the
   // visitor clicks "Enable space jams". That click is the user gesture that

--- a/src/RocketCockpit.tsx
+++ b/src/RocketCockpit.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
 /**
- * The rocket joyride's cockpit dressing: a steel windshield frame whose
- * edges hug the viewport (so warp reads as seen from inside the ship)
- * and the white flash that covers the lightspeed jumps. Pure DOM/SVG —
- * always mounted on /home, revealed by `body.rocket-journey` (App.scss),
- * and never takes pointer input.
+ * The lightspeed journeys' cockpit dressing: a steel windshield frame
+ * whose edges hug the viewport (so warp reads as seen from inside the
+ * ship) and the white flash that covers the jumps. Pure DOM/SVG —
+ * mounted by every page a journey can start or end on (/home, /synth),
+ * revealed by `body.rocket-journey` (App.scss), never takes pointer
+ * input.
  *
  * The frame SVG stretches non-uniformly (preserveAspectRatio="none"):
  * corner curves become gentle ellipses on wide screens, which reads as

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -14,7 +14,8 @@ import {
   EARTH_ABOUT_RING_ID,
 } from "./space3d/solar/BodyAnchors";
 import { hoverState } from "./solarHover";
-import { startRocketJourney } from "./rocketJourney";
+import { startRocketJourney, startSynthJourney } from "./rocketJourney";
+import { ensureAudio } from "./synthAudio";
 
 /**
  * DOM overlays for the home page's 3D bodies. The canvases never take
@@ -142,6 +143,38 @@ const SolarOverlays = () => {
           </TooltipTrigger>
           <TooltipContent updatePositionStrategy="always">
             <p>So u wanna be astronaut?</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      {/* The floating 808 pad: warps to the synth solar system (/synth).
+          Unlocking the AudioContext inside this click is what lets the
+          beat start playing the moment you land. */}
+      <TooltipProvider delayDuration={100}>
+        <Tooltip disableHoverableContent>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              id={asteroidAnchorId("synthpad")}
+              className="asteroid-link"
+              aria-label="Space jam studio"
+              onClick={() => {
+                ensureAudio();
+                startSynthJourney();
+              }}
+              onPointerEnter={() => {
+                hoverState.asteroid = "synthpad";
+              }}
+              onPointerLeave={() => {
+                if (hoverState.asteroid === "synthpad") {
+                  hoverState.asteroid = null;
+                }
+              }}
+            >
+              <BodyOutline outlineId={asteroidOutlineId("synthpad")} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent updatePositionStrategy="always">
+            <p>space jam studio</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/src/Synth.tsx
+++ b/src/Synth.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowLeftCircleIcon } from "lucide-react";
+
+import RocketCockpit from "./RocketCockpit";
+import { startSynthReturn } from "./rocketJourney";
+import {
+  SYNTH_KNOBS,
+  SYNTH_SUN_ANCHOR_ID,
+  synthKnobAnchorId,
+  synthUiState,
+  type SynthKnobSpec,
+  type SynthParam,
+} from "./synthSpec";
+import {
+  ensureAudio,
+  getParam,
+  noteOff,
+  noteOn,
+  setParam,
+  silenceSynth,
+  startArp,
+  synthState,
+  toggleArp,
+} from "./synthAudio";
+
+/**
+ * The space synth page (/synth): DOM overlays for the synth solar
+ * system. The canvases never take pointer input, so each knob planet
+ * gets a fixed-position button here that SynthSystem glues to the
+ * planet's projection each frame — drag one vertically (or scroll, or
+ * arrow-key it) to turn the knob. The sun's overlay toggles the
+ * arpeggiator, the keyboard plays notes, and "back to Earth" rides the
+ * lightspeed warp home.
+ */
+
+// Piano-style key map (ableton layout), semitones up from A3
+const KEY_TO_SEMITONE: Record<string, number> = {
+  a: 0,
+  w: 1,
+  s: 2,
+  e: 3,
+  d: 4,
+  f: 5,
+  t: 6,
+  g: 7,
+  y: 8,
+  h: 9,
+  u: 10,
+  j: 11,
+  k: 12,
+  o: 13,
+  l: 14,
+};
+const BASE_MIDI = 57; // A3
+
+/** Vertical drag distance for a full knob sweep, px */
+const DRAG_FULL_SWEEP_PX = 140;
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+
+const knobDisplay = (knob: SynthKnobSpec, value: number): string =>
+  knob.stepNames
+    ? knob.stepNames[Math.round(value * (knob.stepNames.length - 1))]
+    : `${Math.round(value * 100)}%`;
+
+const Synth = () => {
+  const [params, setParamsState] = useState<Record<SynthParam, number>>(
+    () =>
+      Object.fromEntries(
+        SYNTH_KNOBS.map((knob) => [knob.param, getParam(knob.param)]),
+      ) as Record<SynthParam, number>,
+  );
+  const [playing, setPlaying] = useState(synthState.playing);
+  const [activeParam, setActiveParam] = useState<SynthParam | null>(null);
+  const drag = useRef<{
+    param: SynthParam;
+    pointerId: number;
+    startY: number;
+    startValue: number;
+  } | null>(null);
+
+  const commitParam = useCallback((param: SynthParam, value: number) => {
+    const v = clamp01(value);
+    setParam(param, v);
+    setParamsState((prev) => ({ ...prev, [param]: v }));
+  }, []);
+
+  // Arriving by 808 pad: the click that launched the warp already
+  // unlocked the AudioContext, so the beat can greet the landing. A
+  // deep-linked visit stays silent until the first click on the sun.
+  useEffect(() => {
+    if (synthState.ready) {
+      startArp();
+      setPlaying(true);
+    }
+    return () => {
+      synthUiState.activeKnob = null;
+      silenceSynth();
+    };
+  }, []);
+
+  // The computer keyboard is the keybed
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+      const semitone = KEY_TO_SEMITONE[e.key.toLowerCase()];
+      if (semitone === undefined) return;
+      noteOn(BASE_MIDI + semitone);
+    };
+    const up = (e: KeyboardEvent) => {
+      const semitone = KEY_TO_SEMITONE[e.key.toLowerCase()];
+      if (semitone === undefined) return;
+      noteOff(BASE_MIDI + semitone);
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, []);
+
+  const setActive = useCallback((param: SynthParam | null) => {
+    synthUiState.activeKnob = param;
+    setActiveParam(param);
+  }, []);
+
+  return (
+    <>
+      <RocketCockpit />
+      <div className="synthBackLink">
+        <button type="button" onClick={() => startSynthReturn()}>
+          <ArrowLeftCircleIcon className="starIcon" size={16} />
+          <span>Back to Earth</span>
+        </button>
+      </div>
+      {/* The sun is the power switch */}
+      <button
+        type="button"
+        id={SYNTH_SUN_ANCHOR_ID}
+        className="synth-sun-button"
+        aria-label={playing ? "Pause the beat" : "Play the beat"}
+        onClick={() => {
+          ensureAudio();
+          toggleArp();
+          setPlaying(synthState.playing);
+        }}
+      >
+        <span className="synth-sun-glyph" aria-hidden>
+          {playing ? "❚❚" : "▶"}
+        </span>
+      </button>
+      {SYNTH_KNOBS.map((knob) => {
+        const value = params[knob.param];
+        const isActive = activeParam === knob.param;
+        return (
+          <button
+            key={knob.param}
+            type="button"
+            id={synthKnobAnchorId(knob.param)}
+            className="synth-knob"
+            aria-label={`${knob.label}: ${knobDisplay(knob, value)}`}
+            onPointerDown={(e) => {
+              ensureAudio();
+              (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+              drag.current = {
+                param: knob.param,
+                pointerId: e.pointerId,
+                startY: e.clientY,
+                startValue: value,
+              };
+              setActive(knob.param);
+            }}
+            onPointerMove={(e) => {
+              const d = drag.current;
+              if (!d || d.param !== knob.param || d.pointerId !== e.pointerId) {
+                return;
+              }
+              commitParam(
+                knob.param,
+                d.startValue + (d.startY - e.clientY) / DRAG_FULL_SWEEP_PX,
+              );
+            }}
+            onPointerUp={() => {
+              drag.current = null;
+            }}
+            onPointerCancel={() => {
+              drag.current = null;
+            }}
+            onPointerEnter={() => setActive(knob.param)}
+            onPointerLeave={() => {
+              if (!drag.current) setActive(null);
+            }}
+            onWheel={(e) => {
+              ensureAudio();
+              commitParam(knob.param, value - e.deltaY * 0.0012);
+            }}
+            onKeyDown={(e) => {
+              const step = knob.steps ? 1 / (knob.steps - 1) : 0.05;
+              if (e.key === "ArrowUp" || e.key === "ArrowRight") {
+                e.preventDefault();
+                ensureAudio();
+                commitParam(knob.param, value + step);
+              } else if (e.key === "ArrowDown" || e.key === "ArrowLeft") {
+                e.preventDefault();
+                ensureAudio();
+                commitParam(knob.param, value - step);
+              }
+            }}
+            onFocus={() => setActive(knob.param)}
+            onBlur={() => {
+              if (!drag.current) setActive(null);
+            }}
+          >
+            <svg className="synth-knob-arc" viewBox="0 0 100 100" aria-hidden>
+              <circle className="synth-knob-track" cx="50" cy="50" r="46" />
+              <circle
+                className="synth-knob-value"
+                cx="50"
+                cy="50"
+                r="46"
+                pathLength={100}
+                strokeDasharray={`${value * 100} ${100 - value * 100}`}
+                transform="rotate(-90 50 50)"
+                style={{ stroke: knob.color }}
+              />
+            </svg>
+            <span className="synth-knob-label">
+              {knob.label}
+              {isActive && ` · ${knobDisplay(knob, value)}`}
+            </span>
+          </button>
+        );
+      })}
+      <div className="synth-hint">
+        drag a planet to shape the sound · A–K plays notes · the sun runs the
+        beat
+      </div>
+    </>
+  );
+};
+
+export default Synth;

--- a/src/Synth.tsx
+++ b/src/Synth.tsx
@@ -28,9 +28,12 @@ import {
  * system. The canvases never take pointer input, so each knob planet
  * gets a fixed-position button here that SynthSystem glues to the
  * planet's projection each frame — drag one vertically (or scroll, or
- * arrow-key it) to turn the knob. The sun's overlay toggles the
- * arpeggiator, the keyboard plays notes, and "back to Earth" rides the
- * lightspeed warp home.
+ * arrow-key it) to turn the knob. Stepper planets (the wave selector)
+ * are a different instrument: clicking cycles to the next option, and
+ * the planet itself wears the selected waveform (SynthSystem's
+ * oscilloscope texture), so they carry no value arc. The sun's overlay
+ * toggles the arpeggiator, the keyboard plays notes, and "back to
+ * Earth" rides the lightspeed warp home.
  */
 
 // Piano-style key map (ableton layout), semitones up from A3
@@ -125,6 +128,18 @@ const Synth = () => {
     setActiveParam(param);
   }, []);
 
+  // Stepper planets cycle through their options (wrapping) instead of
+  // sweeping a scale
+  const cycleStep = useCallback(
+    (knob: SynthKnobSpec, direction: 1 | -1) => {
+      const count = knob.stepNames!.length;
+      const step = Math.round(getParam(knob.param) * (count - 1));
+      const next = (step + direction + count) % count;
+      commitParam(knob.param, next / (count - 1));
+    },
+    [commitParam],
+  );
+
   return (
     <>
       <RocketCockpit />
@@ -153,6 +168,42 @@ const Synth = () => {
       {SYNTH_KNOBS.map((knob) => {
         const value = params[knob.param];
         const isActive = activeParam === knob.param;
+        if (knob.stepNames) {
+          // Click-to-cycle stepper: the planet displays the selection
+          // (no sliding scale), the label names it, a click advances it
+          return (
+            <button
+              key={knob.param}
+              type="button"
+              id={synthKnobAnchorId(knob.param)}
+              className="synth-knob synth-knob--stepper"
+              aria-label={`${knob.label}: ${knobDisplay(knob, value)} — click for next`}
+              onClick={() => {
+                ensureAudio();
+                cycleStep(knob, 1);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "ArrowUp" || e.key === "ArrowRight") {
+                  e.preventDefault();
+                  ensureAudio();
+                  cycleStep(knob, 1);
+                } else if (e.key === "ArrowDown" || e.key === "ArrowLeft") {
+                  e.preventDefault();
+                  ensureAudio();
+                  cycleStep(knob, -1);
+                }
+              }}
+              onPointerEnter={() => setActive(knob.param)}
+              onPointerLeave={() => setActive(null)}
+              onFocus={() => setActive(knob.param)}
+              onBlur={() => setActive(null)}
+            >
+              <span className="synth-knob-label">
+                {knob.label} · {knobDisplay(knob, value)}
+              </span>
+            </button>
+          );
+        }
         return (
           <button
             key={knob.param}
@@ -196,15 +247,14 @@ const Synth = () => {
               commitParam(knob.param, value - e.deltaY * 0.0012);
             }}
             onKeyDown={(e) => {
-              const step = knob.steps ? 1 / (knob.steps - 1) : 0.05;
               if (e.key === "ArrowUp" || e.key === "ArrowRight") {
                 e.preventDefault();
                 ensureAudio();
-                commitParam(knob.param, value + step);
+                commitParam(knob.param, value + 0.05);
               } else if (e.key === "ArrowDown" || e.key === "ArrowLeft") {
                 e.preventDefault();
                 ensureAudio();
-                commitParam(knob.param, value - step);
+                commitParam(knob.param, value - 0.05);
               }
             }}
             onFocus={() => setActive(knob.param)}

--- a/src/rocketJourney.ts
+++ b/src/rocketJourney.ts
@@ -1,25 +1,35 @@
 /**
- * State machine for the rocket-ship joyride (the "surprise me" easter
- * egg on /home): boarding swoop -> lightspeed warp -> drop back home.
- * The DOM overlay sets it off (SolarOverlays' rocket button); the 3D
- * scene reads and advances it per frame (space3d/solar/RocketJourney).
- * Lives in its own three-free module, same as solarHover, so main-chunk
- * components can import it without dragging three.js out of its lazy
- * chunk.
+ * State machine for the lightspeed journeys: the rocket joyride (the
+ * "So u wanna be astronaut?" easter egg on /home) and the 808-pad
+ * transit to the synth solar system (/synth) and back. The DOM overlays
+ * set journeys off; the 3D scene reads and advances the state per frame
+ * (space3d/solar/RocketJourney). Lives in its own three-free module,
+ * same as solarHover, so main-chunk components can import it without
+ * dragging three.js out of its lazy chunk.
  *
- * Phases: "boarding" flies the camera in behind the rocket while the
- * windshield frame fades in; a flash covers the jump to the warp zone
- * ("warp"), where the star streaks and flyby artifacts play; a second
- * flash covers the drop back onto the home approach line, after which
- * the journey is over ("idle") and CameraRig's ordinary swoop glides
- * the last stretch onto the perch — the "landing back home".
+ * Phases: "boarding" flies the camera toward the vehicle (or just turns
+ * it toward home, for the return trip) while the windshield frame fades
+ * in; a flash covers the jump to the warp zone ("warp"), where the star
+ * streaks — and, on the joyride, the flyby cameos — play; a second
+ * flash covers the drop onto the destination's approach line, after
+ * which the journey is over ("idle") and CameraRig's ordinary swoop
+ * glides the last stretch onto the perch.
  */
 import { hoverState } from "./solarHover";
 
 export type JourneyPhase = "idle" | "boarding" | "warp";
+export type JourneyDestination = "home" | "synth";
+/** What the boarding beat aims at: the rocket's nose, the 808 pad, or
+ *  nothing (the synth return just turns the camera toward home). */
+export type JourneyVehicle = "rocket" | "pad" | "none";
 
-export const BOARDING_SECONDS = 1.8;
-export const WARP_SECONDS = 11.4;
+/** The full joyride (rocket): board, long warp with cameos, land home */
+const BOARDING_SECONDS = 1.8;
+const WARP_SECONDS = 11.4;
+/** The synth transit (808 pad, both directions): shorter, streaks only */
+const TRANSIT_BOARD_SECONDS = 1.3;
+const RETURN_TURN_SECONDS = 1;
+const TRANSIT_WARP_SECONDS = 4.2;
 
 export const journeyState = {
   phase: "idle" as JourneyPhase,
@@ -34,22 +44,64 @@ export const journeyState = {
    *  the overlay button can outlive the scene — without a driver the
    *  ride must not start, or the hidden page UI would never come back. */
   driverAlive: false,
+  // ── per-journey plan, set by the start functions ──
+  destination: "home" as JourneyDestination,
+  vehicle: "rocket" as JourneyVehicle,
+  boardSeconds: BOARDING_SECONDS,
+  warpSeconds: WARP_SECONDS,
+  /** Flyby cameos only play on the joyride, not the synth transits */
+  cameos: true,
 };
 
 /** The `body` class that hides the page UI and reveals the windshield
  *  overlay while the journey plays (same pattern as `video-mode`). */
 const JOURNEY_BODY_CLASS = "rocket-journey";
 
-export function startRocketJourney(): void {
+function beginJourney(
+  vehicle: JourneyVehicle,
+  destination: JourneyDestination,
+  boardSeconds: number,
+  warpSeconds: number,
+  cameos: boolean,
+): void {
   if (journeyState.phase !== "idle" || !journeyState.driverAlive) return;
+  journeyState.vehicle = vehicle;
+  journeyState.destination = destination;
+  journeyState.boardSeconds = boardSeconds;
+  journeyState.warpSeconds = warpSeconds;
+  journeyState.cameos = cameos;
   journeyState.phase = "boarding";
   journeyState.phaseElapsed = 0;
-  // The pointer is parked on the rocket's overlay while it boards; the
+  // The pointer is parked on the clicked overlay while it boards; the
   // overlay goes pointer-events:none without a reliable pointerleave, so
   // drop the hover freeze/whitewash here
   hoverState.asteroid = null;
   document.body.classList.add(JOURNEY_BODY_CLASS);
 }
+
+/** The rocket joyride: there and back again, all on /home. */
+export const startRocketJourney = (): void =>
+  beginJourney("rocket", "home", BOARDING_SECONDS, WARP_SECONDS, true);
+
+/** The 808 pad: warp from /home to the synth solar system (/synth). */
+export const startSynthJourney = (): void =>
+  beginJourney(
+    "pad",
+    "synth",
+    TRANSIT_BOARD_SECONDS,
+    TRANSIT_WARP_SECONDS,
+    false,
+  );
+
+/** Back to Earth from the synth system (/synth -> /home). */
+export const startSynthReturn = (): void =>
+  beginJourney(
+    "none",
+    "home",
+    RETURN_TURN_SECONDS,
+    TRANSIT_WARP_SECONDS,
+    false,
+  );
 
 /** Ends the ride (natural landing or an abort — route change, scene
  *  unmount) and restores the page UI. Safe to call when already idle. */
@@ -61,7 +113,7 @@ export function endRocketJourney(): void {
 }
 
 /** One-shot white flash covering the warp entry/exit teleports (the
- *  element lives in Home's RocketCockpit overlay). */
+ *  element lives in the page's RocketCockpit overlay). */
 export function flashWarp(): void {
   const el = document.getElementById("warp-flash");
   if (!el) return;

--- a/src/space3d/Space3DBackground.tsx
+++ b/src/space3d/Space3DBackground.tsx
@@ -26,21 +26,36 @@ const Space3DBackground = ({
   isLanding,
   isHomePage,
   isAboutPage,
+  isSynthPage,
+  onJourneyNavigate,
 }: {
   isNightMode: boolean;
   isLanding: boolean;
   isHomePage: boolean;
   isAboutPage: boolean;
+  isSynthPage: boolean;
+  /** Router navigation for the lightspeed journeys (passed down into the
+   *  canvas, where router context can't reach) */
+  onJourneyNavigate: (to: string) => void;
 }) => {
   return (
     <>
       <SpaceCanvas>
         <StarField isLanding={isLanding} opacityTarget={isNightMode ? 1 : 0} />
       </SpaceCanvas>
-      {(isLanding || isHomePage || isAboutPage) && (
+      {(isLanding || isHomePage || isAboutPage || isSynthPage) && (
         <SolarScene
-          view={isLanding ? "landing" : isAboutPage ? "about" : "home"}
+          view={
+            isLanding
+              ? "landing"
+              : isSynthPage
+                ? "synth"
+                : isAboutPage
+                  ? "about"
+                  : "home"
+          }
           isNightMode={isNightMode}
+          onNavigate={onJourneyNavigate}
         />
       )}
     </>

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -6,6 +6,7 @@ import { EARTH, moonPosition, planetPosition, rigState } from "./constants";
 import { starPanState } from "../starPan";
 import { scrollTransitionState } from "../../scrollTransition";
 import { journeyState } from "../../rocketJourney";
+import { SYNTH_CAM_HEIGHT, SYNTH_ORIGIN } from "../../synthSpec";
 
 /**
  * Camera choreography, ported from hunt-codes-3. Landing hovers straight
@@ -19,7 +20,7 @@ import { journeyState } from "../../rocketJourney";
  * a few seconds; once arrived the camera rides the moving goal.
  */
 
-export type SolarView = "landing" | "home" | "about";
+export type SolarView = "landing" | "home" | "about" | "synth";
 
 // Height tuned so Earth's orbit (r 17.5) nearly reaches the bottom edge
 // (~16px margin on a laptop): visible half-height = tan(fov/2)·y ≈ .52·35.
@@ -100,7 +101,17 @@ function computeGoal(
   camera: THREE.Camera,
   viewport: { width: number; height: number },
 ) {
-  if (view === "landing") {
+  if (view === "synth") {
+    // Straight down over the synth sun, like the landing view's orbital
+    // diagram — the knob planets read as a control panel. Same 0.01 z
+    // nudge to keep the lookAt out of the exact-degenerate pole case.
+    goalPos.set(
+      SYNTH_ORIGIN.x,
+      SYNTH_ORIGIN.y + SYNTH_CAM_HEIGHT,
+      SYNTH_ORIGIN.z + 0.01,
+    );
+    goalLook.set(SYNTH_ORIGIN.x, SYNTH_ORIGIN.y, SYNTH_ORIGIN.z);
+  } else if (view === "landing") {
     if (viewport.width >= LG_BREAKPOINT_PX) {
       // Drop the sun below center by panning the camera + look target the
       // same amount in −Z (screen-down), so the view stays straight-down.
@@ -173,17 +184,18 @@ function computeGoal(
   }
 }
 
-/** The home view's camera goal at time t, written into the caller's
- *  vectors — the rocket journey uses it to drop the camera onto the
- *  home approach line before handing control back. */
-export function homeViewGoal(
+/** A view's camera goal at time t, written into the caller's vectors —
+ *  the lightspeed journeys use it to drop the camera onto the
+ *  destination's approach line before handing control back. */
+export function viewGoal(
+  view: SolarView,
   t: number,
   camera: THREE.Camera,
   viewport: { width: number; height: number },
   outPos: THREE.Vector3,
   outLook: THREE.Vector3,
 ): void {
-  computeGoal("home", t, camera, viewport);
+  computeGoal(view, t, camera, viewport);
   outPos.copy(goalPos);
   outLook.copy(goalLook);
 }

--- a/src/space3d/solar/DrumPad.tsx
+++ b/src/space3d/solar/DrumPad.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+import { planetPosition, type SolarPlanetConfig } from "./constants";
+import { asteroidOutlineId } from "./BodyAnchors";
+import { writeSilhouette } from "./outline";
+import { hoverState } from "../../solarHover";
+
+/**
+ * The synth easter egg's front door: a little TR-808-style drum machine
+ * floating among the link bodies on /home — charcoal slab, 4x4 grid of
+ * red/orange/yellow/cream pads, a row of knobs, a blinking status LED.
+ * Clicking its overlay (SolarOverlays) warps to the synth solar system.
+ * Reuses the asteroid link plumbing: same config shape, BodyAnchors
+ * overlay, hover freeze/brighten/outline, landing fade.
+ *
+ * Orientation: like the rocket, the rig re-derives its basis every
+ * frame so the pad face tips toward the camera (blended with world-up,
+ * so it reads like a product shot rather than a billboard), and the
+ * body sways a few degrees instead of tumbling — you can always see the
+ * pads.
+ */
+
+const FADE_IN_SECONDS = 3;
+const FADE_OUT_SECONDS = 1;
+const HOVER_EMISSIVE = 0.55;
+
+/** Classic 808 pad-row colors, front row to back. Local -z is the front
+ *  edge (the rig maps +z up-screen, away from the viewer). */
+const PAD_ROW_COLORS = ["#ff4d4d", "#ff9d3c", "#ffd23f", "#f2f0e9"];
+const PAD_COLS = [-0.57, -0.19, 0.19, 0.57];
+const PAD_ROWS = [-0.46, -0.18, 0.1, 0.38];
+const KNOB_XS = [-0.66, -0.22, 0.22, 0.66];
+
+const BLINK_PERIOD_SECONDS = 1.4;
+const BLINK_ON_FRACTION = 0.65;
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+// scratch values, reused every frame
+const topDir = new THREE.Vector3();
+const backEdge = new THREE.Vector3();
+const sideAxis = new THREE.Vector3();
+const basis = new THREE.Matrix4();
+
+export default function DrumPad({
+  config,
+  visible = true,
+}: {
+  config: SolarPlanetConfig;
+  visible?: boolean;
+}) {
+  const group = useRef<THREE.Group>(null); // orbit position + fade
+  const rig = useRef<THREE.Group>(null); // face-to-camera basis
+  const body = useRef<THREE.Group>(null); // sways around the face axis
+  const led = useRef<THREE.Mesh>(null);
+  const opacity = useRef(visible ? 1 : 0);
+  // Out-of-band so the first frame always initializes the materials
+  const appliedOpacity = useRef(-1);
+  const swayPhase = useRef(0);
+  const bobPhase = useRef(0);
+
+  const materials = useMemo(
+    () => ({
+      chassis: new THREE.MeshStandardMaterial({
+        color: "#2a2e35",
+        metalness: 0.35,
+        roughness: 0.55,
+        emissive: "#ffffff",
+        emissiveIntensity: 0,
+        transparent: true,
+      }),
+      pads: PAD_ROW_COLORS.map(
+        (color) =>
+          new THREE.MeshStandardMaterial({
+            color,
+            metalness: 0.1,
+            roughness: 0.5,
+            emissive: "#ffffff",
+            emissiveIntensity: 0,
+            transparent: true,
+          }),
+      ),
+      knob: new THREE.MeshStandardMaterial({
+        color: "#cfd6dd",
+        metalness: 0.8,
+        roughness: 0.35,
+        emissive: "#ffffff",
+        emissiveIntensity: 0,
+        transparent: true,
+      }),
+      led: new THREE.MeshBasicMaterial({
+        color: "#ff5252",
+        transparent: true,
+      }),
+    }),
+    [],
+  );
+  useEffect(
+    () => () => {
+      materials.pads.forEach((material) => material.dispose());
+      materials.chassis.dispose();
+      materials.knob.dispose();
+      materials.led.dispose();
+    },
+    [materials],
+  );
+
+  const allMaterials = useMemo(
+    () => [materials.chassis, ...materials.pads, materials.knob, materials.led],
+    [materials],
+  );
+
+  // Meshes that feed the hover silhouette (everything solid)
+  const outlineMeshes = useRef<THREE.Mesh[]>([]);
+  const registerOutlineMesh = (mesh: THREE.Mesh | null) => {
+    if (mesh && !outlineMeshes.current.includes(mesh)) {
+      outlineMeshes.current.push(mesh);
+    }
+  };
+
+  useFrame(({ clock, camera, size }, delta) => {
+    const t = clock.elapsedTime;
+    const hovered = hoverState.asteroid === config.name;
+
+    if (!hovered) {
+      swayPhase.current += delta * 0.5;
+      bobPhase.current += delta * 1.1;
+    }
+
+    if (group.current) {
+      planetPosition(config, t, group.current.position);
+      group.current.position.y += Math.sin(bobPhase.current) * 0.06;
+
+      // Same landing-view fade as the asteroids
+      const step = visible
+        ? delta / FADE_IN_SECONDS
+        : -delta / FADE_OUT_SECONDS;
+      opacity.current = THREE.MathUtils.clamp(opacity.current + step, 0, 1);
+      if (opacity.current !== appliedOpacity.current) {
+        appliedOpacity.current = opacity.current;
+        group.current.visible = opacity.current > 0.005;
+        allMaterials.forEach((material) => {
+          material.opacity = opacity.current;
+        });
+      }
+    }
+
+    // Tip the pad face toward the camera, blended with world-up so it
+    // reads three-quarter rather than dead-on; the back edge stays
+    // up-screen. Skip the update when the camera sits right on the face
+    // normal (the landing top-down pose) — the basis would degenerate.
+    if (rig.current && group.current) {
+      topDir
+        .copy(camera.position)
+        .sub(group.current.position)
+        .normalize()
+        .addScaledVector(UP, 0.35)
+        .normalize();
+      backEdge.copy(UP).addScaledVector(topDir, -UP.dot(topDir));
+      if (backEdge.lengthSq() > 1e-3) {
+        backEdge.normalize();
+        sideAxis.crossVectors(topDir, backEdge);
+        basis.makeBasis(sideAxis, topDir, backEdge);
+        rig.current.quaternion.setFromRotationMatrix(basis);
+      }
+    }
+
+    if (body.current) {
+      body.current.rotation.y = 0.3 * Math.sin(swayPhase.current);
+    }
+
+    // Status LED blink (frozen look doesn't matter — it's tiny)
+    if (led.current) {
+      led.current.visible =
+        t % BLINK_PERIOD_SECONDS < BLINK_PERIOD_SECONDS * BLINK_ON_FRACTION;
+    }
+
+    // Hover: wash toward white, same treatment as the other link bodies
+    const ease = Math.min(delta * 6, 1);
+    materials.chassis.emissiveIntensity +=
+      ((hovered ? HOVER_EMISSIVE : 0) - materials.chassis.emissiveIntensity) *
+      ease;
+    materials.pads.forEach((material) => {
+      material.emissiveIntensity = materials.chassis.emissiveIntensity;
+    });
+    materials.knob.emissiveIntensity = materials.chassis.emissiveIntensity;
+
+    if (hovered) {
+      writeSilhouette(
+        asteroidOutlineId(config.name),
+        outlineMeshes.current,
+        camera,
+        size,
+      );
+    }
+  });
+
+  return (
+    <group ref={group}>
+      <group ref={rig} scale={config.radius}>
+        <group ref={body}>
+          <mesh ref={registerOutlineMesh} material={materials.chassis}>
+            <boxGeometry args={[1.9, 0.5, 1.3]} />
+          </mesh>
+          {/* 4x4 pad grid on the top face, one classic color per row */}
+          {PAD_ROWS.map((z, row) =>
+            PAD_COLS.map((x) => (
+              <mesh
+                key={`${row}-${x}`}
+                ref={registerOutlineMesh}
+                material={materials.pads[row]}
+                position={[x, 0.28, z]}
+              >
+                <boxGeometry args={[0.3, 0.08, 0.2]} />
+              </mesh>
+            )),
+          )}
+          {/* Knob row along the back edge */}
+          {KNOB_XS.map((x) => (
+            <mesh
+              key={x}
+              ref={registerOutlineMesh}
+              material={materials.knob}
+              position={[x, 0.31, 0.56]}
+            >
+              <cylinderGeometry args={[0.09, 0.09, 0.12, 12]} />
+            </mesh>
+          ))}
+          {/* Blinking status LED, front-right corner */}
+          <mesh
+            ref={led}
+            material={materials.led}
+            position={[0.8, 0.29, -0.56]}
+          >
+            <sphereGeometry args={[0.06, 10, 8]} />
+          </mesh>
+        </group>
+      </group>
+    </group>
+  );
+}

--- a/src/space3d/solar/RocketJourney.tsx
+++ b/src/space3d/solar/RocketJourney.tsx
@@ -2,34 +2,33 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
-import { planetPosition, ROCKET } from "./constants";
+import { planetPosition, ROCKET, SYNTH_PAD } from "./constants";
 import { rocketNoseDirection } from "./Rocket";
-import { homeViewGoal, type SolarView } from "./CameraRig";
+import { viewGoal, type SolarView } from "./CameraRig";
 import { ARTIFACT_BUILDERS, disposeArtifact } from "./warpArtifacts";
-import {
-  BOARDING_SECONDS,
-  endRocketJourney,
-  flashWarp,
-  journeyState,
-  WARP_SECONDS,
-} from "../../rocketJourney";
+import { endRocketJourney, flashWarp, journeyState } from "../../rocketJourney";
+import { SYNTH_ORIGIN } from "../../synthSpec";
 
 /**
- * Drives the rocket joyride (the /home "surprise me" easter egg). While
- * journeyState is active this component owns the camera — CameraRig
- * stands down — and plays three beats:
+ * Drives every lightspeed journey: the rocket joyride (the /home
+ * "So u wanna be astronaut?" easter egg) and the 808-pad transits to
+ * the synth solar system and back. While journeyState is active this
+ * component owns the camera — CameraRig stands down — and plays three
+ * beats:
  *
- * 1. Boarding: the camera swoops from the home perch to just behind the
- *    rocket, lining up with its nose, while the stars fade and the DOM
- *    windshield frame fades in (App.scss, keyed off body.rocket-journey).
- * 2. Warp: a flash covers a teleport to a "warp zone" 900 units out
- *    along the rocket's heading — far enough that the whole solar system
- *    is a speck behind the camera. The rig (this component's group) is
- *    parked there carrying the Star Wars streak field and the flyby
- *    artifact cameos; the camera sways gently inside it.
- * 3. Re-entry: a second flash covers a teleport onto the home view's
- *    approach line, then the journey ends and CameraRig's ordinary
- *    resume swoop glides the last stretch onto the perch — the landing.
+ * 1. Boarding: the camera swoops toward the journey's vehicle (behind
+ *    the rocket's nose, or down over the 808 pad; the synth return just
+ *    swings the nose around toward home) while the stars fade and the
+ *    DOM windshield frame fades in (App.scss, `body.rocket-journey`).
+ * 2. Warp: a flash covers a teleport to a "warp zone" hundreds of units
+ *    along the travel heading — far enough that no solar system is more
+ *    than a speck. The rig (this component's group) is parked there
+ *    carrying the Star Wars streak field — plus the flyby artifact
+ *    cameos on the joyride — and the camera sways gently inside it.
+ * 3. Re-entry: a second flash covers a teleport onto the destination
+ *    view's approach line (navigating to its route if needed), then the
+ *    journey ends and CameraRig's ordinary resume swoop glides the last
+ *    stretch onto the perch — the landing.
  *
  * The streaks are one LineSegments whose head vertices march toward the
  * camera and wrap; line length and material opacity ride the warp
@@ -38,9 +37,15 @@ import {
  */
 
 const BOARD_CAM_BEHIND = 1.5;
+/** The pad boarding parks a bit further back — it's flat and wide */
+const BOARD_PAD_BEHIND = 2.2;
 const BOARD_LOOK_AHEAD = 10;
 
+/** Joyride warp zone: this far from the origin along the rocket's nose */
 const WARP_DISTANCE = 900;
+/** Transit warp zone: this far past the boarding spot along the heading
+ *  (roughly a quarter of the way to the other system) */
+const TRANSIT_WARP_AHEAD = 450;
 /** Intensity envelope: streaks stretch in/out over these ramps */
 const WARP_RAMP_IN_SECONDS = 0.9;
 const WARP_RAMP_OUT_SECONDS = 1;
@@ -62,19 +67,26 @@ const ARTIFACT_SPEED = 115;
 const ARTIFACT_FIRST_SPAWN = 1;
 const ARTIFACT_SPAWN_INTERVAL = 1.25;
 
-/** How far out on the home approach line re-entry drops the camera */
+/** How far out on the destination's approach line re-entry drops the
+ *  camera (the synth view sits closer, so its approach is shorter) */
 const REENTRY_DISTANCE = 130;
+const SYNTH_REENTRY_DISTANCE = 90;
 
 const UP = new THREE.Vector3(0, 1, 0);
 const Z_AXIS = new THREE.Vector3(0, 0, 1);
+const SYNTH_ORIGIN_VEC = new THREE.Vector3(
+  SYNTH_ORIGIN.x,
+  SYNTH_ORIGIN.y,
+  SYNTH_ORIGIN.z,
+);
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
 const clamp01 = (x: number) => THREE.MathUtils.clamp(x, 0, 1);
 
 // scratch values, reused every frame
-const rocketPos = new THREE.Vector3();
-const noseDir = new THREE.Vector3();
+const refPos = new THREE.Vector3();
+const travelDir = new THREE.Vector3();
 const targetPos = new THREE.Vector3();
 const targetQuat = new THREE.Quaternion();
 const lookTarget = new THREE.Vector3();
@@ -101,13 +113,23 @@ interface FlybyArtifact {
 const ARTIFACT_HEIGHTS = [-2, 3, -3.5, 2.5, 4.5, -2.5, 3.5, -3];
 const ARTIFACT_SCALES = [4.5, 3.8, 3.6, 3.4, 3.6, 3.8, 3.8, 3.2];
 
-export default function RocketJourney({ view }: { view: SolarView }) {
+export default function RocketJourney({
+  view,
+  navigate,
+}: {
+  view: SolarView;
+  /** Router navigation, threaded in from outside the canvas (context
+   *  doesn't cross the R3F reconciler boundary) — re-entry uses it when
+   *  the destination lives on another route */
+  navigate: (to: string) => void;
+}) {
   const rig = useRef<THREE.Group>(null);
   const streakLines = useRef<THREE.LineSegments>(null);
 
   const startPos = useRef(new THREE.Vector3());
   const startQuat = useRef(new THREE.Quaternion());
   const startCaptured = useRef(false);
+  const originView = useRef<SolarView>(view);
   const warpPos = useRef(new THREE.Vector3());
   const warpQuat = useRef(new THREE.Quaternion());
 
@@ -206,8 +228,10 @@ export default function RocketJourney({ view }: { view: SolarView }) {
       return;
     }
     // Route change mid-ride (browser back): abort and let CameraRig
-    // swoop to the new view from wherever the camera is
-    if (view !== "home") {
+    // swoop to the new view from wherever the camera is. Only a change
+    // AWAY from the journey's origin view counts — arrival navigation
+    // happens after the journey has already ended.
+    if (startCaptured.current && view !== originView.current) {
       if (rig.current) rig.current.visible = false;
       startCaptured.current = false;
       endRocketJourney();
@@ -223,18 +247,32 @@ export default function RocketJourney({ view }: { view: SolarView }) {
     if (state.phase === "boarding") {
       if (!startCaptured.current) {
         startCaptured.current = true;
+        originView.current = view;
         startPos.current.copy(camera.position);
         startQuat.current.copy(camera.quaternion);
       }
-      // Chase pose: behind the rocket, sighted along its nose
-      planetPosition(ROCKET, t, rocketPos);
-      rocketNoseDirection(t, noseDir);
-      targetPos.copy(rocketPos).addScaledVector(noseDir, -BOARD_CAM_BEHIND);
-      lookTarget.copy(rocketPos).addScaledVector(noseDir, BOARD_LOOK_AHEAD);
+      // Chase pose + travel heading, per vehicle
+      if (state.vehicle === "rocket") {
+        // Behind the rocket, sighted along its nose
+        planetPosition(ROCKET, t, refPos);
+        rocketNoseDirection(t, travelDir);
+        targetPos.copy(refPos).addScaledVector(travelDir, -BOARD_CAM_BEHIND);
+      } else if (state.vehicle === "pad") {
+        // Over the 808 pad, sighted through it toward the synth system
+        planetPosition(SYNTH_PAD, t, refPos);
+        travelDir.copy(SYNTH_ORIGIN_VEC).sub(refPos).normalize();
+        targetPos.copy(refPos).addScaledVector(travelDir, -BOARD_PAD_BEHIND);
+      } else {
+        // Return trip: no vehicle — hold position and swing the nose
+        // around toward the home system
+        targetPos.copy(startPos.current);
+        travelDir.copy(startPos.current).multiplyScalar(-1).normalize();
+      }
+      lookTarget.copy(targetPos).addScaledVector(travelDir, BOARD_LOOK_AHEAD);
       lookMatrix.lookAt(targetPos, lookTarget, UP);
       targetQuat.setFromRotationMatrix(lookMatrix);
 
-      const p = clamp01(state.phaseElapsed / BOARDING_SECONDS);
+      const p = clamp01(state.phaseElapsed / state.boardSeconds);
       const e = easeInOutCubic(p);
       camera.position.lerpVectors(startPos.current, targetPos, e);
       camera.quaternion.slerpQuaternions(startQuat.current, targetQuat, e);
@@ -244,12 +282,17 @@ export default function RocketJourney({ view }: { view: SolarView }) {
       if (p >= 1) {
         state.phase = "warp";
         state.phaseElapsed = 0;
-        startCaptured.current = false;
         flashWarp();
         // Jump along the current heading: same orientation, new spot —
         // the flash covers the position cut, the view direction doesn't
-        // change, and the solar system ends up a speck behind us
-        warpPos.current.copy(noseDir).multiplyScalar(WARP_DISTANCE);
+        // change, and every solar system ends up a speck
+        if (state.vehicle === "rocket") {
+          warpPos.current.copy(travelDir).multiplyScalar(WARP_DISTANCE);
+        } else {
+          warpPos.current
+            .copy(targetPos)
+            .addScaledVector(travelDir, TRANSIT_WARP_AHEAD);
+        }
         warpQuat.current.copy(targetQuat);
         camera.position.copy(warpPos.current);
         camera.quaternion.copy(warpQuat.current);
@@ -257,6 +300,10 @@ export default function RocketJourney({ view }: { view: SolarView }) {
           rig.current.position.copy(warpPos.current);
           rig.current.quaternion.copy(warpQuat.current);
           rig.current.visible = true;
+        }
+        // A transit must not inherit a frozen cameo from an aborted joyride
+        if (!state.cameos) {
+          artifacts.forEach((artifact) => (artifact.group.visible = false));
         }
       }
       return;
@@ -267,12 +314,14 @@ export default function RocketJourney({ view }: { view: SolarView }) {
     const intensity = THREE.MathUtils.smoothstep(
       Math.min(
         clamp01(elapsed / WARP_RAMP_IN_SECONDS),
-        clamp01((WARP_SECONDS - elapsed) / WARP_RAMP_OUT_SECONDS),
+        clamp01((state.warpSeconds - elapsed) / WARP_RAMP_OUT_SECONDS),
       ),
       0,
       1,
     );
-    state.starDim = clamp01((WARP_SECONDS - elapsed) / STAR_RETURN_SECONDS);
+    state.starDim = clamp01(
+      (state.warpSeconds - elapsed) / STAR_RETURN_SECONDS,
+    );
 
     // Gentle sway + roll inside the rig so the ride breathes without
     // moving the streak field itself
@@ -301,41 +350,55 @@ export default function RocketJourney({ view }: { view: SolarView }) {
     streaks.positionAttr.needsUpdate = true;
     streaks.material.opacity = intensity;
 
-    // Flyby cameos: each pops in far ahead, drifts outward as it nears,
-    // and exits past the shoulder of the windshield
-    for (const artifact of artifacts) {
-      const local = elapsed - artifact.spawnAt;
-      const z = ARTIFACT_Z_START + local * ARTIFACT_SPEED;
-      if (local < 0 || z > ARTIFACT_Z_EXIT) {
-        artifact.group.visible = false;
-        continue;
+    // Flyby cameos (joyride only): each pops in far ahead, drifts
+    // outward as it nears, and exits past the shoulder of the windshield
+    if (state.cameos) {
+      for (const artifact of artifacts) {
+        const local = elapsed - artifact.spawnAt;
+        const z = ARTIFACT_Z_START + local * ARTIFACT_SPEED;
+        if (local < 0 || z > ARTIFACT_Z_EXIT) {
+          artifact.group.visible = false;
+          continue;
+        }
+        artifact.group.visible = true;
+        const progress =
+          (z - ARTIFACT_Z_START) / (ARTIFACT_Z_EXIT - ARTIFACT_Z_START);
+        artifact.group.position.set(
+          artifact.side * (9 + progress * 14),
+          artifact.y,
+          z,
+        );
+        artifact.group.rotation.set(
+          artifact.tilt,
+          artifact.baseYaw + t * artifact.spin,
+          0,
+        );
       }
-      artifact.group.visible = true;
-      const progress =
-        (z - ARTIFACT_Z_START) / (ARTIFACT_Z_EXIT - ARTIFACT_Z_START);
-      artifact.group.position.set(
-        artifact.side * (9 + progress * 14),
-        artifact.y,
-        z,
-      );
-      artifact.group.rotation.set(
-        artifact.tilt,
-        artifact.baseYaw + t * artifact.spin,
-        0,
-      );
     }
 
-    if (elapsed >= WARP_SECONDS) {
-      // Drop out of lightspeed onto the home approach line; ending the
+    if (elapsed >= state.warpSeconds) {
+      // Drop out of lightspeed onto the destination's approach line
+      // (hopping routes if the destination lives elsewhere); ending the
       // journey hands the camera back to CameraRig, whose resume swoop
       // glides it the rest of the way onto the perch
-      homeViewGoal(t, camera, size, goalPos, goalLook);
+      const destView: SolarView =
+        state.destination === "synth" ? "synth" : "home";
+      viewGoal(destView, t, camera, size, goalPos, goalLook);
       forward.copy(goalLook).sub(goalPos).normalize();
-      camera.position.copy(goalPos).addScaledVector(forward, -REENTRY_DISTANCE);
+      camera.position
+        .copy(goalPos)
+        .addScaledVector(
+          forward,
+          destView === "synth" ? -SYNTH_REENTRY_DISTANCE : -REENTRY_DISTANCE,
+        );
       lookMatrix.lookAt(camera.position, goalLook, UP);
       camera.quaternion.setFromRotationMatrix(lookMatrix);
       if (rig.current) rig.current.visible = false;
+      startCaptured.current = false;
       flashWarp();
+      if (view !== destView) {
+        navigate(destView === "synth" ? "/synth" : "/home");
+      }
       endRocketJourney();
     }
   });

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -8,7 +8,9 @@ import Sun from "./Sun";
 import Asteroid from "./Asteroid";
 import Satellite from "./Satellite";
 import Rocket from "./Rocket";
+import DrumPad from "./DrumPad";
 import RocketJourney from "./RocketJourney";
+import SynthSystem from "./SynthSystem";
 import SunSvgAnchor from "./SunSvgAnchor";
 import BodyAnchors from "./BodyAnchors";
 import { ASTEROIDS, PLANETS } from "./constants";
@@ -34,9 +36,13 @@ let hasPlayedLandingIntro = false;
 const SolarScene = ({
   view,
   isNightMode,
+  onNavigate,
 }: {
   view: SolarView;
   isNightMode: boolean;
+  /** Router navigation for the lightspeed journeys (threaded through the
+   *  canvas boundary — router context doesn't cross into R3F) */
+  onNavigate: (to: string) => void;
 }) => {
   const isLanding = view === "landing";
   const [planetsRevealed, setPlanetsRevealed] = useState(
@@ -126,6 +132,12 @@ const SolarScene = ({
             config={asteroid}
             visible={view === "home"}
           />
+        ) : asteroid.name === "synthpad" ? (
+          <DrumPad
+            key={asteroid.name}
+            config={asteroid}
+            visible={view === "home"}
+          />
         ) : (
           <Asteroid
             key={asteroid.name}
@@ -134,9 +146,12 @@ const SolarScene = ({
           />
         ),
       )}
-      {/* Mounted before CameraRig: while the joyride is active it must
+      {/* The second solar system, far below this one: six knob-planets
+          around a beat-pulsing sun (the space synth) */}
+      {view === "synth" && <SynthSystem isNightMode={isNightMode} />}
+      {/* Mounted before CameraRig: while a journey is active it must
           pose the camera first each frame (CameraRig stands down) */}
-      <RocketJourney view={view} />
+      <RocketJourney view={view} navigate={onNavigate} />
       <CameraRig view={view} />
       <SunSvgAnchor />
       <BodyAnchors />

--- a/src/space3d/solar/SynthSystem.tsx
+++ b/src/space3d/solar/SynthSystem.tsx
@@ -35,6 +35,79 @@ const REVEAL_SECONDS = 1.2;
 const SWAY_RADIANS = 0.06;
 const SWAY_RATE = 0.13;
 
+/**
+ * Stepper planets (the wave selector) wear their current option: the
+ * waveform is drawn as a glowing oscilloscope trace wrapping the
+ * equator, so the planet itself displays the shape it's set to. One
+ * texture per step, index-aligned with the spec's stepNames.
+ */
+const WAVE_TEXTURE_W = 512;
+const WAVE_TEXTURE_H = 256;
+const WAVE_CYCLES = 4;
+
+function createWaveTexture(shape: string): THREE.CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = WAVE_TEXTURE_W;
+  canvas.height = WAVE_TEXTURE_H;
+  const ctx = canvas.getContext("2d")!;
+  const midY = WAVE_TEXTURE_H / 2;
+  const amp = WAVE_TEXTURE_H * 0.2;
+  const period = WAVE_TEXTURE_W / WAVE_CYCLES;
+
+  // Oscilloscope face: near-black screen with a faint axis line
+  ctx.fillStyle = "#141b2a";
+  ctx.fillRect(0, 0, WAVE_TEXTURE_W, WAVE_TEXTURE_H);
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.12)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, midY);
+  ctx.lineTo(WAVE_TEXTURE_W, midY);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#dff1ff";
+  ctx.lineWidth = 8;
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  if (shape === "sine") {
+    for (let x = 0; x <= WAVE_TEXTURE_W; x += 2) {
+      const y = midY - amp * Math.sin((x / period) * Math.PI * 2);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+  } else {
+    for (let c = 0; c < WAVE_CYCLES; c++) {
+      const x0 = c * period;
+      if (shape === "triangle") {
+        // 0 -> +amp -> -amp -> 0, tiling cleanly across cycles
+        if (c === 0) ctx.moveTo(x0, midY);
+        ctx.lineTo(x0 + period * 0.25, midY - amp);
+        ctx.lineTo(x0 + period * 0.75, midY + amp);
+        ctx.lineTo(x0 + period, midY);
+      } else if (shape === "saw") {
+        // Ramp up, vertical drop
+        if (c === 0) ctx.moveTo(x0, midY + amp);
+        ctx.lineTo(x0 + period, midY - amp);
+        ctx.lineTo(x0 + period, midY + amp);
+      } else {
+        // square: high half, low half, hard edges
+        if (c === 0) ctx.moveTo(x0, midY - amp);
+        ctx.lineTo(x0 + period * 0.5, midY - amp);
+        ctx.lineTo(x0 + period * 0.5, midY + amp);
+        ctx.lineTo(x0 + period, midY + amp);
+        if (c < WAVE_CYCLES - 1) ctx.lineTo(x0 + period, midY - amp);
+      }
+    }
+  }
+  ctx.stroke();
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = 4;
+  return texture;
+}
+
 const ORIGIN = new THREE.Vector3(
   SYNTH_ORIGIN.x,
   SYNTH_ORIGIN.y,
@@ -87,6 +160,18 @@ function KnobPlanet({
   const orbitMaterial = useRef<THREE.LineBasicMaterial>(null);
   const glow = useRef(0);
 
+  // Stepper planets carry one oscilloscope texture per option; the
+  // frame loop swaps the active one in as the value changes
+  const stepTextures = useMemo(
+    () => spec.stepNames?.map((name) => createWaveTexture(name)) ?? null,
+    [spec.stepNames],
+  );
+  useEffect(
+    () => () => stepTextures?.forEach((texture) => texture.dispose()),
+    [stepTextures],
+  );
+  const appliedStep = useRef(-1);
+
   const orbitLine = useMemo(() => {
     const points: THREE.Vector3[] = [];
     for (let i = 0; i <= 128; i++) {
@@ -116,17 +201,32 @@ function KnobPlanet({
         Math.sin(phase) * spec.orbitRadius,
       );
     }
-    // The knob's value is legible from orbit: higher = faster spin
+    // The knob's value is legible from orbit: higher = faster spin.
+    // Steppers scroll at a steady readable pace instead — their spin
+    // is a ticker for the oscilloscope trace, not a value display.
     if (mesh.current) {
-      mesh.current.rotation.y += delta * (0.3 + value * 2.2);
+      mesh.current.rotation.y +=
+        delta * (stepTextures ? 0.55 : 0.3 + value * 2.2);
     }
     if (surface.current) {
       const active = synthUiState.activeKnob === spec.param;
       glow.current +=
         ((active ? 1 : 0) - glow.current) * Math.min(delta * 6, 1);
-      surface.current.emissiveIntensity =
-        (0.22 + value * 0.25 + glow.current * 0.5) * reveal.current;
+      // Steppers glow bright and flat — the texture IS the display
+      surface.current.emissiveIntensity = stepTextures
+        ? (0.8 + glow.current * 0.4) * reveal.current
+        : (0.22 + value * 0.25 + glow.current * 0.5) * reveal.current;
       surface.current.opacity = reveal.current;
+      // Show the currently selected waveform on the planet's face
+      if (stepTextures) {
+        const step = Math.round(value * (stepTextures.length - 1));
+        if (step !== appliedStep.current) {
+          appliedStep.current = step;
+          surface.current.map = stepTextures[step];
+          surface.current.emissiveMap = stepTextures[step];
+          surface.current.needsUpdate = true;
+        }
+      }
     }
     if (orbitMaterial.current) {
       orbitMaterial.current.opacity = 0.22 * reveal.current;
@@ -144,19 +244,29 @@ function KnobPlanet({
         />
       </lineLoop>
       <group ref={group}>
-        <mesh ref={mesh}>
-          <sphereGeometry args={[spec.radius, 32, 24]} />
-          <meshStandardMaterial
-            ref={surface}
-            color={spec.color}
-            roughness={0.45}
-            metalness={0.1}
-            emissive={spec.color}
-            emissiveIntensity={0}
-            transparent
-            opacity={0}
-          />
-        </mesh>
+        {/* Steppers are tipped 90° so the equator — where the trace is
+            drawn — faces the top-down camera instead of the blank pole;
+            the mesh's own spin then scrolls the trace like a ticker */}
+        <group rotation={stepTextures ? [Math.PI / 2, 0, 0] : [0, 0, 0]}>
+          <mesh ref={mesh}>
+            <sphereGeometry args={[spec.radius, 32, 24]} />
+            {/* Steppers show their oscilloscope texture true-color (white
+              base, white emissive so the trace glows); plain knobs get
+              the spec's flat color treatment */}
+            <meshStandardMaterial
+              ref={surface}
+              color={stepTextures ? "#ffffff" : spec.color}
+              map={stepTextures ? stepTextures[0] : null}
+              roughness={0.45}
+              metalness={0.1}
+              emissive={stepTextures ? "#ffffff" : spec.color}
+              emissiveMap={stepTextures ? stepTextures[0] : null}
+              emissiveIntensity={0}
+              transparent
+              opacity={0}
+            />
+          </mesh>
+        </group>
       </group>
     </>
   );

--- a/src/space3d/solar/SynthSystem.tsx
+++ b/src/space3d/solar/SynthSystem.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+import { projectBody, type ProjectedBody } from "./projection";
+import { liveElementById } from "../svgTracking";
+import {
+  SYNTH_KNOBS,
+  SYNTH_ORIGIN,
+  SYNTH_SUN_ANCHOR_ID,
+  synthKnobAnchorId,
+  synthUiState,
+  type SynthKnobSpec,
+} from "../../synthSpec";
+import { getParam, synthState } from "../../synthAudio";
+
+/**
+ * The synth solar system (/synth): a second, stranger system parked far
+ * below the real one — a magenta sun that pulses with the beat, ringed
+ * by six knob-planets, one per synth parameter. The planets ARE the
+ * knobs: their DOM overlays (Synth.tsx) take the pointer input, and
+ * this scene answers back — a planet spins faster the higher its value
+ * and glows while grabbed.
+ *
+ * The overlay gluing is BodyAnchors' pattern, run locally: every frame
+ * each knob planet (and the sun's play button) is projected through the
+ * camera and its overlay is positioned around it. Mounted only on the
+ * synth view, and everything fades in on arrival.
+ */
+
+const SUN_RADIUS = 2.2;
+const REVEAL_SECONDS = 1.2;
+/** Planets sway a few degrees around their bearing instead of orbiting
+ *  away — knobs that wander off-screen aren't knobs */
+const SWAY_RADIANS = 0.06;
+const SWAY_RATE = 0.13;
+
+const ORIGIN = new THREE.Vector3(
+  SYNTH_ORIGIN.x,
+  SYNTH_ORIGIN.y,
+  SYNTH_ORIGIN.z,
+);
+
+// scratch values, reused every frame
+const worldPos = new THREE.Vector3();
+const projected: ProjectedBody = { x: 0, y: 0, projR: 0, inFront: false };
+
+/** Position the overlay element around the body's projection (the
+ *  BodyAnchors recipe). */
+function glueOverlay(
+  el: HTMLElement,
+  persp: THREE.PerspectiveCamera,
+  size: { width: number; height: number },
+  radius: number,
+  ringScale: number,
+  minSizePx: number,
+) {
+  projectBody(persp, size, worldPos, radius, projected);
+  if (!projected.inFront) {
+    el.style.visibility = "hidden";
+    return;
+  }
+  const sizePx = Math.max(2 * projected.projR * ringScale, minSizePx);
+  el.style.position = "fixed";
+  el.style.margin = "0";
+  el.style.left = `${projected.x - sizePx / 2}px`;
+  el.style.top = `${projected.y - sizePx / 2}px`;
+  el.style.width = `${sizePx}px`;
+  el.style.height = `${sizePx}px`;
+  el.style.visibility = "visible";
+}
+
+function KnobPlanet({
+  spec,
+  index,
+  orbitColor,
+  reveal,
+}: {
+  spec: SynthKnobSpec;
+  index: number;
+  orbitColor: string;
+  reveal: React.MutableRefObject<number>;
+}) {
+  const group = useRef<THREE.Group>(null);
+  const mesh = useRef<THREE.Mesh>(null);
+  const surface = useRef<THREE.MeshStandardMaterial>(null);
+  const orbitMaterial = useRef<THREE.LineBasicMaterial>(null);
+  const glow = useRef(0);
+
+  const orbitLine = useMemo(() => {
+    const points: THREE.Vector3[] = [];
+    for (let i = 0; i <= 128; i++) {
+      const a = (i / 128) * Math.PI * 2;
+      points.push(
+        new THREE.Vector3(
+          Math.cos(a) * spec.orbitRadius,
+          0,
+          Math.sin(a) * spec.orbitRadius,
+        ),
+      );
+    }
+    return new THREE.BufferGeometry().setFromPoints(points);
+  }, [spec.orbitRadius]);
+  useEffect(() => () => orbitLine.dispose(), [orbitLine]);
+
+  useFrame(({ clock }, delta) => {
+    const t = clock.elapsedTime;
+    const value = getParam(spec.param);
+
+    if (group.current) {
+      const phase =
+        spec.orbitPhase + SWAY_RADIANS * Math.sin(t * SWAY_RATE + index * 1.7);
+      group.current.position.set(
+        Math.cos(phase) * spec.orbitRadius,
+        0,
+        Math.sin(phase) * spec.orbitRadius,
+      );
+    }
+    // The knob's value is legible from orbit: higher = faster spin
+    if (mesh.current) {
+      mesh.current.rotation.y += delta * (0.3 + value * 2.2);
+    }
+    if (surface.current) {
+      const active = synthUiState.activeKnob === spec.param;
+      glow.current +=
+        ((active ? 1 : 0) - glow.current) * Math.min(delta * 6, 1);
+      surface.current.emissiveIntensity =
+        (0.22 + value * 0.25 + glow.current * 0.5) * reveal.current;
+      surface.current.opacity = reveal.current;
+    }
+    if (orbitMaterial.current) {
+      orbitMaterial.current.opacity = 0.22 * reveal.current;
+    }
+  });
+
+  return (
+    <>
+      <lineLoop geometry={orbitLine}>
+        <lineBasicMaterial
+          ref={orbitMaterial}
+          color={orbitColor}
+          transparent
+          opacity={0}
+        />
+      </lineLoop>
+      <group ref={group}>
+        <mesh ref={mesh}>
+          <sphereGeometry args={[spec.radius, 32, 24]} />
+          <meshStandardMaterial
+            ref={surface}
+            color={spec.color}
+            roughness={0.45}
+            metalness={0.1}
+            emissive={spec.color}
+            emissiveIntensity={0}
+            transparent
+            opacity={0}
+          />
+        </mesh>
+      </group>
+    </>
+  );
+}
+
+export default function SynthSystem({ isNightMode }: { isNightMode: boolean }) {
+  const size = useThree((s) => s.size);
+  const sun = useRef<THREE.Mesh>(null);
+  const sunMaterial = useRef<THREE.MeshStandardMaterial>(null);
+  const glowMaterial = useRef<THREE.MeshBasicMaterial>(null);
+  // Arrival fade, shared with every knob planet
+  const reveal = useRef(0);
+
+  useFrame(({ camera, clock }, delta) => {
+    const t = clock.elapsedTime;
+    reveal.current = Math.min(1, reveal.current + delta / REVEAL_SECONDS);
+
+    // The beat: synthAudio spikes pulse to 1 on each note; decay it here
+    // and swell the sun with it
+    synthState.pulse = Math.max(0, synthState.pulse - delta * 2.4);
+    const swell = 1 + 0.16 * synthState.pulse;
+    if (sun.current) sun.current.scale.setScalar(swell);
+    if (sunMaterial.current) {
+      sunMaterial.current.emissiveIntensity =
+        (1.1 + synthState.pulse * 0.9) * reveal.current;
+      sunMaterial.current.opacity = reveal.current;
+    }
+    if (glowMaterial.current) {
+      glowMaterial.current.opacity =
+        (0.26 + synthState.pulse * 0.12) * reveal.current;
+    }
+
+    // Glue the /synth overlays to their bodies (BodyAnchors' job, done
+    // locally for the synth system's own cast)
+    const persp = camera as THREE.PerspectiveCamera;
+    persp.updateMatrixWorld();
+    for (let i = 0; i < SYNTH_KNOBS.length; i++) {
+      const spec = SYNTH_KNOBS[i];
+      const el = liveElementById(
+        synthKnobAnchorId(spec.param),
+      ) as HTMLElement | null;
+      if (!el) continue;
+      const phase =
+        spec.orbitPhase + SWAY_RADIANS * Math.sin(t * SWAY_RATE + i * 1.7);
+      worldPos.set(
+        ORIGIN.x + Math.cos(phase) * spec.orbitRadius,
+        ORIGIN.y,
+        ORIGIN.z + Math.sin(phase) * spec.orbitRadius,
+      );
+      glueOverlay(el, persp, size, spec.radius, 1.5, 48);
+    }
+    const sunEl = liveElementById(SYNTH_SUN_ANCHOR_ID) as HTMLElement | null;
+    if (sunEl) {
+      worldPos.copy(ORIGIN);
+      glueOverlay(sunEl, persp, size, SUN_RADIUS, 1.15, 64);
+    }
+  });
+
+  return (
+    <group position={[ORIGIN.x, ORIGIN.y, ORIGIN.z]}>
+      {/* This system brings its own light — the real sun is 1600 units
+          away and its point light doesn't reach */}
+      <ambientLight intensity={0.3} />
+      <pointLight color="#e6d4ff" intensity={2.2} decay={0} />
+      <mesh ref={sun}>
+        <sphereGeometry args={[SUN_RADIUS, 48, 32]} />
+        <meshStandardMaterial
+          ref={sunMaterial}
+          color="#3a1f52"
+          emissive="#c26bff"
+          emissiveIntensity={0}
+          roughness={0.6}
+          transparent
+          opacity={0}
+        />
+      </mesh>
+      {/* Soft additive halo, same back-side-shell trick as the corona */}
+      <mesh scale={1.6}>
+        <sphereGeometry args={[SUN_RADIUS, 32, 24]} />
+        <meshBasicMaterial
+          ref={glowMaterial}
+          color="#7a3fd1"
+          transparent
+          opacity={0}
+          side={THREE.BackSide}
+          blending={THREE.AdditiveBlending}
+          depthWrite={false}
+        />
+      </mesh>
+      {SYNTH_KNOBS.map((spec, i) => (
+        <KnobPlanet
+          key={spec.param}
+          spec={spec}
+          index={i}
+          orbitColor={isNightMode ? "#ffffff" : "#141428"}
+          reveal={reveal}
+        />
+      ))}
+    </group>
+  );
+}

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -158,9 +158,23 @@ export const ASTEROIDS: SolarPlanetConfig[] = [
     spinSpeed: 0.2 * SPEED_SCALE,
     yOffset: ASTEROID_Y + 1.4,
   },
+  {
+    // Rendered as the floating 808 drum pad (DrumPad.tsx). Clicking it
+    // warps to the synth solar system (/synth). High in the sky on the
+    // other flank of the sun from the rocket.
+    name: "synthpad",
+    kind: "mercury",
+    radius: 0.4,
+    orbitRadius: 4.9,
+    orbitSpeed: EARTH.orbitSpeed,
+    orbitPhase: EARTH.orbitPhase - 0.42,
+    spinSpeed: 0.2 * SPEED_SCALE,
+    yOffset: ASTEROID_Y + 1.15,
+  },
 ];
 
 export const ROCKET = ASTEROIDS.find((a) => a.name === "rocket")!;
+export const SYNTH_PAD = ASTEROIDS.find((a) => a.name === "synthpad")!;
 
 /** Earth's moon — orbits Earth (not the sun), in the same XZ plane. */
 export const MOON = {

--- a/src/synthAudio.ts
+++ b/src/synthAudio.ts
@@ -131,10 +131,36 @@ export const getParam = (param: SynthParam): number => params[param];
 
 const midiHz = (midi: number) => 440 * Math.pow(2, (midi - 69) / 12);
 
+// ── Note events ──
+// Fired once per audible note — arp steps and keyboard presses alike —
+// at the note's audible moment (the arp schedules notes up to ~160ms
+// ahead, so emission is deferred to match). The /synth page uses this
+// to march the "andrewhunt" letter highlight in time with the music.
+type NoteListener = () => void;
+const noteListeners = new Set<NoteListener>();
+
+/** Subscribe to every audible note; returns an unsubscribe. */
+export function onSynthNote(listener: NoteListener): () => void {
+  noteListeners.add(listener);
+  return () => {
+    noteListeners.delete(listener);
+  };
+}
+
+function emitNoteAt(when: number): void {
+  if (!ctx || noteListeners.size === 0) return;
+  const delayMs = Math.max(0, (when - ctx.currentTime) * 1000);
+  window.setTimeout(
+    () => noteListeners.forEach((listener) => listener()),
+    delayMs,
+  );
+}
+
 /** One synth voice: two slightly-detuned oscillators through an
  *  envelope gain into the shared bus. */
 function spawnVoice(midi: number, when: number, velocity: number) {
   if (!ctx) return null;
+  emitNoteAt(when);
   const env = ctx.createGain();
   env.gain.setValueAtTime(0.0001, when);
   env.gain.exponentialRampToValueAtTime(velocity, when + 0.015);

--- a/src/synthAudio.ts
+++ b/src/synthAudio.ts
@@ -1,0 +1,236 @@
+import type { SynthParam } from "./synthSpec";
+
+/**
+ * The space synth's Web Audio engine — a little subtractive poly synth
+ * with a built-in arpeggiator, all knobs driven by the planet overlays
+ * on /synth. Three-free and page-agnostic: DOM components call the
+ * exported controls, the 3D scene only reads `synthState` (pulse level,
+ * playing flag) to animate the sun.
+ *
+ * Graph:  voices (2 detuned oscs + envelope each)
+ *           -> voiceBus -> lowpass filter -> master -> destination
+ *                          filter -> delay (feedback loop) -> wet -> master
+ *         LFO -> filter.frequency ("gravity wobble")
+ *
+ * The AudioContext is created lazily inside a user gesture
+ * (ensureAudio() runs in the 808-pad click handler and in every /synth
+ * interaction), so autoplay policy never leaves the synth muted.
+ */
+
+/** Read by SynthSystem every frame; pulse spikes on each arp note and
+ *  the scene eases the sun's scale toward it. */
+export const synthState = {
+  ready: false,
+  playing: false,
+  /** 0..1, set to 1 on each note, decayed by the scene's frame loop */
+  pulse: 0,
+};
+
+/** Knob values, all normalized 0..1 (defaults = a pleasant patch) */
+const params: Record<SynthParam, number> = {
+  wave: 2 / 3, // saw
+  cutoff: 0.55,
+  resonance: 0.25,
+  echo: 0.35,
+  wobble: 0.12,
+  tempo: 0.45,
+};
+
+const WAVEFORMS: OscillatorType[] = ["sine", "triangle", "sawtooth", "square"];
+
+let ctx: AudioContext | null = null;
+let master: GainNode;
+let voiceBus: GainNode;
+let filter: BiquadFilterNode;
+let delay: DelayNode;
+let delayFeedback: GainNode;
+let delayWet: GainNode;
+let lfo: OscillatorNode;
+let lfoGain: GainNode;
+
+const currentWave = (): OscillatorType =>
+  WAVEFORMS[Math.round(params.wave * (WAVEFORMS.length - 1))];
+
+const cutoffHz = () => 120 * Math.pow(8000 / 120, params.cutoff);
+const arpStepSeconds = () => 60 / (70 + params.tempo * 110) / 2; // 8ths at 70-180 BPM
+
+function applyParam(param: SynthParam): void {
+  if (!ctx) return;
+  const t = ctx.currentTime;
+  switch (param) {
+    case "wave":
+      break; // picked up by the next note
+    case "cutoff":
+      filter.frequency.setTargetAtTime(cutoffHz(), t, 0.03);
+      break;
+    case "resonance":
+      filter.Q.setTargetAtTime(0.5 + params.resonance * 14, t, 0.03);
+      break;
+    case "echo":
+      delayWet.gain.setTargetAtTime(params.echo * 0.55, t, 0.03);
+      delayFeedback.gain.setTargetAtTime(0.1 + params.echo * 0.55, t, 0.03);
+      break;
+    case "wobble":
+      lfoGain.gain.setTargetAtTime(params.wobble * 2400, t, 0.03);
+      lfo.frequency.setTargetAtTime(0.8 + params.wobble * 5, t, 0.03);
+      break;
+    case "tempo":
+      break; // the scheduler reads it per step
+  }
+}
+
+/** Create/resume the context. Must be called from a user gesture at
+ *  least once; safe to call repeatedly. Returns readiness. */
+export function ensureAudio(): boolean {
+  if (typeof AudioContext === "undefined") return false;
+  if (!ctx) {
+    ctx = new AudioContext();
+    master = ctx.createGain();
+    master.gain.value = 0.16;
+    master.connect(ctx.destination);
+
+    filter = ctx.createBiquadFilter();
+    filter.type = "lowpass";
+    filter.connect(master);
+
+    voiceBus = ctx.createGain();
+    voiceBus.connect(filter);
+
+    // Space echo: post-filter tap with a feedback loop
+    delay = ctx.createDelay(1.5);
+    delay.delayTime.value = 0.34;
+    delayFeedback = ctx.createGain();
+    delayWet = ctx.createGain();
+    filter.connect(delay);
+    delay.connect(delayFeedback);
+    delayFeedback.connect(delay);
+    delay.connect(delayWet);
+    delayWet.connect(master);
+
+    lfo = ctx.createOscillator();
+    lfo.type = "triangle";
+    lfoGain = ctx.createGain();
+    lfoGain.gain.value = 0;
+    lfo.connect(lfoGain);
+    lfoGain.connect(filter.frequency);
+    lfo.start();
+
+    (Object.keys(params) as SynthParam[]).forEach(applyParam);
+    synthState.ready = true;
+  }
+  if (ctx.state === "suspended") void ctx.resume();
+  return true;
+}
+
+export function setParam(param: SynthParam, value: number): void {
+  params[param] = Math.min(1, Math.max(0, value));
+  applyParam(param);
+}
+
+export const getParam = (param: SynthParam): number => params[param];
+
+const midiHz = (midi: number) => 440 * Math.pow(2, (midi - 69) / 12);
+
+/** One synth voice: two slightly-detuned oscillators through an
+ *  envelope gain into the shared bus. */
+function spawnVoice(midi: number, when: number, velocity: number) {
+  if (!ctx) return null;
+  const env = ctx.createGain();
+  env.gain.setValueAtTime(0.0001, when);
+  env.gain.exponentialRampToValueAtTime(velocity, when + 0.015);
+  env.connect(voiceBus);
+  const oscs = [0, 1].map((i) => {
+    const osc = ctx!.createOscillator();
+    osc.type = currentWave();
+    osc.frequency.setValueAtTime(midiHz(midi), when);
+    osc.detune.value = i === 0 ? -6 : 6;
+    osc.connect(env);
+    osc.start(when);
+    return osc;
+  });
+  return { env, oscs };
+}
+
+function releaseVoice(
+  voice: { env: GainNode; oscs: OscillatorNode[] },
+  when: number,
+  releaseSeconds: number,
+) {
+  voice.env.gain.cancelScheduledValues(when);
+  voice.env.gain.setTargetAtTime(0.0001, when, releaseSeconds / 4);
+  voice.oscs.forEach((osc) => osc.stop(when + releaseSeconds + 0.1));
+}
+
+// ── Keyboard voices ──
+const MAX_HELD = 8;
+const held = new Map<number, { env: GainNode; oscs: OscillatorNode[] }>();
+
+export function noteOn(midi: number): void {
+  if (!ensureAudio() || !ctx || held.has(midi) || held.size >= MAX_HELD) {
+    return;
+  }
+  const voice = spawnVoice(midi, ctx.currentTime, 0.42);
+  if (voice) {
+    held.set(midi, voice);
+    synthState.pulse = 1;
+  }
+}
+
+export function noteOff(midi: number): void {
+  const voice = held.get(midi);
+  if (!voice || !ctx) return;
+  held.delete(midi);
+  releaseVoice(voice, ctx.currentTime, 0.35);
+}
+
+// ── Arpeggiator ──
+// A spacey A-minor-pentatonic climb; the tempo knob stretches the steps
+const ARP_PATTERN = [45, 52, 57, 60, 64, 67, 64, 60, 57, 52, 62, 55];
+let arpTimer: number | null = null;
+let arpStep = 0;
+let nextNoteTime = 0;
+const LOOKAHEAD_S = 0.16;
+const TICK_MS = 60;
+
+function arpTick() {
+  if (!ctx) return;
+  while (nextNoteTime < ctx.currentTime + LOOKAHEAD_S) {
+    const midi = ARP_PATTERN[arpStep % ARP_PATTERN.length];
+    const step = arpStepSeconds();
+    const voice = spawnVoice(midi, nextNoteTime, 0.5);
+    if (voice) releaseVoice(voice, nextNoteTime + step * 0.85, 0.3);
+    // Close enough to the audible moment (≤ the lookahead) for the sun
+    synthState.pulse = 1;
+    arpStep++;
+    nextNoteTime += step;
+  }
+  arpTimer = window.setTimeout(arpTick, TICK_MS);
+}
+
+export function startArp(): void {
+  if (!ensureAudio() || !ctx || synthState.playing) return;
+  synthState.playing = true;
+  arpStep = 0;
+  nextNoteTime = ctx.currentTime + 0.06;
+  arpTick();
+}
+
+function stopArp(): void {
+  synthState.playing = false;
+  if (arpTimer !== null) {
+    window.clearTimeout(arpTimer);
+    arpTimer = null;
+  }
+}
+
+export const toggleArp = (): void =>
+  synthState.playing ? stopArp() : startArp();
+
+/** Leaving /synth: silence everything but keep the context alive so a
+ *  return trip picks up instantly. */
+export function silenceSynth(): void {
+  stopArp();
+  if (!ctx) return;
+  held.forEach((voice) => releaseVoice(voice, ctx!.currentTime, 0.2));
+  held.clear();
+}

--- a/src/synthSpec.ts
+++ b/src/synthSpec.ts
@@ -47,10 +47,13 @@ export const SYNTH_CAM_HEIGHT = 32;
  */
 export const SYNTH_KNOBS: SynthKnobSpec[] = [
   {
+    // Stepper: click cycles the waveform, and the planet wears the
+    // selected shape as an oscilloscope trace (bigger radius so the
+    // trace stays legible from the top-down camera)
     param: "wave",
     label: "wave",
     color: "#cfd6dd",
-    radius: 0.8,
+    radius: 1.15,
     orbitRadius: 4.2,
     orbitPhase: 5.9,
     steps: 4,

--- a/src/synthSpec.ts
+++ b/src/synthSpec.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared spec for the space synth (the 808-pad easter egg): the synth
+ * solar system's world placement, the knob-planet layout, and the DOM
+ * anchor ids that glue the /synth overlays to the 3D bodies. Three-free
+ * so the page components (Synth.tsx, SolarOverlays) can import it
+ * without dragging three.js out of its lazy chunk; the 3D side
+ * (SynthSystem, CameraRig, RocketJourney) reads the same numbers.
+ */
+
+export type SynthParam =
+  "wave" | "cutoff" | "resonance" | "echo" | "wobble" | "tempo";
+
+export interface SynthKnobSpec {
+  param: SynthParam;
+  /** Overlay label under the planet */
+  label: string;
+  /** Planet surface color (also its glow) */
+  color: string;
+  /** Planet radius, world units */
+  radius: number;
+  orbitRadius: number;
+  /** Fixed bearing on the ring, radians (planets sway around it but
+   *  don't orbit away — knobs that wander off-screen aren't knobs) */
+  orbitPhase: number;
+  /** Steps for discrete knobs (wave: 4); continuous when absent */
+  steps?: number;
+  /** Labels for discrete steps, shown instead of a percentage */
+  stepNames?: string[];
+}
+
+/**
+ * The synth system's sun sits far below the real solar system — past
+ * the camera's far plane from either vantage, so the two systems can
+ * never photobomb each other.
+ */
+export const SYNTH_ORIGIN = { x: 0, y: -1600, z: 0 };
+
+/** Top-down synth view: camera height over the synth sun (mirrors the
+ *  landing view's straight-down orbital-diagram framing) */
+export const SYNTH_CAM_HEIGHT = 32;
+
+/**
+ * The knob planets. Screen mapping under the top-down camera: world +x
+ * is screen-right, world +z is screen-down. The outer planets ride
+ * bearings near the vertical axis (|x| ≲ 6.6) so the whole panel stays
+ * on screen down to phone aspect.
+ */
+export const SYNTH_KNOBS: SynthKnobSpec[] = [
+  {
+    param: "wave",
+    label: "wave",
+    color: "#cfd6dd",
+    radius: 0.8,
+    orbitRadius: 4.2,
+    orbitPhase: 5.9,
+    steps: 4,
+    stepNames: ["sine", "triangle", "saw", "square"],
+  },
+  {
+    param: "cutoff",
+    label: "nebula filter",
+    color: "#9e80f9",
+    radius: 1.5,
+    orbitRadius: 7.5,
+    orbitPhase: 0.75,
+  },
+  {
+    param: "resonance",
+    label: "ring resonance",
+    color: "#ff6b6b",
+    radius: 1,
+    orbitRadius: 6,
+    orbitPhase: 2.6,
+  },
+  {
+    param: "echo",
+    label: "space echo",
+    color: "#5efffc",
+    radius: 1.1,
+    orbitRadius: 9,
+    orbitPhase: 4,
+  },
+  {
+    param: "wobble",
+    label: "gravity wobble",
+    color: "#ffd23f",
+    radius: 0.9,
+    orbitRadius: 7,
+    orbitPhase: 1.75,
+  },
+  {
+    param: "tempo",
+    label: "warp tempo",
+    color: "#7ccf4f",
+    radius: 1.05,
+    orbitRadius: 10,
+    orbitPhase: 4.9,
+  },
+];
+
+export const synthKnobAnchorId = (param: SynthParam) => `synth-knob-${param}`;
+export const SYNTH_SUN_ANCHOR_ID = "synth-sun-button";
+
+/**
+ * Hover/drag flags for the knob overlays, bridged into the WebGL scene
+ * the same way solarHover works: the DOM sets them, SynthSystem reads
+ * them per frame to glow the hovered planet.
+ */
+export const synthUiState = {
+  activeKnob: null as SynthParam | null,
+};


### PR DESCRIPTION
## What

Follow-up to the rocket joyride (#80) — the lightspeed plumbing now goes somewhere.

**The space synth (/synth)** — a floating TR-808 pad joins the link bodies on /home. Clicking it rides the warp (short transit, streaks only — the flyby cameos stay exclusive to the joyride) to a second solar system parked 1,600 units below the real one, where six planets are the knobs of a little Web Audio subtractive synth:

- **wave · nebula filter · ring resonance · space echo · gravity wobble · warp tempo** — drag a planet vertically (or scroll / arrow-key it; they're real buttons) to turn its knob; a ring arc shows the value and the planet spins faster + glows the higher it's set
- the magenta **sun is the power switch** for a built-in pentatonic arpeggiator and pulses with every note; **keys A–K** play notes live
- the 808-pad click unlocks the AudioContext, so the beat is already playing when you drop out of lightspeed; **Back to Earth** warps home
- journey state machine grew destinations/vehicles (joyride / transit / return); `CameraRig` gained the synth view; router navigation is threaded through the canvas boundary for mid-flash route hops

**Wave planet is a click-to-cycle stepper** — discrete options aren't a sliding scale: clicking advances sine → triangle → saw → square (wrapping), the arc is gone, and the planet wears the selected waveform as a glowing oscilloscope trace (tipped so the trace band faces the top-down camera, scrolling like a ticker).

**Name ticker keeps time** — on /synth every audible note (arp step or keyboard press) advances the highlighted "andrewhunt" letter, so the green letter marches to the warp tempo and holds still in silence. Everywhere else the 200ms clock ticker is untouched.

## Testing

- `tsc` / `eslint` / `build` / `knip` all clean
- Verified in-browser end to end: pad tooltip + transit + return journeys, knob drags (filter sweep with live readout), stepper cycling through all four waveforms, keyboard notes, note-synced ticker (frozen in silence, exactly +1 per manual note), abort paths, day + night palettes, mobile + desktop layouts

**Also included** — copy change from Andrew's local master: the music toggle now reads "Listen to my space music (real analog synths! no ai)".
