### PR TITLE
Home layout: link trio arcs over the sun, rocket splits the Earth→edge gap, responsive placement

### DIFF
--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -20,6 +20,7 @@ import {
   startSynthJourney,
 } from "./rocketJourney";
 import { ensureAudio } from "./synthAudio";
+import useWindowSize from "./useWindowSize";
 
 /**
  * DOM overlays for the home page's 3D bodies. The canvases never take
@@ -62,6 +63,9 @@ const ASTEROID_LINKS = [
 
 const SolarOverlays = () => {
   const navigate = useNavigate();
+  // The 808 pad sits out on phones (SolarScene hides the 3D pad; this
+  // hides its click target so no invisible button floats in the sky)
+  const isPhone = useWindowSize() === "sm";
   // Navigating away doesn't fire pointerleave — don't leave a hover
   // glow stuck on
   React.useEffect(
@@ -154,42 +158,44 @@ const SolarOverlays = () => {
       {/* The floating 808 pad: warps to the synth solar system (/synth).
           Unlocking the AudioContext inside this click is what lets the
           beat start playing the moment you land. */}
-      <TooltipProvider delayDuration={100}>
-        <Tooltip disableHoverableContent>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              id={asteroidAnchorId("synthpad")}
-              className="asteroid-link"
-              aria-label="Space jam studio"
-              onClick={() => {
-                ensureAudio();
-                startSynthJourney();
-                // The studio lives at /synth: flip the URL as the ride
-                // boards (shareable, back-button aborts the trip) rather
-                // than after the warp lands. Only if the journey actually
-                // launched — the 3D driver may be dead (crashed canvas).
-                if (journeyState.phase !== "idle") {
-                  void navigate("/synth");
-                }
-              }}
-              onPointerEnter={() => {
-                hoverState.asteroid = "synthpad";
-              }}
-              onPointerLeave={() => {
-                if (hoverState.asteroid === "synthpad") {
-                  hoverState.asteroid = null;
-                }
-              }}
-            >
-              <BodyOutline outlineId={asteroidOutlineId("synthpad")} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent updatePositionStrategy="always">
-            <p>Space jam studio</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      {!isPhone && (
+        <TooltipProvider delayDuration={100}>
+          <Tooltip disableHoverableContent>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                id={asteroidAnchorId("synthpad")}
+                className="asteroid-link"
+                aria-label="Space jam studio"
+                onClick={() => {
+                  ensureAudio();
+                  startSynthJourney();
+                  // The studio lives at /synth: flip the URL as the ride
+                  // boards (shareable, back-button aborts the trip) rather
+                  // than after the warp lands. Only if the journey actually
+                  // launched — the 3D driver may be dead (crashed canvas).
+                  if (journeyState.phase !== "idle") {
+                    void navigate("/synth");
+                  }
+                }}
+                onPointerEnter={() => {
+                  hoverState.asteroid = "synthpad";
+                }}
+                onPointerLeave={() => {
+                  if (hoverState.asteroid === "synthpad") {
+                    hoverState.asteroid = null;
+                  }
+                }}
+              >
+                <BodyOutline outlineId={asteroidOutlineId("synthpad")} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent updatePositionStrategy="always">
+              <p>Space jam studio</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
     </>
   );
 };

--- a/src/space3d/solar/Satellite.tsx
+++ b/src/space3d/solar/Satellite.tsx
@@ -47,7 +47,17 @@ const Z_AXIS = new THREE.Vector3(0, 0, 1);
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
 const UP = new THREE.Vector3(0, 1, 0);
 const earthPos = new THREE.Vector3();
+const sideDir = new THREE.Vector3();
 const legsDir = new THREE.Vector3();
+
+/** How far the leg cone swings off dead-away-from-camera: enough right
+ *  (+side) and down (-y) drift that the trailing legs still read as a
+ *  cone instead of hiding edge-on behind the sphere. */
+const LEGS_SIDE_DRIFT = 0.35;
+const LEGS_DOWN_DRIFT = 0.05;
+const legsMatrix = new THREE.Matrix4();
+const legsBack = new THREE.Vector3();
+const ZERO = new THREE.Vector3(0, 0, 0);
 
 export default function Satellite({
   config,
@@ -195,12 +205,25 @@ export default function Satellite({
       materials.badge.opacity = opacity.current;
     }
 
-    // Point the leg cone at the co-rotating frame's screen-right (the
-    // rotation Z->side is about +Y, so the beacon stays world-up)
+    // Point the leg cone mostly AWAY from the camera in the co-rotating
+    // frame (the home camera looks along the sun→Earth axis, so "away"
+    // is the Earth direction): the GitHub sphere leads, the legs trail
+    // behind it, drifted right + down so the cone reads as a shape
+    // instead of hiding dead-on behind the sphere.
     if (rig.current) {
       planetPosition(EARTH, t, earthPos);
-      legsDir.copy(earthPos).normalize().cross(UP).normalize();
-      rig.current.quaternion.setFromUnitVectors(Z_AXIS, legsDir);
+      earthPos.normalize(); // ≈ camera forward on the home perch
+      sideDir.copy(earthPos).cross(UP).normalize(); // screen-right
+      legsDir
+        .copy(earthPos)
+        .addScaledVector(sideDir, LEGS_SIDE_DRIFT)
+        .addScaledVector(UP, -LEGS_DOWN_DRIFT)
+        .normalize();
+      // lookAt aims local -Z, so sight down the NEGATED direction; this
+      // keeps local +Y world-up (the beacon stays on top of the head,
+      // which a minimal Z→dir rotation does not guarantee)
+      legsMatrix.lookAt(ZERO, legsBack.copy(legsDir).negate(), UP);
+      rig.current.quaternion.setFromRotationMatrix(legsMatrix);
     }
 
     // Slow roll about the leg axis — the cone spins in place, legs never

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -13,7 +13,8 @@ import RocketJourney from "./RocketJourney";
 import SynthSystem from "./SynthSystem";
 import SunSvgAnchor from "./SunSvgAnchor";
 import BodyAnchors from "./BodyAnchors";
-import { ASTEROIDS, PLANETS } from "./constants";
+import { ASTEROIDS, layoutState, PLANETS } from "./constants";
+import useWindowWidth from "../../useWindowWidth";
 
 /**
  * The perspective solar-system canvas (hunt-codes-3's scene), layered
@@ -45,6 +46,16 @@ const SolarScene = ({
   onNavigate: (to: string) => void;
 }) => {
   const isLanding = view === "landing";
+  // Below the lg breakpoint the camera switches to its NDC-fraction
+  // framing (CameraRig) and the wide-screen body placement stops
+  // fitting — the link bodies pull inward (constants.ts `compact`
+  // overrides). On phone widths the 808 pad sits out entirely.
+  const { width } = useWindowWidth();
+  const isCompact = width < 1280;
+  const isPhone = width < 768;
+  useEffect(() => {
+    layoutState.compact = isCompact;
+  }, [isCompact]);
   const [planetsRevealed, setPlanetsRevealed] = useState(
     () => hasPlayedLandingIntro || !isLanding,
   );
@@ -138,7 +149,9 @@ const SolarScene = ({
           <DrumPad
             key={asteroid.name}
             config={asteroid}
-            visible={view === "home"}
+            // No pad on phones: the sky above the sun is too tight for a
+            // fourth clickable, and SolarOverlays hides its button too
+            visible={view === "home" && !isPhone}
           />
         ) : (
           <Asteroid

--- a/src/space3d/solar/constants.ts
+++ b/src/space3d/solar/constants.ts
@@ -29,7 +29,21 @@ export interface SolarPlanetConfig {
   /** Brand badge decal projected onto both sides of the body (asteroids
    *  with a logo also spin upright-only so the mark stays readable) */
   logo?: AsteroidLogo;
+  /** Placement overrides applied while layoutState.compact (phone-width
+   *  viewports): the home view's link bodies pull inward so nothing
+   *  clips the narrow frame. */
+  compact?: Partial<
+    Pick<SolarPlanetConfig, "orbitRadius" | "orbitPhase" | "yOffset">
+  >;
 }
+
+/**
+ * Whether the phone-width placement overrides apply. Written by
+ * SolarScene from the canvas size (same 768px line as useWindowSize's
+ * "sm"); read by planetPosition every frame — a plain mutable module,
+ * like solarHover, so the frame loops stay React-free.
+ */
+export const layoutState = { compact: false };
 
 export const SUN_RADIUS = 3;
 
@@ -109,67 +123,97 @@ export const EARTH = PLANETS.find((p) => p.name === "Earth")!;
 const ASTEROID_Y = SUN_RADIUS;
 export const ASTEROIDS: SolarPlanetConfig[] = [
   {
+    // The link trio (blog rock, GitHub Sputnik, LinkedIn rock) clusters
+    // in a shallow arc centered over the sun's apex: satellite on top,
+    // the rocks flanking a step lower.
     name: "recent",
     kind: "mercury",
     radius: 0.28,
-    orbitRadius: 4.2,
+    orbitRadius: 2.8,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase + 0.35,
+    orbitPhase: EARTH.orbitPhase - 0.24,
     spinSpeed: 0.2 * SPEED_SCALE,
-    // Floats lower than its siblings: on the home view it reads nestled
-    // down near the sun's limb instead of high among the other links
-    yOffset: ASTEROID_Y - 1.2,
+    yOffset: ASTEROID_Y + 1.1,
     logo: "blog",
+    compact: {
+      orbitRadius: 4.5,
+      orbitPhase: EARTH.orbitPhase + 0.14,
+      yOffset: ASTEROID_Y - 0.6,
+    },
   },
   {
     // Rendered as the Sputnik satellite (Satellite.tsx), which carries
-    // its own GitHub badge — no decal `logo` needed
+    // its own GitHub badge — no decal `logo` needed. Crowns the trio,
+    // directly above the sun's apex.
     name: "github",
     kind: "mercury",
     radius: 0.32,
     orbitRadius: 2.8,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase - 0.7,
+    orbitPhase: EARTH.orbitPhase - 0.56,
     spinSpeed: -0.25 * SPEED_SCALE,
-    yOffset: ASTEROID_Y,
+    yOffset: ASTEROID_Y + 1.3,
+    compact: {
+      orbitRadius: 4.5,
+      orbitPhase: EARTH.orbitPhase + 0.01,
+      yOffset: ASTEROID_Y - 0.15,
+    },
   },
   {
     name: "linkedin",
     kind: "mercury",
     radius: 0.22,
-    orbitRadius: 2.4,
+    orbitRadius: 2.8,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase - 1.15,
+    orbitPhase: EARTH.orbitPhase - 0.88,
     spinSpeed: 0.3 * SPEED_SCALE,
     logo: "linkedin",
-    yOffset: ASTEROID_Y,
+    yOffset: ASTEROID_Y + 1.1,
+    compact: {
+      orbitRadius: 4.5,
+      orbitPhase: EARTH.orbitPhase - 0.12,
+      yOffset: ASTEROID_Y - 0.6,
+    },
   },
   {
     // Rendered as the cartoon rocket (Rocket.tsx). Not a link: clicking
-    // it launches the lightspeed joyride (rocketJourney.ts). Floats a
-    // little above and outside the other links so it reads as its own
-    // thing parked in the sky.
+    // it launches the lightspeed joyride (rocketJourney.ts). Parked out
+    // past Earth, splitting the gap between Earth and the right edge of
+    // a wide viewport; pulls inward on phones so it stays in frame.
     name: "rocket",
     kind: "mercury",
     radius: 0.42,
-    orbitRadius: 6.2,
+    orbitRadius: 6.6,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase + 0.3,
+    orbitPhase: EARTH.orbitPhase + 0.42,
     spinSpeed: 0.2 * SPEED_SCALE,
-    yOffset: ASTEROID_Y + 1.4,
+    yOffset: ASTEROID_Y + 0.9,
+    compact: {
+      orbitRadius: 5.6,
+      orbitPhase: EARTH.orbitPhase + 0.29,
+      yOffset: ASTEROID_Y - 1.1,
+    },
   },
   {
     // Rendered as the floating 808 drum pad (DrumPad.tsx). Clicking it
-    // warps to the synth solar system (/synth). High in the sky on the
-    // other flank of the sun from the rocket.
+    // warps to the synth solar system (/synth). Hovers just above the
+    // sun's shoulder, off to the right. Hidden entirely on phone-width
+    // screens (SolarScene + SolarOverlays).
     name: "synthpad",
     kind: "mercury",
     radius: 0.4,
-    orbitRadius: 4.9,
+    orbitRadius: 3.6,
     orbitSpeed: EARTH.orbitSpeed,
-    orbitPhase: EARTH.orbitPhase - 0.42,
+    orbitPhase: EARTH.orbitPhase - 0.12,
     spinSpeed: 0.2 * SPEED_SCALE,
-    yOffset: ASTEROID_Y + 1.15,
+    yOffset: ASTEROID_Y - 0.45,
+    // Tablet widths (compact layout, pad still shown): slide left so it
+    // doesn't eclipse the LinkedIn rock, which shares its base bearing
+    compact: {
+      orbitRadius: 4.2,
+      orbitPhase: EARTH.orbitPhase - 0.36,
+      yOffset: ASTEROID_Y - 0.5,
+    },
   },
 ];
 
@@ -187,17 +231,20 @@ export const MOON = {
   spinSpeed: 0.05 * SPEED_SCALE,
 };
 
-/** Position of a planet at elapsed time t (seconds). */
+/** Position of a planet at elapsed time t (seconds), honoring the
+ *  phone-width overrides while layoutState.compact. */
 export function planetPosition(
   p: SolarPlanetConfig,
   t: number,
   out = new THREE.Vector3(),
 ): THREE.Vector3 {
-  const angle = p.orbitPhase + t * p.orbitSpeed;
+  const c = layoutState.compact ? p.compact : undefined;
+  const angle = (c?.orbitPhase ?? p.orbitPhase) + t * p.orbitSpeed;
+  const orbitRadius = c?.orbitRadius ?? p.orbitRadius;
   return out.set(
-    Math.cos(angle) * p.orbitRadius,
-    p.yOffset ?? 0,
-    Math.sin(angle) * p.orbitRadius,
+    Math.cos(angle) * orbitRadius,
+    c?.yOffset ?? p.yOffset ?? 0,
+    Math.sin(angle) * orbitRadius,
   );
 }
 


### PR DESCRIPTION
Stacked on #82 (base branch is `ah/badge-medallion-site-polish`; retarget to master after that merges if GitHub doesn't do it automatically).

## What changed

### Wide screens (lg+, ≥1280)
- **Link trio (LinkedIn rock · GitHub Sputnik · blog rock)** now clusters in a shallow arc centered over the sun's apex, satellite crowning the top directly above the sun — previously the three scattered across half the sky. Clear of the home info block and the name letters.
- **Rocket** parks to the right of Earth, splitting the gap between Earth and the right viewport edge (~x 1350 on a 1600px screen).
- **808 pad** hovers just above the sun's right shoulder instead of floating high in the sky.
- **Satellite orientation flipped**: the GH-logo sphere now leads toward the camera with the antenna legs trailing behind (drifted right/down so the cone still reads). The rig uses a lookAt basis instead of a minimal-rotation quaternion so the beacon stays on top of the head — the naive Z→dir rotation dropped it under the chin. Side bonus: the badge-decal ring now sweeps closer to face-on, so the GH logo is legible longer per roll.

### Small + medium screens
- New `compact` placement overrides per body (`constants.ts`), applied by `planetPosition` when `layoutState.compact` is set — a mutable module written by SolarScene, same pattern as `solarHover`. The threshold is the **1280px lg breakpoint**, matching where CameraRig switches to its NDC-fraction framing (768 was wrong — tablets had the trio projecting off-frame left).
- Phone (<768): the **synth pad is gone entirely** (3D pad hidden in SolarScene + its overlay button unmounted in SolarOverlays, so no invisible click target floats in the sky). Trio arcs over the sun below Earth's ring; rocket tucks lower-right — everything in frame, nothing overlapping Earth, the moon, the text block, or the info panel. Verified at 375x812.
- Tablet (768–1280): pad slides to the left flank (its base bearing eclipsed the LinkedIn rock), trio + rocket use the compact placement. Verified at 768x1024.

## Notes for review
- Placements were tuned against live projections (reading the glued BodyAnchors overlay positions), not eyeballed world coords; desktop/tablet/mobile all screenshot-verified settled.
- The asteroid-frozen-on-screen invariant is untouched: every body still orbits at exactly `EARTH.orbitSpeed`; only radius/phase/height (and their compact variants) moved.
- The rocket joyride is unaffected — its boarding shot derives from Earth's direction, not the rocket's bearing; the pad transit reads `SYNTH_PAD` through `planetPosition`, so warps stay consistent with wherever the pad renders.
- `tsc`, `lint`, `build` all clean.