### PR TITLE
/journey: résumé + life story as an opening crawl over an open-space warp cruise

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -119,6 +119,191 @@ $breakpoint-lg: 1280px;
   }
 }
 
+// ─── /journey: the story crawl ────────────────
+// Deep space even in day mode — additive warp streaks and gold text
+// read as nothing on the pink sky. Same forced-night trick as
+// body.rocket-journey below; the palette toggle rests during the show.
+body.journey-mode {
+  .App-background_day,
+  .App-gg-bridge,
+  .gg-fog-layer {
+    opacity: 0 !important;
+  }
+
+  .App-background_day,
+  .gg-fog-drift {
+    animation: none !important;
+  }
+
+  .App-background_night {
+    opacity: 1 !important;
+  }
+
+  .day-night-switch {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.5s ease;
+  }
+}
+
+// The perspective stage: the tilt lives on a wrapper, the per-frame
+// translate on the crawl itself (Journey.tsx writes the transform)
+.journey-page {
+  position: fixed;
+  inset: 0;
+  z-index: 4;
+  overflow: hidden;
+  pointer-events: none;
+  perspective: 400px;
+  perspective-origin: 50% 30%;
+  // The crawl dissolves into the distance instead of hitting the ceiling
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 4%,
+    #000 30%,
+    #000 100%
+  );
+}
+
+.journey-tilt {
+  position: absolute;
+  inset: 0;
+  transform: rotateX(24deg);
+  transform-origin: 50% 100%;
+}
+
+.journey-crawl {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: min(640px, 86vw);
+  transform: translate3d(-50%, 0, 0);
+  will-change: transform;
+  text-align: center;
+  color: #ffd23f;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.55;
+
+  p {
+    margin: 0 0 1.1em;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 19px;
+  }
+}
+
+.journey-overline {
+  color: $purp-light;
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+}
+
+.journey-title {
+  font-family: "nova-mono", monospace;
+  font-size: 62px;
+  letter-spacing: 0.08em;
+  margin: 0.2em 0 0;
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 40px;
+  }
+}
+
+.journey-subtitle {
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-size: 15px;
+  opacity: 0.8;
+}
+
+.journey-chapter {
+  margin-top: 4.5em;
+
+  h2 {
+    font-size: 34px;
+    margin: 0.25em 0 0.6em;
+
+    @media (max-width: $breakpoint-sm) {
+      font-size: 26px;
+    }
+  }
+}
+
+.journey-era {
+  color: $purp-light;
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.journey-end {
+  margin-top: 7em;
+  margin-bottom: 20vh;
+}
+
+// The résumé page's pointer to the cinematic version
+.journey-plug {
+  margin-top: 8px;
+  font-size: 15px;
+  opacity: 0.85;
+}
+
+// Post-credits chip row, revealed once the crawl's tail clears the fade
+.journey-credits {
+  position: fixed;
+  left: 50%;
+  bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+  transform: translateX(-50%) translateY(12px);
+  display: flex;
+  gap: 28px;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.8s ease,
+    transform 0.8s ease;
+  z-index: 10;
+
+  button,
+  a {
+    color: $purp-light;
+    background: none;
+    border: none;
+    font-size: 15px;
+  }
+
+  &.shown {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(-50%);
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    flex-direction: column;
+    gap: 12px;
+  }
+}
+
+.journey-hint {
+  position: fixed;
+  left: 50%;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  z-index: 5;
+  transition: opacity 1s ease;
+
+  &.hint-hidden {
+    opacity: 0;
+  }
+}
+
 // The corner "hunt.codes" medallion (space3d/BadgeMedallion — drawn in
 // the shared star canvas, which never takes pointer input). This is its
 // DOM hit target on every page but the landing: the coin doubles as the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import cx from "classnames";
 import "./App.scss";
 
 import Home from "./Home";
+import Journey from "./Journey";
 import Resume from "./Resume";
 import Synth from "./Synth";
 import SvgGenerator from "./SvgGenerator";
@@ -53,6 +54,7 @@ const ROUTE_TITLES: Record<string, string> = {
   "/home": DEFAULT_TITLE,
   "/about": "About Me | Andrew Hunt",
   "/synth": "Space Jam Studio | Andrew Hunt",
+  "/journey": "The Journey | Andrew Hunt",
   "/draw": "SVG Studio | Andrew Hunt",
 };
 
@@ -111,6 +113,7 @@ const App = () => {
           <Route path="/home" element={<Home />} />
           <Route path="/about" element={<Resume />} />
           <Route path="/synth" element={<Synth />} />
+          <Route path="/journey" element={<Journey />} />
           <Route path="/draw" element={<SvgGenerator />} />
         </Routes>
       </Router>

--- a/src/AppBackground.tsx
+++ b/src/AppBackground.tsx
@@ -77,6 +77,8 @@ const AppBackground = ({
     location.pathname.includes("about") || location.pathname.includes("draw");
   // The synth solar system (the 808-pad easter egg's destination)
   const isSynthPage = location.pathname.includes("synth");
+  // The /journey story crawl's open-space cruise
+  const isJourneyPage = location.pathname.includes("journey");
   const isLanding = location.pathname === "/" || location.pathname === "";
   const [musicEnabled, setMusicEnabled] = useState(false);
 
@@ -199,6 +201,7 @@ const AppBackground = ({
             isHomePage={isHomePage}
             isAboutPage={isAboutPage}
             isSynthPage={isSynthPage}
+            isJourneyPage={isJourneyPage}
             onJourneyNavigate={journeyNavigate}
           />
         </Suspense>

--- a/src/BadgeLink.tsx
+++ b/src/BadgeLink.tsx
@@ -19,7 +19,9 @@ const BadgeLink = ({ isNightMode }: { isNightMode: boolean }) => {
   // (Space3DBackground) — an invisible link over other content would
   // hijack clicks.
   const visible =
-    pathname === "/synth" || (pathname === "/home" && isNightMode);
+    pathname === "/synth" ||
+    pathname === "/journey" ||
+    (pathname === "/home" && isNightMode);
   if (!visible) return null;
 
   return (

--- a/src/Journey.tsx
+++ b/src/Journey.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowLeftCircleIcon } from "lucide-react";
+import cx from "classnames";
+
+import {
+  JOURNEY_CHAPTERS,
+  JOURNEY_INTRO,
+  JOURNEY_OUTRO,
+} from "./journeyContent";
+import { cruiseState } from "./journeyCruise";
+
+/**
+ * The /journey page: Andrew's story as an opening crawl, gliding into
+ * a vanishing point while the 3D scene (space3d/solar/JourneyCruise)
+ * cruises through open space behind it.
+ *
+ * The crawl advances on its own at reading pace; wheel, touch drag, or
+ * arrow keys scrub it (forward or back), and the scrub speed feeds the
+ * flight — push the story hard and the star field kicks toward
+ * lightspeed (cruiseState.boost). All the words live in
+ * journeyContent.ts; this file only drives the motion.
+ *
+ * Under prefers-reduced-motion the auto-play stops: the crawl moves
+ * only when the visitor scrolls it.
+ */
+
+/** Reading-pace auto-advance */
+const BASE_SPEED_PX_S = 30;
+/** Extra px/s of crawl velocity per px of wheel delta */
+const WHEEL_IMPULSE = 5;
+const TOUCH_IMPULSE = 9;
+const KEY_IMPULSE = 420;
+/** Scrub velocity decays toward 0 with this half-life feel (per second) */
+const VELOCITY_DECAY = 3.2;
+const MAX_VELOCITY = 2600;
+/** Scrub speed that reads as "full burn" to the cruise (px/s) */
+const FULL_BURN_VELOCITY = 1000;
+
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+
+const Journey = () => {
+  const crawlRef = useRef<HTMLDivElement>(null);
+  const progress = useRef(0);
+  const velocity = useRef(0);
+  const [ended, setEnded] = useState(false);
+  const endedRef = useRef(false);
+
+  // The crawl needs deep space even in day mode (additive streaks on a
+  // pink sky read as nothing) — the same forced-night trick as the
+  // lightspeed rides, via a body class (App.scss)
+  useEffect(() => {
+    document.body.classList.add("journey-mode");
+    return () => {
+      document.body.classList.remove("journey-mode");
+      cruiseState.boost = 0;
+    };
+  }, []);
+
+  useEffect(() => {
+    const reduced = prefersReducedMotion();
+    let raf = 0;
+    let last = performance.now();
+
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      const dt = Math.min((now - last) / 1000, 0.1);
+      last = now;
+      const el = crawlRef.current;
+      if (!el) return;
+
+      // The story is over once the crawl's tail clears the fade; park
+      // there (scrubbing back un-parks)
+      const limit = el.offsetHeight + window.innerHeight * 0.35;
+
+      velocity.current *= Math.exp(-dt * VELOCITY_DECAY);
+      const auto = reduced || endedRef.current ? 0 : BASE_SPEED_PX_S;
+      progress.current = Math.min(
+        Math.max(progress.current + (auto + velocity.current) * dt, 0),
+        limit,
+      );
+      el.style.transform = `translate3d(-50%, ${-progress.current}px, 0)`;
+
+      // Feed the flight: hard scrubbing (either direction) revs the ship
+      cruiseState.boost = Math.min(
+        1,
+        Math.abs(velocity.current) / FULL_BURN_VELOCITY,
+      );
+
+      const atEnd = progress.current >= limit - 1;
+      if (atEnd !== endedRef.current) {
+        endedRef.current = atEnd;
+        setEnded(atEnd);
+      }
+    };
+    raf = requestAnimationFrame(tick);
+
+    const impulse = (amount: number) => {
+      velocity.current = Math.min(
+        Math.max(velocity.current + amount, -MAX_VELOCITY),
+        MAX_VELOCITY,
+      );
+    };
+    const onWheel = (e: WheelEvent) => {
+      impulse((e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY) * WHEEL_IMPULSE);
+    };
+    let lastTouchY: number | null = null;
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY;
+      if (y == null || lastTouchY == null) return;
+      // Nothing else scrolls here — claim the gesture (no iOS rubber-band)
+      e.preventDefault();
+      impulse((lastTouchY - y) * TOUCH_IMPULSE);
+      lastTouchY = y;
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "ArrowDown" || e.key === "PageDown" || e.key === " ") {
+        e.preventDefault();
+        impulse(KEY_IMPULSE);
+      } else if (e.key === "ArrowUp" || e.key === "PageUp") {
+        e.preventDefault();
+        impulse(-KEY_IMPULSE);
+      }
+    };
+
+    window.addEventListener("wheel", onWheel, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+
+  const replay = () => {
+    progress.current = 0;
+    velocity.current = 0;
+    endedRef.current = false;
+    setEnded(false);
+  };
+
+  return (
+    <>
+      <div className="homePageBackLink">
+        <Link
+          className="mt-4 flex items-center gap-1 transition-transform"
+          to="/home"
+        >
+          <ArrowLeftCircleIcon className="starIcon" size={16} />
+          <span>Back to orbit</span>
+        </Link>
+      </div>
+      <main className="journey-page" aria-label="Andrew Hunt's journey">
+        <div className="journey-tilt">
+          <div ref={crawlRef} className="journey-crawl">
+            <p className="journey-overline">{JOURNEY_INTRO.overline}</p>
+            <h1 className="journey-title">{JOURNEY_INTRO.title}</h1>
+            <p className="journey-subtitle">{JOURNEY_INTRO.subtitle}</p>
+            {JOURNEY_CHAPTERS.map((chapter) => (
+              <section key={chapter.title} className="journey-chapter">
+                <p className="journey-era">{chapter.era}</p>
+                <h2>{chapter.title}</h2>
+                {chapter.lines.map((line) => (
+                  <p key={line}>{line}</p>
+                ))}
+              </section>
+            ))}
+            <section className="journey-chapter journey-end">
+              <h2>{JOURNEY_OUTRO.title}</h2>
+              <p className="journey-era">{JOURNEY_OUTRO.subtitle}</p>
+            </section>
+          </div>
+        </div>
+      </main>
+      {/* Post-credits: once the crawl clears the screen */}
+      <div className={cx("journey-credits", ended && "shown")}>
+        <button type="button" onClick={replay}>
+          ↺ Roll it again
+        </button>
+        <Link to="/about">Read the plain-text version</Link>
+        <Link to="/home">Back to orbit</Link>
+      </div>
+      <div className={cx("journey-hint", ended && "hint-hidden")}>
+        scroll to travel faster
+      </div>
+    </>
+  );
+};
+
+export default Journey;

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -141,6 +141,13 @@ const Resume = () => {
             </a>
             .
           </p>
+          <p className="journey-plug">
+            Prefer the cinematic cut?{" "}
+            <Link className="inverse" to="/journey">
+              Watch the journey
+            </Link>{" "}
+            🚀
+          </p>
           <div className="resume-divider" />
           <h2>A few things I care about:</h2>
           <ul className="hor-list">

--- a/src/journeyContent.ts
+++ b/src/journeyContent.ts
@@ -1,0 +1,104 @@
+/**
+ * The /journey crawl, chapter by chapter — the whole story lives in this
+ * one file so editing the journey never touches layout or 3D code.
+ *
+ * To add or edit a chapter: append/edit an entry in JOURNEY_CHAPTERS.
+ * Each chapter renders as an era overline, a title, and one paragraph
+ * per line. Anything you haven't decided yet: leave it as "[to fill in]"
+ * and it'll ride the crawl until you replace it.
+ */
+
+export interface JourneyChapter {
+  /** Small overline above the title: a year, range, or era */
+  era: string;
+  title: string;
+  /** Body copy; each entry renders as its own paragraph */
+  lines: string[];
+}
+
+export const JOURNEY_INTRO = {
+  overline: "A while ago, in a timezone three hours behind…",
+  title: "THE JOURNEY",
+  subtitle: "the andrew hunt story",
+};
+
+export const JOURNEY_CHAPTERS: JourneyChapter[] = [
+  {
+    era: "the early years",
+    title: "Grew up in Oregon",
+    lines: [
+      "Raised in [to fill in: hometown], Oregon — evergreens, drizzle, and a family computer that was asking for it.",
+      "[to fill in: first computer / first thing ever built]",
+    ],
+  },
+  {
+    era: "[to fill in: years] · New Jersey",
+    title: "Princeton University",
+    lines: [
+      "Studied [to fill in: major] at Princeton.",
+      "[to fill in: a story — the class, the club, the thesis, the all-nighter]",
+    ],
+  },
+  {
+    era: "Summer 2016 · San Francisco",
+    title: "Airbnb — the internship",
+    lines: [
+      "First taste of San Francisco: shipped landing pages for new features and contributed components to the company frontend framework.",
+      "Liked it enough to come back.",
+    ],
+  },
+  {
+    era: "2017 – 2020 · San Francisco",
+    title: "Airbnb — Software Engineer",
+    lines: [
+      "Built dozens of pricing and availability features across the Experiences host and guest products.",
+      "Ran 20+ A/B tests that compounded into >10% more bookings, cut load times by >30% on 10+ pages, and led the TypeScript migration.",
+    ],
+  },
+  {
+    era: "2020 – 2021 · San Francisco",
+    title: "Untapped — Software Engineer",
+    lines: [
+      "Launched the Recruiter Analytics platform at Untapped (fka Jumpstart).",
+      "Introduced TypeScript, led the frontend platform group, and made the core app 40% faster.",
+    ],
+  },
+  {
+    era: "2021 – 2025 · San Francisco",
+    title: "Zip — Staff Software Engineer",
+    lines: [
+      "Four years, zero to staff: new product features, shared component systems, and the frontend infrastructure underneath all of it.",
+      "CI type-safety gates, testing across Jest, Datadog Synthetics, and Chromatic, logging with Segment, and build & deploy spanning Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow.",
+      "TypeScript to 99% coverage; page loads cut by more than half.",
+    ],
+  },
+  {
+    era: "2025",
+    title: "The sabbatical",
+    lines: [
+      "Stepped away for a proper recharge — and a move across the country to New York City.",
+      "[to fill in: the best thing you did with the time off]",
+    ],
+  },
+  {
+    era: "2025 – present · NYC",
+    title: "Independent Consultant — Argos",
+    lines: [
+      "Consulting from New York: designing, building, and shipping production frontend for Argos, a legal-tech AI product.",
+      "An LLM-powered agentic chatbot, legal document management, data visualization — plus advising on architecture, performance, and DevX.",
+    ],
+  },
+  {
+    era: "fall 2026 →",
+    title: "The next chapter",
+    lines: [
+      "Looking to go full-time again.",
+      "This entry could be about your team — andrew@hunt.codes.",
+    ],
+  },
+];
+
+export const JOURNEY_OUTRO = {
+  title: "THE END",
+  subtitle: "(for now)",
+};

--- a/src/journeyCruise.ts
+++ b/src/journeyCruise.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared state for the /journey cruise: the crawl page (DOM) writes how
+ * hard the visitor is pushing the scroll, and the 3D cruise
+ * (space3d/solar/JourneyCruise) eases the warp-streak intensity toward
+ * it — scrub fast and the ship burns harder. Plain mutable module, same
+ * pattern as solarHover / rocketJourney, so main-chunk pages can import
+ * it without dragging three.js out of its lazy chunk.
+ */
+export const cruiseState = {
+  /** 0..1 — extra flight intensity from crawl scroll velocity (decays
+   *  back to 0 in the crawl's frame loop) */
+  boost: 0,
+};

--- a/src/space3d/Space3DBackground.tsx
+++ b/src/space3d/Space3DBackground.tsx
@@ -46,6 +46,7 @@ const Space3DBackground = ({
   isHomePage,
   isAboutPage,
   isSynthPage,
+  isJourneyPage,
   onJourneyNavigate,
 }: {
   isNightMode: boolean;
@@ -53,6 +54,7 @@ const Space3DBackground = ({
   isHomePage: boolean;
   isAboutPage: boolean;
   isSynthPage: boolean;
+  isJourneyPage: boolean;
   /** Router navigation for the lightspeed journeys (passed down into the
    *  canvas, where router context can't reach) */
   onJourneyNavigate: (to: string) => void;
@@ -74,16 +76,22 @@ const Space3DBackground = ({
           </BadgeBoundary>
         )}
       </SpaceCanvas>
-      {(isLanding || isHomePage || isAboutPage || isSynthPage) && (
+      {(isLanding ||
+        isHomePage ||
+        isAboutPage ||
+        isSynthPage ||
+        isJourneyPage) && (
         <SolarScene
           view={
             isLanding
               ? "landing"
               : isSynthPage
                 ? "synth"
-                : isAboutPage
-                  ? "about"
-                  : "home"
+                : isJourneyPage
+                  ? "journey"
+                  : isAboutPage
+                    ? "about"
+                    : "home"
           }
           isNightMode={isNightMode}
           onNavigate={onJourneyNavigate}

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -20,7 +20,7 @@ import { SYNTH_CAM_HEIGHT, SYNTH_ORIGIN } from "../../synthSpec";
  * a few seconds; once arrived the camera rides the moving goal.
  */
 
-export type SolarView = "landing" | "home" | "about" | "synth";
+export type SolarView = "landing" | "home" | "about" | "synth" | "journey";
 
 // Height tuned so Earth's orbit (r 17.5) nearly reaches the bottom edge
 // (~16px margin on a laptop): visible half-height = tan(fov/2)·y ≈ .52·35.
@@ -212,9 +212,11 @@ export default function CameraRig({ view }: { view: SolarView }) {
   useFrame(({ camera, clock, size }, delta) => {
     const t = clock.elapsedTime;
     const scrub = scrollTransitionState;
-    // The synth system sits outside the scroll journey — no stop to
-    // adopt or scrub toward; its view changes always take the timed swoop
-    const stop = view === "synth" ? null : JOURNEY_STOPS[view];
+    // The synth system and the /journey cruise sit outside the scroll
+    // journey — no stop to adopt or scrub toward; view changes to or
+    // from them always take the timed swoop
+    const stop =
+      view === "synth" || view === "journey" ? null : JOURNEY_STOPS[view];
 
     // First frame: adopt the mounted view as the journey position (fresh
     // page loads start with the module's stale zeros)
@@ -223,6 +225,17 @@ export default function CameraRig({ view }: { view: SolarView }) {
       scrub.target = stop;
       scrub.progress = stop;
       scrub.initialized = true;
+    }
+
+    // The /journey cruise (JourneyCruise) owns the camera while its view
+    // is up — same stand-down/handoff dance as the lightspeed rides below
+    if (view === "journey") {
+      activeView.current = view;
+      journeyHandoff.current = true;
+      rigState.settled = false;
+      scrub.rigSettled = false;
+      prevQuat.current = null;
+      return;
     }
 
     // The rocket joyride (RocketJourney, mounted before this so it runs
@@ -249,13 +262,15 @@ export default function CameraRig({ view }: { view: SolarView }) {
     }
 
     if (view !== activeView.current) {
-      // A hop to or from the synth system never comes from the scrub —
-      // the journey's parked progress says nothing about the camera there
-      const fromSynth = activeView.current === "synth";
+      // A hop from the synth system or the /journey cruise never comes
+      // from the scrub — the parked progress says nothing about the
+      // camera there
+      const fromDetached =
+        activeView.current === "synth" || activeView.current === "journey";
       activeView.current = view;
       if (
         stop !== null &&
-        !fromSynth &&
+        !fromDetached &&
         Math.abs(scrub.progress - stop) < 0.35
       ) {
         // Scroll-committed arrival: the scrub carried the camera here.

--- a/src/space3d/solar/JourneyCruise.tsx
+++ b/src/space3d/solar/JourneyCruise.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+import WarpStreaks from "./WarpStreaks";
+import { journeyState } from "../../rocketJourney";
+import { cruiseState } from "../../journeyCruise";
+
+/**
+ * The /journey flight: while the crawl page is up, the camera cruises
+ * through open space — parked far from both solar systems, drifting
+ * through the shared streak field (WarpStreaks) at an easy burn. The
+ * crawl's scroll velocity feeds cruiseState.boost, so scrubbing the
+ * story hard kicks the ship toward lightspeed and eases back to a
+ * drift when the visitor lets go.
+ *
+ * While mounted this component owns the camera (CameraRig stands down,
+ * same dance as the lightspeed rides): on mount it eases from wherever
+ * the camera was into the cruise pose; on unmount CameraRig's handoff
+ * swoop glides back to the destination view.
+ */
+
+/** Far from the home system (origin) and the synth system (far below) */
+const CRUISE_POS = new THREE.Vector3(0, 30, 700);
+/** Flight heading: out into empty space, away from every body */
+const CRUISE_DIR = new THREE.Vector3(0.2, 0.06, 1).normalize();
+const ENTRY_SECONDS = 1.6;
+/** Idle drift vs full-burn streak intensity */
+const BASE_INTENSITY = 0.28;
+const BOOST_INTENSITY = 0.65;
+/** Cruise streaks amble slower than the rides' warp sprint */
+const CRUISE_SPEED_SCALE = 0.45;
+/** Background point stars dim a touch so the crawl + streaks read */
+const STAR_DIM_CRUISE = 0.3;
+
+const UP = new THREE.Vector3(0, 1, 0);
+const Z_AXIS = new THREE.Vector3(0, 0, 1);
+
+const easeInOutCubic = (x: number) =>
+  x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
+
+// scratch values, reused every frame
+const lookTarget = new THREE.Vector3();
+const lookMatrix = new THREE.Matrix4();
+const cruiseQuat = new THREE.Quaternion();
+const sway = new THREE.Vector3();
+const swayedPos = new THREE.Vector3();
+const rollQuat = new THREE.Quaternion();
+const targetQuat = new THREE.Quaternion();
+
+export default function JourneyCruise() {
+  const rig = useRef<THREE.Group>(null);
+  const fromPos = useRef(new THREE.Vector3());
+  const fromQuat = useRef(new THREE.Quaternion());
+  const captured = useRef(false);
+  const entry = useRef(0);
+  const intensity = useRef(0);
+
+  // The cruise borrows the rides' star dim; hand it back on unmount
+  useEffect(
+    () => () => {
+      journeyState.starDim = 0;
+    },
+    [],
+  );
+
+  useFrame(({ camera, clock }, rawDelta) => {
+    // Clamped like the rides: a backgrounded tab pauses, not skips
+    const delta = Math.min(rawDelta, 0.1);
+    const t = clock.elapsedTime;
+
+    if (!captured.current) {
+      captured.current = true;
+      fromPos.current.copy(camera.position);
+      fromQuat.current.copy(camera.quaternion);
+      lookTarget.copy(CRUISE_POS).add(CRUISE_DIR);
+      lookMatrix.lookAt(CRUISE_POS, lookTarget, UP);
+      cruiseQuat.setFromRotationMatrix(lookMatrix);
+      if (rig.current) {
+        rig.current.position.copy(CRUISE_POS);
+        rig.current.quaternion.copy(cruiseQuat);
+      }
+    }
+
+    entry.current = Math.min(1, entry.current + delta / ENTRY_SECONDS);
+    const e = easeInOutCubic(entry.current);
+
+    // Gentle sway + roll around the parked pose so the flight breathes
+    // (the same feel as the rides' warp; the streak field stays put)
+    sway
+      .set(Math.sin(t * 0.8) * 0.5, Math.sin(t * 1.17) * 0.35, 0)
+      .applyQuaternion(cruiseQuat);
+    swayedPos.copy(CRUISE_POS).add(sway);
+    rollQuat.setFromAxisAngle(Z_AXIS, Math.sin(t * 0.6) * 0.03);
+    targetQuat.copy(cruiseQuat).multiply(rollQuat);
+
+    camera.position.lerpVectors(fromPos.current, swayedPos, e);
+    camera.quaternion.slerpQuaternions(fromQuat.current, targetQuat, e);
+
+    // Throttle: idle drift plus however hard the crawl is being scrubbed
+    const target = Math.min(
+      1,
+      BASE_INTENSITY + cruiseState.boost * BOOST_INTENSITY,
+    );
+    intensity.current +=
+      (target * e - intensity.current) * Math.min(1, delta * 3);
+
+    journeyState.starDim = STAR_DIM_CRUISE * e;
+  });
+
+  return (
+    <group ref={rig}>
+      <WarpStreaks
+        getIntensity={() => intensity.current}
+        speedScale={CRUISE_SPEED_SCALE}
+      />
+    </group>
+  );
+}

--- a/src/space3d/solar/RocketJourney.tsx
+++ b/src/space3d/solar/RocketJourney.tsx
@@ -6,6 +6,7 @@ import { planetPosition, ROCKET, SYNTH_PAD } from "./constants";
 import { rocketNoseDirection } from "./Rocket";
 import { viewGoal, type SolarView } from "./CameraRig";
 import { ARTIFACT_BUILDERS, disposeArtifact } from "./warpArtifacts";
+import WarpStreaks from "./WarpStreaks";
 import { endRocketJourney, flashWarp, journeyState } from "../../rocketJourney";
 import { SYNTH_ORIGIN } from "../../synthSpec";
 
@@ -51,15 +52,6 @@ const WARP_RAMP_IN_SECONDS = 0.9;
 const WARP_RAMP_OUT_SECONDS = 1;
 /** Stars fade back in over the last stretch of warp (decelerating) */
 const STAR_RETURN_SECONDS = 1.2;
-
-const STREAK_COUNT = 340;
-/** Streak heads live at rig-local z in [-DEPTH+PAD, PAD); -z is ahead */
-const STREAK_DEPTH = 320;
-const STREAK_BEHIND_PAD = 20;
-const STREAK_RADIUS_MIN = 1.5;
-const STREAK_RADIUS_MAX = 60;
-const STREAK_SPEED = 300;
-const STREAK_LENGTH = 30;
 
 const ARTIFACT_Z_START = -170;
 const ARTIFACT_Z_EXIT = 25;
@@ -124,7 +116,8 @@ export default function RocketJourney({
   navigate: (to: string) => void;
 }) {
   const rig = useRef<THREE.Group>(null);
-  const streakLines = useRef<THREE.LineSegments>(null);
+  /** Warp intensity envelope, read by the shared streak field per frame */
+  const warpIntensity = useRef(0);
 
   const startPos = useRef(new THREE.Vector3());
   const startQuat = useRef(new THREE.Quaternion());
@@ -136,59 +129,6 @@ export default function RocketJourney({
   const sawDestView = useRef(false);
   const warpPos = useRef(new THREE.Vector3());
   const warpQuat = useRef(new THREE.Quaternion());
-
-  // Streak field: per-streak cylindrical spots + speeds, plus the
-  // two-vertex-per-streak line buffers (head bright, tail dim)
-  const streaks = useMemo(() => {
-    const x = new Float32Array(STREAK_COUNT);
-    const y = new Float32Array(STREAK_COUNT);
-    const z = new Float32Array(STREAK_COUNT);
-    const speed = new Float32Array(STREAK_COUNT);
-    const colors = new Float32Array(STREAK_COUNT * 6);
-    const tint = new THREE.Color();
-    for (let i = 0; i < STREAK_COUNT; i++) {
-      const angle = Math.random() * Math.PI * 2;
-      // sqrt-distributed radius = uniform density over the disc
-      const radius =
-        STREAK_RADIUS_MIN +
-        Math.sqrt(Math.random()) * (STREAK_RADIUS_MAX - STREAK_RADIUS_MIN);
-      x[i] = Math.cos(angle) * radius;
-      y[i] = Math.sin(angle) * radius;
-      z[i] = -STREAK_DEPTH + Math.random() * (STREAK_DEPTH + STREAK_BEHIND_PAD);
-      speed[i] = STREAK_SPEED * (0.7 + Math.random() * 0.6);
-      const pick = Math.random();
-      tint.set(pick < 0.7 ? "#ffffff" : pick < 0.85 ? "#ab8ffd" : "#9ecbff");
-      colors[i * 6] = tint.r;
-      colors[i * 6 + 1] = tint.g;
-      colors[i * 6 + 2] = tint.b;
-      colors[i * 6 + 3] = tint.r * 0.05;
-      colors[i * 6 + 4] = tint.g * 0.05;
-      colors[i * 6 + 5] = tint.b * 0.05;
-    }
-    const geometry = new THREE.BufferGeometry();
-    const positionAttr = new THREE.BufferAttribute(
-      new Float32Array(STREAK_COUNT * 6),
-      3,
-    );
-    positionAttr.setUsage(THREE.DynamicDrawUsage);
-    geometry.setAttribute("position", positionAttr);
-    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
-    const material = new THREE.LineBasicMaterial({
-      vertexColors: true,
-      transparent: true,
-      opacity: 0,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-    });
-    return { x, y, z, speed, geometry, positionAttr, material };
-  }, []);
-  useEffect(
-    () => () => {
-      streaks.geometry.dispose();
-      streaks.material.dispose();
-    },
-    [streaks],
-  );
 
   const artifacts: FlybyArtifact[] = useMemo(
     () =>
@@ -229,6 +169,7 @@ export default function RocketJourney({
     if (state.phase === "idle") {
       if (rig.current?.visible) rig.current.visible = false;
       startCaptured.current = false;
+      warpIntensity.current = 0;
       return;
     }
     // Route change mid-ride (browser back): abort and let CameraRig
@@ -334,6 +275,7 @@ export default function RocketJourney({
       0,
       1,
     );
+    warpIntensity.current = intensity;
     state.starDim = clamp01(
       (state.warpSeconds - elapsed) / STAR_RETURN_SECONDS,
     );
@@ -346,24 +288,6 @@ export default function RocketJourney({
     camera.position.copy(warpPos.current).add(sway);
     rollQuat.setFromAxisAngle(Z_AXIS, Math.sin(t * 0.7) * 0.035);
     camera.quaternion.copy(warpQuat.current).multiply(rollQuat);
-
-    // March the streak heads toward the camera and wrap; tails trail
-    // "ahead" (where the streak came from) by the stretched length
-    const positions = streaks.positionAttr.array as Float32Array;
-    const length = STREAK_LENGTH * intensity + 0.2;
-    for (let i = 0; i < STREAK_COUNT; i++) {
-      let zHead = streaks.z[i] + streaks.speed[i] * intensity * delta;
-      if (zHead > STREAK_BEHIND_PAD) zHead -= STREAK_DEPTH + STREAK_BEHIND_PAD;
-      streaks.z[i] = zHead;
-      positions[i * 6] = streaks.x[i];
-      positions[i * 6 + 1] = streaks.y[i];
-      positions[i * 6 + 2] = zHead;
-      positions[i * 6 + 3] = streaks.x[i];
-      positions[i * 6 + 4] = streaks.y[i];
-      positions[i * 6 + 5] = zHead - length;
-    }
-    streaks.positionAttr.needsUpdate = true;
-    streaks.material.opacity = intensity;
 
     // Flyby cameos (joyride only): each pops in far ahead, drifts
     // outward as it nears, and exits past the shoulder of the windshield
@@ -426,12 +350,7 @@ export default function RocketJourney({
           visible */}
       <ambientLight intensity={0.55} />
       <pointLight position={[6, 14, 18]} intensity={2.2} decay={0} />
-      <lineSegments
-        ref={streakLines}
-        geometry={streaks.geometry}
-        material={streaks.material}
-        frustumCulled={false}
-      />
+      <WarpStreaks getIntensity={() => warpIntensity.current} />
       {artifacts.map((artifact, i) => (
         <primitive key={i} object={artifact.group} />
       ))}

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -10,6 +10,7 @@ import Satellite from "./Satellite";
 import Rocket from "./Rocket";
 import DrumPad from "./DrumPad";
 import RocketJourney from "./RocketJourney";
+import JourneyCruise from "./JourneyCruise";
 import SynthSystem from "./SynthSystem";
 import SunSvgAnchor from "./SunSvgAnchor";
 import BodyAnchors from "./BodyAnchors";
@@ -164,6 +165,8 @@ const SolarScene = ({
       {/* The second solar system, far below this one: six knob-planets
           around a beat-pulsing sun (the space synth) */}
       {view === "synth" && <SynthSystem isNightMode={isNightMode} />}
+      {/* The /journey cruise: open-space flight behind the story crawl */}
+      {view === "journey" && <JourneyCruise />}
       {/* Mounted before CameraRig: while a journey is active it must
           pose the camera first each frame (CameraRig stands down) */}
       <RocketJourney view={view} navigate={onNavigate} />

--- a/src/space3d/solar/WarpStreaks.tsx
+++ b/src/space3d/solar/WarpStreaks.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * The lightspeed streak field: one LineSegments whose head vertices
+ * march toward the local origin (the camera's seat) and wrap; line
+ * length and material opacity ride the intensity, so the field
+ * stretches out of nothing as intensity rises and collapses back to
+ * nothing as it falls.
+ *
+ * Extracted from RocketJourney so every space flight shares one
+ * implementation: the joyride and 808 transits drive it with their warp
+ * envelope, the /journey cruise idles it low and revs it with the
+ * crawl's scroll. Parent it under a rig positioned/oriented at the
+ * camera's flight pose; streaks live in rig-local space with -z ahead.
+ */
+
+const STREAK_COUNT = 340;
+/** Streak heads live at rig-local z in [-DEPTH+PAD, PAD); -z is ahead */
+const STREAK_DEPTH = 320;
+const STREAK_BEHIND_PAD = 20;
+const STREAK_RADIUS_MIN = 1.5;
+const STREAK_RADIUS_MAX = 60;
+const STREAK_SPEED = 300;
+const STREAK_LENGTH = 30;
+
+export default function WarpStreaks({
+  getIntensity,
+  speedScale = 1,
+}: {
+  /** Read per frame (a ref accessor, not React state): 0 = no streaks,
+   *  1 = full lightspeed */
+  getIntensity: () => number;
+  /** Scales the march speed and stretch — the cruise ambles, the warp
+   *  sprints */
+  speedScale?: number;
+}) {
+  const lines = useRef<THREE.LineSegments>(null);
+
+  // Per-streak cylindrical spots + speeds, plus the two-vertex-per-streak
+  // line buffers (head bright, tail dim)
+  const streaks = useMemo(() => {
+    const x = new Float32Array(STREAK_COUNT);
+    const y = new Float32Array(STREAK_COUNT);
+    const z = new Float32Array(STREAK_COUNT);
+    const speed = new Float32Array(STREAK_COUNT);
+    const colors = new Float32Array(STREAK_COUNT * 6);
+    const tint = new THREE.Color();
+    for (let i = 0; i < STREAK_COUNT; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      // sqrt-distributed radius = uniform density over the disc
+      const radius =
+        STREAK_RADIUS_MIN +
+        Math.sqrt(Math.random()) * (STREAK_RADIUS_MAX - STREAK_RADIUS_MIN);
+      x[i] = Math.cos(angle) * radius;
+      y[i] = Math.sin(angle) * radius;
+      z[i] = -STREAK_DEPTH + Math.random() * (STREAK_DEPTH + STREAK_BEHIND_PAD);
+      speed[i] = STREAK_SPEED * (0.7 + Math.random() * 0.6);
+      const pick = Math.random();
+      tint.set(pick < 0.7 ? "#ffffff" : pick < 0.85 ? "#ab8ffd" : "#9ecbff");
+      colors[i * 6] = tint.r;
+      colors[i * 6 + 1] = tint.g;
+      colors[i * 6 + 2] = tint.b;
+      colors[i * 6 + 3] = tint.r * 0.05;
+      colors[i * 6 + 4] = tint.g * 0.05;
+      colors[i * 6 + 5] = tint.b * 0.05;
+    }
+    const geometry = new THREE.BufferGeometry();
+    const positionAttr = new THREE.BufferAttribute(
+      new Float32Array(STREAK_COUNT * 6),
+      3,
+    );
+    positionAttr.setUsage(THREE.DynamicDrawUsage);
+    geometry.setAttribute("position", positionAttr);
+    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+    const material = new THREE.LineBasicMaterial({
+      vertexColors: true,
+      transparent: true,
+      opacity: 0,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+    return { x, y, z, speed, geometry, positionAttr, material };
+  }, []);
+  useEffect(
+    () => () => {
+      streaks.geometry.dispose();
+      streaks.material.dispose();
+    },
+    [streaks],
+  );
+
+  useFrame((_, rawDelta) => {
+    // Clamped like the rides' fades: a backgrounded tab must pause the
+    // flight, not fast-forward it on the first frame back
+    const delta = Math.min(rawDelta, 0.1);
+    const intensity = THREE.MathUtils.clamp(getIntensity(), 0, 1);
+
+    // March the streak heads toward the camera and wrap; tails trail
+    // "ahead" (where the streak came from) by the stretched length
+    const positions = streaks.positionAttr.array as Float32Array;
+    const length = STREAK_LENGTH * speedScale * intensity + 0.2;
+    for (let i = 0; i < STREAK_COUNT; i++) {
+      let zHead =
+        streaks.z[i] + streaks.speed[i] * speedScale * intensity * delta;
+      if (zHead > STREAK_BEHIND_PAD) zHead -= STREAK_DEPTH + STREAK_BEHIND_PAD;
+      streaks.z[i] = zHead;
+      positions[i * 6] = streaks.x[i];
+      positions[i * 6 + 1] = streaks.y[i];
+      positions[i * 6 + 2] = zHead;
+      positions[i * 6 + 3] = streaks.x[i];
+      positions[i * 6 + 4] = streaks.y[i];
+      positions[i * 6 + 5] = zHead - length;
+    }
+    streaks.positionAttr.needsUpdate = true;
+    streaks.material.opacity = intensity;
+  });
+
+  return (
+    <lineSegments
+      ref={lines}
+      geometry={streaks.geometry}
+      material={streaks.material}
+      frustumCulled={false}
+    />
+  );
+}


### PR DESCRIPTION
Stacked on #83 (base is `ah/home-layout-tune`; retarget after the stack merges).

## What this is

A new `/journey` page: the camera cruises through open space while Andrew's story rolls by as a perspective-tilted opening crawl — gold text, purple era overlines, dissolving into the distance under a mask. Chapters: grew up in Oregon → Princeton → Airbnb internship → Airbnb → Untapped → Zip → sabbatical → Argos → "the next chapter." Unknown details ride along as **"[to fill in]"**.

## Easy to update

Everything you'd ever edit lives in **`src/journeyContent.ts`** — chapters are plain `{ era, title, lines[] }` data. Add/edit/reorder entries and the crawl, spacing, and end-detection all adapt; no layout or 3D code involved.

## The ride

- **Auto-advances at reading pace**; wheel / touch drag / arrow keys / space scrub it in either direction with momentum.
- **Scrub speed feeds the flight**: `cruiseState.boost` couples crawl velocity to warp-streak intensity — push the story hard and the ship kicks toward lightspeed, let go and it eases back to an idle drift.
- Ends parked on **THE END (for now)** with a post-credits row: replay, plain-text version (/about), back to orbit. `/about` gained a "Prefer the cinematic cut?" link.
- `prefers-reduced-motion`: auto-play off — the crawl moves only on input.
- Journey mode forces the night backdrop (same body-class trick as the lightspeed rides) and rests the day/night toggle; badge wordmark stays as the corner home link.

## rocketJourney reuse + improvements

- The Star-Wars streak field is **extracted from RocketJourney into `WarpStreaks.tsx`** (intensity accessor + `speedScale` prop, self-disposing) — the joyride/808 warps and the new cruise now share one implementation instead of duplicating buffers and the per-frame march.
- New **`JourneyCruise.tsx`** parks a rig in open space (far from both solar systems), eases the camera in from wherever it was, adds the rides' sway/roll breathing, and drives the shared streaks at an idle burn.
- **CameraRig** learned the view: `journey` stands the rig down with the same handoff dance as the rides, so leaving /journey resumes with the ordinary swoop (a long cinematic zoom back to the home perch). The stall-proof scroll-commit guard covers the new detached view too.
- StarField's journey dim is reused to fade the point stars ~30% behind the crawl.

## Testing done

Screenshot-verified on the dev server: deep-link entry (camera pulls away from the solar system into the cruise), crawl auto-advance, wheel scrub + full-burn streak coupling, every chapter rendering (including all [to fill in] slots), THE END + credits reveal, replay reset, Back-to-orbit exit (route, body class, star dim all restored; camera resume swoop), /about plug link, and the mobile (375px) crawl scaling. `tsc`, `lint`, `build` clean; `knip` shows only its known false positives.