### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+See `CLAUDE.md` for a full tour of the codebase (architecture, routes, 3D
+internals, content facts) and `README.md` for the standard command list.
+This file only records durable, non-obvious notes for agents.
+
+## Cursor Cloud specific instructions
+
+Single service: a client-only SPA (React 19 + rsbuild + TypeScript, Yarn 4
+via Corepack). No backend / database. Dependencies are already installed by
+the startup update script (`corepack enable` + `yarn install --immutable`).
+
+- Use `yarn` (Corepack shim → 4.6.0) — after `corepack enable`, plain
+  `yarn` resolves to 4.6.0 in this repo. Commands: `yarn start` (rsbuild dev
+  on http://localhost:3000, HMR), `yarn build`, `yarn lint`,
+  `yarn tsc --noEmit`. See `README.md`.
+- Tests run with **`bun test`**, not `yarn test`. `yarn test` (jest) is
+  intentionally broken — its `package.json` config points at
+  `config/jest/babelTransform.js`, which does not exist. The real runner is
+  Bun (`bunfig.toml` preloads `happydom.ts`; CI uses `bun test`). Bun is
+  installed in this environment and on `PATH`.
+- The Node gotcha in `CLAUDE.md` (about an old node v20.10 requiring a PATH
+  prepend before yarn commands) does **not** apply in the cloud VM: the
+  default `node` is v22.14.0, which satisfies `engines` (`>22`) and runs
+  install / lint / tsc / build / dev / `bun test` cleanly. No nvm PATH
+  juggling is needed here despite `.nvmrc` naming 24.18.0.
+- `yarn install` warns about eslint peer-dependency ranges and a few build
+  scripts (`unrs-resolver`, `core-js`, `@parcel/watcher`); these warnings
+  are harmless.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the hunt.codes SPA (React 19 + rsbuild + TypeScript, Yarn 4 via Corepack). No application code was changed.

- Startup update script: `corepack enable` + `yarn install --immutable`.
- Adds `AGENTS.md` with durable, non-obvious cloud notes (references `CLAUDE.md`/`README.md` for the rest).

## Verification (all run in the cloud VM)

| Task | Command | Result |
| --- | --- | --- |
| Install | `yarn install --immutable` | pass |
| Lint | `yarn lint` | pass (clean) |
| Typecheck | `yarn tsc --noEmit` | pass (clean) |
| Tests | `bun test` | 1 pass, 0 fail |
| Build | `yarn build` | built in ~1.2s |
| Dev server | `yarn start` | http://localhost:3000 → HTTP 200 |

## Key findings captured in AGENTS.md

- Tests run with `bun test`, **not** `yarn test` — the jest config points at a missing `config/jest/babelTransform.js`. Bun is the real runner (`bunfig.toml` + CI).
- The `CLAUDE.md` old-node (v20.10) PATH gotcha does not apply in the cloud VM; default `node` is v22.14.0 and runs everything cleanly.

## Hello-world walkthrough

Loaded the landing page, clicked the sun ("ENTER") to swoop into the `/home` view, and toggled the day/night palette.

[hunt_codes_enter_and_daynight_toggle.mp4](https://cursor.com/agents/bc-5480d268-a414-424a-a878-efb58e87c211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhunt_codes_enter_and_daynight_toggle.mp4)

[Home view (night)](https://cursor.com/agents/bc-5480d268-a414-424a-a878-efb58e87c211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_view_night.webp)
[Home view (day)](https://cursor.com/agents/bc-5480d268-a414-424a-a878-efb58e87c211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_view_day.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5480d268-a414-424a-a878-efb58e87c211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5480d268-a414-424a-a878-efb58e87c211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

