### PR TITLE
Tighten About copy and unify meta descriptions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <title>Andrew Hunt - Frontend Engineer | New York</title>
     <meta
       name="description"
-      content="Andrew Hunt is a frontend engineer in New York specializing in web development, performance, and AI-powered tooling. Consulting and open to full-time roles."
+      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, open to full-time roles."
     />
     <meta
       name="keywords"
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:description"
-      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tools. Currently consulting, but open to full-time opportunities."
+      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, open to full-time roles."
     />
     <meta property="og:image" content="https://www.hunt.codes/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -46,7 +46,7 @@
     />
     <meta
       name="twitter:description"
-      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development and AI-powered tooling."
+      content="Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, open to full-time roles."
     />
     <meta name="twitter:image" content="https://www.hunt.codes/og-image.png" />
     <meta name="twitter:creator" content="@_andrew_hunt" />
@@ -97,7 +97,7 @@
         "@type": "Person",
         "name": "Andrew Hunt",
         "jobTitle": "Frontend Engineer & Consultant",
-        "description": "Frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, but open to full-time opportunities.",
+        "description": "Andrew Hunt is a frontend engineer based in New York, specializing in web development, performance, and AI-powered tooling. Currently consulting, open to full-time roles.",
         "url": "https://www.hunt.codes",
         "image": "https://www.hunt.codes/og-image.png",
         "sameAs": [

--- a/src/App.scss
+++ b/src/App.scss
@@ -691,9 +691,6 @@ li > ul > li {
   &:nth-of-type(6) {
     animation-delay: 5s;
   }
-  &:nth-of-type(7) {
-    animation-delay: 6s;
-  }
 }
 
 @keyframes rainbowFromRedToIndigo {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ const ROUTE_TITLES: Record<string, string> = {
   "/": DEFAULT_TITLE,
   "/home": DEFAULT_TITLE,
   "/about": "About Me | Andrew Hunt",
-  "/synth": "Space Jam Studio | Andrew Hunt",
+  "/synth": "Space jam studio | Andrew Hunt",
   "/draw": "SVG Studio | Andrew Hunt",
 };
 

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -22,20 +22,19 @@ const experienceItems = [
     location: "San Francisco",
     date: "2021 - 2025",
     description: [
-      "Developed, shipped, and iterated on new product features",
-      "Led initiatives to standardize and improve shared components",
+      "Shipped product features end to end across Zip's procurement platform",
+      "Led shared-component standardization — tighter UX consistency, less design/eng thrash",
       {
-        item: "Dev infra — CI/Quality/Dev experience:",
+        item: "Dev infra — CI, quality, and DevX:",
         subbullets: [
-          "TypeScript correctness + coverage CI checks",
-          "Testing: Jest unit testing, Datadog Synthetic tests, and visual regression testing via Storybook/Chromatic",
-          "Built FE/BE logging system with Segment",
+          "TypeScript correctness + coverage gates in CI",
+          "Jest unit tests, Datadog synthetics, and visual regression via Storybook/Chromatic",
+          "FE/BE logging pipeline with Segment",
         ],
       },
-      "Architected and managed build & deploy systems across Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow",
-      "Built & maintained frontend infrastructure: dev server, Storybook, testing, logging, sourcemaps, TS/React usage, third-party package usage/maintenance",
-      "TypeScript: Enabled TypeScript and led migration of frontend code to 99% type safety",
-      "Performance: Improved page load times by >50%, primarily via code splitting and routing optimizations",
+      "Owned build & deploy across Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow",
+      "Enabled TypeScript and led the frontend migration to 99% type safety",
+      "Cut page load times by >50% via code splitting and routing optimizations",
     ],
   },
   {
@@ -132,7 +131,7 @@ const Resume = () => {
             for a proper sabbatical. A few months of recharging later, I eased
             back in through consulting, helping teams ship polished, AI-powered
             web products. Come fall 2026 I’m looking to go full-time again —
-            either way, reach out to{" "}
+            reach out to{" "}
             <a
               className="inverse"
               href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"
@@ -142,7 +141,7 @@ const Resume = () => {
             .
           </p>
           <div className="resume-divider" />
-          <h2>A few things I care about:</h2>
+          <h2>How I like to work</h2>
           <ul className="hor-list">
             <li>
               <div className="card-title">Dev infrastructure</div>I believe it’s
@@ -160,9 +159,10 @@ const Resume = () => {
               user experience.
             </li>
             <li>
-              <div className="card-title">Product collaboration</div>I excel
-              when collaborating closely with designers + researchers to build
-              delightful, engaging web products.
+              <div className="card-title">Product collaboration</div>
+              The best products come from designers, researchers, and engineers
+              building in the same room — tight feedback loops, shared taste,
+              and a bias toward shipping the delightful details.
             </li>
             <li>
               <div className="card-title">Performance</div>
@@ -172,9 +172,7 @@ const Resume = () => {
             </li>
           </ul>
           <div>
-            <div className="card-title">
-              Tools and frameworks I know fairly well:
-            </div>
+            <div className="card-title">Tools & Frameworks in my orbit</div>
             <div className="flex flex-wrap gap-2 mt-2">
               {tools.map((t) => (
                 <span className="pill tool-pill" key={t}>
@@ -269,7 +267,6 @@ const interests = [
   "Music Production",
   "Politics 😬",
   "Crosswords",
-  "Web3",
 ];
 
 export default Resume;

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -29,7 +29,7 @@ const experienceItems = [
         subbullets: [
           "TypeScript correctness + coverage gates in CI",
           "Jest unit tests, Datadog synthetics, and visual regression via Storybook/Chromatic",
-          "FE/BE logging pipeline with Segment",
+          "Built unified FE/BE logging pipeline with Segment",
         ],
       },
       "Owned build & deploy across Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Copy polish from the journey review:

- **About intro** — removed unclear “either way,” so the fall-2026 full-time line leads straight into the email CTA
- **How I like to work** — retitled from “A few things I care about”
- **Product collaboration** — rewritten as a belief about shared taste / tight loops instead of “I excel when…”
- **Tools & Frameworks in my orbit** — replaces the hedged tools label
- **Zip bullets** — lead with sharper outcomes; drop the overlapping infra bullet; tighten DevX sub-bullets (including “Built unified FE/BE logging pipeline with Segment”)
- **Interests** — dropped Web3 (and synced the rainbow `nth-of-type` delays)
- **Meta** — one description reused for primary / OG / Twitter / JSON-LD
- **Synth document title** — sentence case: “Space jam studio”

Merged latest `master` (includes `/journey` + draw backend). Conflict resolved by keeping sentence-case synth title and master’s `/journey` title.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn build`
- [ ] Skim `/about` in day + night for the new headings and Zip bullets
- [ ] Confirm interest pills still animate (6 items)
- [ ] Check `/synth` tab title reads “Space jam studio | Andrew Hunt”
- [ ] Confirm `/journey` tab title still works after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7082a5ee-3b5a-4651-a63a-7f24f2bf6684?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7082a5ee-3b5a-4651-a63a-7f24f2bf6684&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

