### PR TITLE
[journey] fly the rocket ride into the /journey story crawl

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -302,7 +302,9 @@ body.journey-mode {
   opacity: 0.85;
 }
 
-// Post-credits chip row, revealed once the crawl's tail clears the fade
+// Post-credits chip row, revealed once the crawl's tail clears the fade.
+// z above the cockpit frame (6000) — it reads as console chrome, not as
+// something trapped behind the dashboard.
 .journey-credits {
   position: fixed;
   left: 50%;
@@ -316,7 +318,7 @@ body.journey-mode {
   transition:
     opacity 0.8s ease,
     transform 0.8s ease;
-  z-index: 10;
+  z-index: 6002;
 
   button,
   a {
@@ -338,6 +340,8 @@ body.journey-mode {
   }
 }
 
+// z above the cockpit frame: the hint sits right on the dashboard
+// console, doubling as a cockpit readout
 .journey-hint {
   position: fixed;
   left: 50%;
@@ -346,11 +350,50 @@ body.journey-mode {
   color: rgba(255, 255, 255, 0.4);
   font-size: 13px;
   letter-spacing: 0.12em;
-  z-index: 5;
+  z-index: 6002;
   transition: opacity 1s ease;
 
   &.hint-hidden {
     opacity: 0;
+  }
+}
+
+// The cockpit's "End trip" control, parked on the right of the dashboard
+// console. Only tangible while the ride is actually flying
+// (body.rocket-journey) — with a dead 3D canvas the crawl page's plain
+// back link serves instead. Same reveal timing as the windshield frame.
+.end-trip {
+  position: fixed;
+  right: 5vw;
+  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  z-index: 6002;
+  padding: 6px 14px;
+  border: 1px solid #ff5252;
+  border-radius: 4px;
+  background: rgba(18, 21, 26, 0.85);
+  color: #ff5252;
+  font-family: "nova-mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.6s ease,
+    visibility 0s linear 0.6s;
+}
+
+body.rocket-journey .end-trip {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity 0.9s ease 0.7s,
+    visibility 0s;
+
+  &:hover {
+    background: rgba(255, 82, 82, 0.22);
   }
 }
 
@@ -1479,8 +1522,8 @@ body.video-mode {
   transition: opacity 0.5s ease;
 }
 
-// ─── Rocket joyride ("surprise me") ────────────────
-// While the ride plays, `rocket-journey` on <body> (rocketJourney.ts)
+// ─── Lightspeed rides (rocket → /journey, 808 transits) ────────────────
+// While a ride plays, `rocket-journey` on <body> (rocketJourney.ts)
 // hides the page chrome — same pattern as video-mode — and reveals the
 // cockpit windshield frame. It also forces the night backdrop: the warp
 // streaks are additive light and need a black sky, even in day mode.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import "./App.scss";
 import Home from "./Home";
 import Journey from "./Journey";
 import Resume from "./Resume";
+import RocketCockpit from "./RocketCockpit";
 import Synth from "./Synth";
 import SvgGenerator from "./SvgGenerator";
 import AppBackground from "AppBackground";
@@ -120,6 +121,10 @@ const App = () => {
           <Route path="/draw" element={<SvgGenerator />} />
           <Route path="/draw/:id" element={<SvgGenerator />} />
         </Routes>
+        {/* App-level so the windshield frame and warp flash survive the
+            rides' mid-flight route hops (/home → /journey → /home) —
+            per-page mounts cut the flash short at every navigation */}
+        <RocketCockpit />
       </Router>
     </div>
   );

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -7,7 +7,6 @@ import { ArrowLeftCircleIcon } from "lucide-react";
 import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
-import RocketCockpit from "./RocketCockpit";
 import ScrollHint from "./ScrollHint";
 import { JOURNEY_STOPS } from "./scrollTransition";
 
@@ -111,7 +110,6 @@ const Home = () => {
   return (
     <>
       <SolarOverlays />
-      <RocketCockpit />
       <div className="homePageBackLink">
         <Link
           className={cx("mt-4 flex items-center gap-1 transition-transform")}

--- a/src/Journey.tsx
+++ b/src/Journey.tsx
@@ -117,11 +117,12 @@ const Journey = () => {
       );
       el.style.transform = `translate3d(-50%, ${-progress.current}px, 0)`;
 
-      // Feed the flight: hard scrubbing (either direction) revs the ship,
-      // and the crawl's position places the flyby cameos (JourneyCruise)
+      // Feed the flight: hard scrubbing revs the ship, signed so a
+      // backwards scrub flies the stars backwards too; the crawl's
+      // position places the flyby cameos (JourneyCruise)
       cruiseState.boost = Math.min(
+        Math.max(velocity.current / FULL_BURN_VELOCITY, -1),
         1,
-        Math.abs(velocity.current) / FULL_BURN_VELOCITY,
       );
       cruiseState.progressPx = progress.current;
       cruiseState.totalPx = limit;

--- a/src/Journey.tsx
+++ b/src/Journey.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeftCircleIcon } from "lucide-react";
 import cx from "classnames";
 
@@ -9,21 +9,30 @@ import {
   JOURNEY_OUTRO,
 } from "./journeyContent";
 import { cruiseState } from "./journeyCruise";
+import { journeyState, requestJourneyLanding } from "./rocketJourney";
 
 /**
  * The /journey page: Andrew's story as a Star Wars-style opening crawl,
- * gliding into a vanishing point while the 3D scene
- * (space3d/solar/JourneyCruise) cruises through open space behind it.
+ * seen from inside the rocket's cockpit — the 3D scene
+ * (space3d/solar/JourneyCruise) flies through the lightspeed streaks
+ * behind the text, and the windshield frame (RocketCockpit, revealed by
+ * body.rocket-journey) wraps the whole show. Clicking the rocket on
+ * /home warps here; deep links board mid-flight.
  *
  * It opens the way the films do: the intro line ("30+ years ago…") fades
  * up flat and centered on the black, holds, and fades out — THEN the
  * steeply-raked crawl begins. Any scrub skips straight into the crawl.
  *
  * The crawl advances on its own at reading pace; wheel, touch drag, or
- * arrow keys scrub it (forward or back), and the scrub speed feeds the
- * flight — push the story hard and the star field kicks toward
- * lightspeed (cruiseState.boost). All the words live in
- * journeyContent.ts; this file only drives the motion.
+ * arrow keys scrub it (forward or back), and the scrub feeds the flight
+ * two ways: speed revs the star field toward lightspeed
+ * (cruiseState.boost), and position places the flyby cameos
+ * (cruiseState.progressPx — the 3D objects pass exactly as the story
+ * does). All the words live in journeyContent.ts; this file only drives
+ * the motion.
+ *
+ * The cockpit's "End trip" button lands the ride: the 3D loop plays the
+ * re-entry flash and drops the ship back onto /home.
  *
  * Under prefers-reduced-motion the intro is skipped and the auto-play
  * stops: the crawl moves only when the visitor scrolls it.
@@ -46,6 +55,7 @@ const prefersReducedMotion = () =>
   Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
 
 const Journey = () => {
+  const navigate = useNavigate();
   const crawlRef = useRef<HTMLDivElement>(null);
   const progress = useRef(0);
   const velocity = useRef(0);
@@ -73,6 +83,9 @@ const Journey = () => {
     return () => {
       document.body.classList.remove("journey-mode");
       cruiseState.boost = 0;
+      // Stale crawl coordinates must not place cameos on the next visit
+      cruiseState.progressPx = 0;
+      cruiseState.totalPx = 0;
     };
   }, []);
 
@@ -104,11 +117,14 @@ const Journey = () => {
       );
       el.style.transform = `translate3d(-50%, ${-progress.current}px, 0)`;
 
-      // Feed the flight: hard scrubbing (either direction) revs the ship
+      // Feed the flight: hard scrubbing (either direction) revs the ship,
+      // and the crawl's position places the flyby cameos (JourneyCruise)
       cruiseState.boost = Math.min(
         1,
         Math.abs(velocity.current) / FULL_BURN_VELOCITY,
       );
+      cruiseState.progressPx = progress.current;
+      cruiseState.totalPx = limit;
 
       const atEnd = progress.current >= limit - 1;
       if (atEnd !== endedRef.current) {
@@ -224,6 +240,26 @@ const Journey = () => {
       >
         scroll to travel faster
       </div>
+      {/* Sits on the cockpit dashboard (App.scss shows it only while
+          body.rocket-journey is up — i.e. whenever the 3D ride is
+          actually flying; with a dead canvas the plain back link above
+          stays instead) */}
+      <button
+        type="button"
+        className="end-trip"
+        onClick={() => {
+          // The 3D loop plays the landing (flash, drop onto home's
+          // approach line, route change); without a ride in flight
+          // there's nothing to land — just leave
+          if (journeyState.phase !== "idle") {
+            requestJourneyLanding();
+          } else {
+            void navigate("/home");
+          }
+        }}
+      >
+        End trip
+      </button>
     </>
   );
 };

--- a/src/RocketCockpit.tsx
+++ b/src/RocketCockpit.tsx
@@ -4,7 +4,8 @@ import React from "react";
  * The lightspeed journeys' cockpit dressing: a steel windshield frame
  * whose edges hug the viewport (so warp reads as seen from inside the
  * ship) and the white flash that covers the jumps. Pure DOM/SVG —
- * mounted by every page a journey can start or end on (/home, /synth),
+ * mounted once at App level (the rides hop routes mid-flight, and a
+ * per-page mount would cut the covering flash short at each hop),
  * revealed by `body.rocket-journey` (App.scss), never takes pointer
  * input.
  *

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -126,9 +126,9 @@ const SolarOverlays = () => {
           </Tooltip>
         </TooltipProvider>
       ))}
-      {/* The rocket easter egg: not a link — clicking it boards the ship
-          and plays the lightspeed joyride (rocketJourney.ts). Same anchor
-          plumbing as the asteroid links. */}
+      {/* The rocket easter egg: clicking it boards the ship and warps to
+          the /journey story crawl (rocketJourney.ts flips the route under
+          the warp flash). Same anchor plumbing as the asteroid links. */}
       <TooltipProvider delayDuration={100}>
         <Tooltip disableHoverableContent>
           <TooltipTrigger asChild>
@@ -137,7 +137,15 @@ const SolarOverlays = () => {
               id={asteroidAnchorId("rocket")}
               className="asteroid-link"
               aria-label="So u wanna be astronaut?"
-              onClick={() => startRocketJourney()}
+              onClick={() => {
+                startRocketJourney();
+                // The ride flips the URL itself under its warp flash; if
+                // the 3D driver is dead (crashed canvas) fall through to
+                // the plain crawl page so the click still goes somewhere
+                if (journeyState.phase === "idle") {
+                  void navigate("/journey");
+                }
+              }}
               onPointerEnter={() => {
                 hoverState.asteroid = "rocket";
               }}

--- a/src/Synth.tsx
+++ b/src/Synth.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowLeftCircleIcon } from "lucide-react";
 
-import RocketCockpit from "./RocketCockpit";
 import { journeyState, startSynthReturn } from "./rocketJourney";
 import {
   SYNTH_KNOBS,
@@ -156,7 +155,6 @@ const Synth = () => {
 
   return (
     <>
-      <RocketCockpit />
       <div className="synthBackLink">
         <button type="button" onClick={() => startSynthReturn()}>
           <ArrowLeftCircleIcon className="starIcon" size={16} />

--- a/src/journeyContent.ts
+++ b/src/journeyContent.ts
@@ -27,16 +27,16 @@ export const JOURNEY_CHAPTERS: JourneyChapter[] = [
     era: "the early years",
     title: "Grew up in Oregon",
     lines: [
-      "Raised in [to fill in: hometown], Oregon — evergreens, drizzle, and a family computer that was asking for it.",
-      "[to fill in: first computer / first thing ever built]",
+      "Born in Rochester, NY; raised in Oregon — evergreens, drizzle, and a family computer that was asking for it.",
+      "Lego robotics kid, later captain of the high-school robotics team — with a middle-school magnum opus in between: a website called “Andy and David: A place for fun.” It was.",
     ],
   },
   {
-    era: "[to fill in: years] · New Jersey",
+    era: "2013 – 2017 · New Jersey",
     title: "Princeton University",
     lines: [
-      "Studied [to fill in: major] at Princeton.",
-      "[to fill in: a story — the class, the club, the thesis, the all-nighter]",
+      "Studied computer science at Princeton.",
+      "Four years of problem sets and late nights, with an eye drifting steadily toward the West Coast.",
     ],
   },
   {
@@ -68,7 +68,7 @@ export const JOURNEY_CHAPTERS: JourneyChapter[] = [
     title: "Zip — Staff Software Engineer",
     lines: [
       "Four years, zero to staff: new product features, shared component systems, and the frontend infrastructure underneath all of it.",
-      "CI type-safety gates, testing across Jest, Datadog Synthetics, and Chromatic, logging with Segment, and build & deploy spanning Webpack, Jenkins, Docker, S3, Cloudflare, and Webflow.",
+      "Type-safety gates in CI, testing three layers deep, and the build-and-deploy machinery under everything.",
       "TypeScript to 99% coverage; page loads cut by more than half.",
     ],
   },
@@ -77,7 +77,7 @@ export const JOURNEY_CHAPTERS: JourneyChapter[] = [
     title: "The sabbatical",
     lines: [
       "Stepped away for a proper recharge — and a move across the country to New York City.",
-      "[to fill in: the best thing you did with the time off]",
+      "Somewhere in there, got thoroughly addicted to 3D printing.",
     ],
   },
   {

--- a/src/journeyCruise.ts
+++ b/src/journeyCruise.ts
@@ -1,13 +1,20 @@
 /**
  * Shared state for the /journey cruise: the crawl page (DOM) writes how
- * hard the visitor is pushing the scroll, and the 3D cruise
- * (space3d/solar/JourneyCruise) eases the warp-streak intensity toward
- * it — scrub fast and the ship burns harder. Plain mutable module, same
- * pattern as solarHover / rocketJourney, so main-chunk pages can import
- * it without dragging three.js out of its lazy chunk.
+ * hard the visitor is pushing the scroll and where the crawl currently
+ * sits, and the 3D cruise (space3d/solar/JourneyCruise) reads both —
+ * scrub fast and the ship burns harder; the flyby cameos are glued to
+ * the crawl's progress, so they pass by exactly as the story does.
+ * Plain mutable module, same pattern as solarHover / rocketJourney, so
+ * main-chunk pages can import it without dragging three.js out of its
+ * lazy chunk.
  */
 export const cruiseState = {
   /** 0..1 — extra flight intensity from crawl scroll velocity (decays
    *  back to 0 in the crawl's frame loop) */
   boost: 0,
+  /** Crawl position in px (0 = story start), written every crawl frame */
+  progressPx: 0,
+  /** Full crawl length in px; 0 until the crawl page has measured itself
+   *  (the cameos hide while it's 0 — no crawl, no story to fly past) */
+  totalPx: 0,
 };

--- a/src/journeyCruise.ts
+++ b/src/journeyCruise.ts
@@ -9,8 +9,10 @@
  * lazy chunk.
  */
 export const cruiseState = {
-  /** 0..1 — extra flight intensity from crawl scroll velocity (decays
-   *  back to 0 in the crawl's frame loop) */
+  /** -1..1 — signed flight throttle from crawl scroll velocity (decays
+   *  back to 0 in the crawl's frame loop): magnitude revs the streaks,
+   *  sign steers them — scrub the story backwards and the ship flies
+   *  backwards too */
   boost: 0,
   /** Crawl position in px (0 = story start), written every crawl frame */
   progressPx: 0,

--- a/src/rocketJourney.ts
+++ b/src/rocketJourney.ts
@@ -1,31 +1,34 @@
 /**
- * State machine for the lightspeed journeys: the rocket joyride (the
- * "So u wanna be astronaut?" easter egg on /home) and the 808-pad
- * transit to the synth solar system (/synth) and back. The DOM overlays
- * set journeys off; the 3D scene reads and advances the state per frame
- * (space3d/solar/RocketJourney). Lives in its own three-free module,
- * same as solarHover, so main-chunk components can import it without
- * dragging three.js out of its lazy chunk.
+ * State machine for the lightspeed journeys: the rocket ride to the
+ * /journey story crawl (the "So u wanna be astronaut?" easter egg on
+ * /home) and the 808-pad transit to the synth solar system (/synth) and
+ * back. The DOM overlays set journeys off; the 3D scene reads and
+ * advances the state per frame (space3d/solar/RocketJourney plays the
+ * boarding beats and the synth warps; space3d/solar/JourneyCruise owns
+ * the rocket ride's open-ended warp on /journey). Lives in its own
+ * three-free module, same as solarHover, so main-chunk components can
+ * import it without dragging three.js out of its lazy chunk.
  *
  * Phases: "boarding" flies the camera toward the vehicle (or just turns
  * it toward home, for the return trip) while the windshield frame fades
- * in; a flash covers the jump to the warp zone ("warp"), where the star
- * streaks — and, on the joyride, the flyby cameos — play; a second
- * flash covers the drop onto the destination's approach line, after
- * which the journey is over ("idle") and CameraRig's ordinary swoop
- * glides the last stretch onto the perch.
+ * in; a flash covers the jump to the warp zone ("warp"). The synth
+ * transits' warp is timed — a second flash drops onto the destination's
+ * approach line and the journey is over ("idle"). The rocket ride's warp
+ * is the /journey cruise itself: it lasts as long as the visitor rides
+ * the story crawl, until the cockpit's "End trip" button (or the crawl
+ * page going away) lands it.
  */
 import { hoverState } from "./solarHover";
 
 export type JourneyPhase = "idle" | "boarding" | "warp";
-export type JourneyDestination = "home" | "synth";
+export type JourneyDestination = "home" | "synth" | "journey";
 /** What the boarding beat aims at: the rocket's nose, the 808 pad, or
- *  nothing (the synth return just turns the camera toward home). */
+ *  nothing (the synth return just turns the camera toward home; the
+ *  /journey cruise starts mid-warp on a deep link). */
 export type JourneyVehicle = "rocket" | "pad" | "none";
 
-/** The full joyride (rocket): board, long warp with cameos, land home */
+/** The rocket ride: board behind the nose, then warp into the crawl */
 const BOARDING_SECONDS = 1.8;
-const WARP_SECONDS = 11.4;
 /** The synth transit (808 pad, both directions): quick, streaks only —
  *  it's navigation the visitor takes twice a session, not the joyride
  *  show. The warp still fits its full 0.9s stretch-in + 1s collapse-out
@@ -47,13 +50,16 @@ export const journeyState = {
    *  the overlay button can outlive the scene — without a driver the
    *  ride must not start, or the hidden page UI would never come back. */
   driverAlive: false,
+  /** The cockpit's "End trip" button raises this; JourneyCruise's frame
+   *  loop consumes it (flash, drop onto home's approach line, land). */
+  landingRequested: false,
   // ── per-journey plan, set by the start functions ──
   destination: "home" as JourneyDestination,
   vehicle: "rocket" as JourneyVehicle,
   boardSeconds: BOARDING_SECONDS,
-  warpSeconds: WARP_SECONDS,
-  /** Flyby cameos only play on the joyride, not the synth transits */
-  cameos: true,
+  /** Timed warps only (the synth transits); the rocket ride's warp is
+   *  open-ended — the crawl decides when it's over */
+  warpSeconds: TRANSIT_WARP_SECONDS,
 };
 
 /** The `body` class that hides the page UI and reveals the windshield
@@ -65,16 +71,15 @@ function beginJourney(
   destination: JourneyDestination,
   boardSeconds: number,
   warpSeconds: number,
-  cameos: boolean,
 ): void {
   if (journeyState.phase !== "idle" || !journeyState.driverAlive) return;
   journeyState.vehicle = vehicle;
   journeyState.destination = destination;
   journeyState.boardSeconds = boardSeconds;
   journeyState.warpSeconds = warpSeconds;
-  journeyState.cameos = cameos;
   journeyState.phase = "boarding";
   journeyState.phaseElapsed = 0;
+  journeyState.landingRequested = false;
   // The pointer is parked on the clicked overlay while it boards; the
   // overlay goes pointer-events:none without a reliable pointerleave, so
   // drop the hover freeze/whitewash here
@@ -82,29 +87,42 @@ function beginJourney(
   document.body.classList.add(JOURNEY_BODY_CLASS);
 }
 
-/** The rocket joyride: there and back again, all on /home. */
+/** The rocket ride: board on /home, then warp into the /journey story
+ *  crawl (RocketJourney flips the route under the warp flash). */
 export const startRocketJourney = (): void =>
-  beginJourney("rocket", "home", BOARDING_SECONDS, WARP_SECONDS, true);
+  beginJourney("rocket", "journey", BOARDING_SECONDS, Infinity);
 
 /** The 808 pad: warp from /home to the synth solar system (/synth). */
 export const startSynthJourney = (): void =>
-  beginJourney(
-    "pad",
-    "synth",
-    TRANSIT_BOARD_SECONDS,
-    TRANSIT_WARP_SECONDS,
-    false,
-  );
+  beginJourney("pad", "synth", TRANSIT_BOARD_SECONDS, TRANSIT_WARP_SECONDS);
 
 /** Back to Earth from the synth system (/synth -> /home). */
 export const startSynthReturn = (): void =>
-  beginJourney(
-    "none",
-    "home",
-    RETURN_TURN_SECONDS,
-    TRANSIT_WARP_SECONDS,
-    false,
-  );
+  beginJourney("none", "home", RETURN_TURN_SECONDS, TRANSIT_WARP_SECONDS);
+
+/** The /journey cruise announcing itself (JourneyCruise's first frame):
+ *  a deep link or résumé-link arrival starts the ride mid-warp — cockpit
+ *  up, no boarding beat. No-op when the rocket boarding already began
+ *  the ride (or any other journey is playing). */
+export function startJourneyCruise(): void {
+  if (journeyState.phase !== "idle") return;
+  journeyState.vehicle = "none";
+  journeyState.destination = "journey";
+  journeyState.boardSeconds = 0;
+  journeyState.warpSeconds = Infinity;
+  journeyState.phase = "warp";
+  journeyState.phaseElapsed = 0;
+  journeyState.landingRequested = false;
+  document.body.classList.add(JOURNEY_BODY_CLASS);
+}
+
+/** The cockpit's "End trip" button: asks the cruise to drop out of
+ *  lightspeed and land home. The 3D loop performs the landing (flash,
+ *  approach line, route change) on its next frame. */
+export function requestJourneyLanding(): void {
+  if (journeyState.phase === "idle") return;
+  journeyState.landingRequested = true;
+}
 
 /** Ends the ride (natural landing or an abort — route change, scene
  *  unmount) and restores the page UI. Safe to call when already idle. */
@@ -112,11 +130,12 @@ export function endRocketJourney(): void {
   journeyState.phase = "idle";
   journeyState.phaseElapsed = 0;
   journeyState.starDim = 0;
+  journeyState.landingRequested = false;
   document.body.classList.remove(JOURNEY_BODY_CLASS);
 }
 
 /** One-shot white flash covering the warp entry/exit teleports (the
- *  element lives in the page's RocketCockpit overlay). */
+ *  element lives in the app-level RocketCockpit overlay). */
 export function flashWarp(): void {
   const el = document.getElementById("warp-flash");
   if (!el) return;

--- a/src/space3d/solar/JourneyCruise.tsx
+++ b/src/space3d/solar/JourneyCruise.tsx
@@ -121,6 +121,9 @@ export default function JourneyCruise({
   const captured = useRef(false);
   const entry = useRef(0);
   const intensity = useRef(0);
+  /** Signed streak direction, eased toward the scrub's sign: +1 cruising
+   *  forward, -1 while the story is being rewound */
+  const flow = useRef(1);
   /** Latched by the landing so the frames before unmount stay put */
   const landed = useRef(false);
 
@@ -206,12 +209,16 @@ export default function JourneyCruise({
     camera.quaternion.slerpQuaternions(fromQuat.current, targetQuat, e);
 
     // Throttle: idle drift plus however hard the crawl is being scrubbed
+    // (boost is signed — magnitude revs the burn, sign steers the flow:
+    // scrub the story backwards and the star field streams backwards)
     const target = Math.min(
       1,
-      BASE_INTENSITY + cruiseState.boost * BOOST_INTENSITY,
+      BASE_INTENSITY + Math.abs(cruiseState.boost) * BOOST_INTENSITY,
     );
     intensity.current +=
       (target * e - intensity.current) * Math.min(1, delta * 3);
+    const flowTarget = cruiseState.boost < 0 ? -1 : 1;
+    flow.current += (flowTarget - flow.current) * Math.min(1, delta * 3);
 
     // Chase the cruise's star dim rather than assigning it: a rocket
     // arrival comes in fully dimmed (boarding drove starDim to 1) and
@@ -256,6 +263,7 @@ export default function JourneyCruise({
       <pointLight position={[6, 14, 18]} intensity={2.2} decay={0} />
       <WarpStreaks
         getIntensity={() => intensity.current}
+        getFlow={() => flow.current}
         speedScale={CRUISE_SPEED_SCALE}
       />
       {artifacts.map((artifact, i) => (

--- a/src/space3d/solar/JourneyCruise.tsx
+++ b/src/space3d/solar/JourneyCruise.tsx
@@ -1,85 +1,193 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import WarpStreaks from "./WarpStreaks";
-import { journeyState } from "../../rocketJourney";
+import { viewGoal } from "./CameraRig";
+import { ARTIFACT_BUILDERS, disposeArtifact } from "./warpArtifacts";
+import {
+  endRocketJourney,
+  flashWarp,
+  journeyState,
+  startJourneyCruise,
+} from "../../rocketJourney";
 import { cruiseState } from "../../journeyCruise";
 
 /**
- * The /journey flight: while the crawl page is up, the camera cruises
- * through open space — parked far from both solar systems, drifting
- * through the shared streak field (WarpStreaks) at an easy burn. The
- * crawl's scroll velocity feeds cruiseState.boost, so scrubbing the
- * story hard kicks the ship toward lightspeed and eases back to a
- * drift when the visitor lets go.
+ * The /journey flight: the rocket ride's destination and the story
+ * crawl's stage. While the crawl page is up, the camera is parked far
+ * from both solar systems, flying through the shared streak field
+ * (WarpStreaks) from inside the cockpit (RocketCockpit's windshield,
+ * revealed by body.rocket-journey). This component starts the ride
+ * state itself on its first frame, so a deep link or the résumé link
+ * gets the cockpit too — not just the rocket easter egg.
+ *
+ * The crawl's scroll velocity feeds cruiseState.boost (scrub the story
+ * hard and the ship kicks toward lightspeed), and the crawl's PROGRESS
+ * drives the flyby cameos: each artifact owns its own stretch of the
+ * story, so they pass exactly as the text does — park the crawl and the
+ * cameo parks, scroll back and it rewinds. (Eventually these become
+ * objects matched to the chapters they fly past.)
  *
  * While mounted this component owns the camera (CameraRig stands down,
- * same dance as the lightspeed rides): on mount it eases from wherever
- * the camera was into the cruise pose; on unmount CameraRig's handoff
- * swoop glides back to the destination view.
+ * same dance as the synth transits): arriving out of the rocket's
+ * boarding flash it snaps straight to the cruise pose (RocketJourney
+ * already teleported the camera there under the flash); on a plain
+ * navigation it eases in from wherever the camera was. The cockpit's
+ * "End trip" button raises journeyState.landingRequested; the landing
+ * plays the rides' re-entry beat — flash, drop onto home's approach
+ * line, route change — and CameraRig's resume swoop glides the last
+ * stretch onto the perch.
  */
 
 /** Far from the home system (origin) and the synth system (far below) */
-const CRUISE_POS = new THREE.Vector3(0, 30, 700);
+export const CRUISE_POS = new THREE.Vector3(0, 30, 700);
 /** Flight heading: out into empty space, away from every body */
 const CRUISE_DIR = new THREE.Vector3(0.2, 0.06, 1).normalize();
 const ENTRY_SECONDS = 1.6;
 /** Idle drift vs full-burn streak intensity */
 const BASE_INTENSITY = 0.28;
 const BOOST_INTENSITY = 0.65;
-/** Cruise streaks amble slower than the rides' warp sprint */
+/** Cruise streaks amble slower than the synth transits' warp sprint */
 const CRUISE_SPEED_SCALE = 0.45;
 /** Background point stars dim a touch so the crawl + streaks read */
 const STAR_DIM_CRUISE = 0.3;
 
+/** How far out on home's approach line the landing drops the camera
+ *  (same spot the old timed joyride landed on) */
+const REENTRY_DISTANCE = 130;
+
+/** Flyby cameo flight path, in rig-local units (-z is ahead) */
+const ARTIFACT_Z_START = -170;
+const ARTIFACT_Z_EXIT = 25;
+/** Each cameo owns 1/Nth of the crawl (its "slot"); it waits LEAD of the
+ *  slot, then crosses the windshield over SPAN of it — so the cameos
+ *  tile the story one at a time, with every pass finished by the end. */
+const ARTIFACT_LEAD = 0.05;
+const ARTIFACT_SPAN = 0.9;
+
+/** Lateral flyby heights, hand-varied so consecutive cameos don't trace
+ *  the same line across the window */
+const ARTIFACT_HEIGHTS = [-2, 3, -3.5, 2.5, 4.5, -2.5, 3.5, -3];
+const ARTIFACT_SCALES = [4.5, 3.8, 3.6, 3.4, 3.6, 3.8, 3.8, 3.2];
+
 const UP = new THREE.Vector3(0, 1, 0);
 const Z_AXIS = new THREE.Vector3(0, 0, 1);
+
+/** The parked flight orientation, derived once from the heading */
+export const CRUISE_QUAT = new THREE.Quaternion().setFromRotationMatrix(
+  new THREE.Matrix4().lookAt(
+    CRUISE_POS,
+    CRUISE_POS.clone().add(CRUISE_DIR),
+    UP,
+  ),
+);
 
 const easeInOutCubic = (x: number) =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
 
 // scratch values, reused every frame
-const lookTarget = new THREE.Vector3();
-const lookMatrix = new THREE.Matrix4();
-const cruiseQuat = new THREE.Quaternion();
 const sway = new THREE.Vector3();
 const swayedPos = new THREE.Vector3();
 const rollQuat = new THREE.Quaternion();
 const targetQuat = new THREE.Quaternion();
+const goalPos = new THREE.Vector3();
+const goalLook = new THREE.Vector3();
+const forward = new THREE.Vector3();
+const lookMatrix = new THREE.Matrix4();
 
-export default function JourneyCruise() {
+interface FlybyArtifact {
+  group: THREE.Group;
+  /** Which 1/Nth of the crawl this cameo rides */
+  slot: number;
+  /** -1 flies past on the left, +1 on the right */
+  side: number;
+  y: number;
+  baseYaw: number;
+  tilt: number;
+  spin: number;
+}
+
+export default function JourneyCruise({
+  navigate,
+}: {
+  /** Router navigation, threaded in from outside the canvas — the
+   *  landing hops back to /home */
+  navigate: (to: string) => void;
+}) {
   const rig = useRef<THREE.Group>(null);
   const fromPos = useRef(new THREE.Vector3());
   const fromQuat = useRef(new THREE.Quaternion());
   const captured = useRef(false);
   const entry = useRef(0);
   const intensity = useRef(0);
+  /** Latched by the landing so the frames before unmount stay put */
+  const landed = useRef(false);
 
-  // The cruise borrows the rides' star dim; hand it back on unmount
-  useEffect(
-    () => () => {
-      journeyState.starDim = 0;
-    },
+  const artifacts: FlybyArtifact[] = useMemo(
+    () =>
+      ARTIFACT_BUILDERS.map((build, i) => {
+        const group = build();
+        group.scale.setScalar(ARTIFACT_SCALES[i]);
+        group.visible = false;
+        return {
+          group,
+          slot: i,
+          side: i % 2 === 0 ? -1 : 1,
+          y: ARTIFACT_HEIGHTS[i],
+          baseYaw: (i * Math.PI) / 3,
+          tilt: (i % 2 === 0 ? 1 : -1) * (0.15 + (i % 3) * 0.12),
+          spin: 0.6 + (i % 3) * 0.35,
+        };
+      }),
     [],
   );
+  useEffect(
+    () => () => artifacts.forEach((a) => disposeArtifact(a.group)),
+    [artifacts],
+  );
 
-  useFrame(({ camera, clock }, rawDelta) => {
+  // Leaving /journey any way but the landing (browser back, credits
+  // links) must still restore the page UI and star brightness
+  useEffect(() => () => endRocketJourney(), []);
+
+  useFrame(({ camera, clock, size }, rawDelta) => {
+    if (landed.current) return;
     // Clamped like the rides: a backgrounded tab pauses, not skips
     const delta = Math.min(rawDelta, 0.1);
     const t = clock.elapsedTime;
 
     if (!captured.current) {
       captured.current = true;
+      // A rocket arrival lands mid-warp: the boarding flash already
+      // covered the teleport to the cruise pose, so skip the entry ease.
+      // (Checked before startJourneyCruise, which flips idle → warp.)
+      if (journeyState.phase === "warp") entry.current = 1;
+      startJourneyCruise();
       fromPos.current.copy(camera.position);
       fromQuat.current.copy(camera.quaternion);
-      lookTarget.copy(CRUISE_POS).add(CRUISE_DIR);
-      lookMatrix.lookAt(CRUISE_POS, lookTarget, UP);
-      cruiseQuat.setFromRotationMatrix(lookMatrix);
       if (rig.current) {
         rig.current.position.copy(CRUISE_POS);
-        rig.current.quaternion.copy(cruiseQuat);
+        rig.current.quaternion.copy(CRUISE_QUAT);
       }
+    }
+
+    // "End trip": drop out of lightspeed onto home's approach line —
+    // the same re-entry beat as the synth transits. Ending the journey
+    // hands the camera to CameraRig, whose resume swoop after the route
+    // change glides the last stretch onto the perch.
+    if (journeyState.landingRequested) {
+      landed.current = true;
+      viewGoal("home", t, camera, size, goalPos, goalLook);
+      forward.copy(goalLook).sub(goalPos).normalize();
+      camera.position.copy(goalPos).addScaledVector(forward, -REENTRY_DISTANCE);
+      lookMatrix.lookAt(camera.position, goalLook, UP);
+      camera.quaternion.setFromRotationMatrix(lookMatrix);
+      if (rig.current) rig.current.visible = false;
+      flashWarp();
+      navigate("/home");
+      endRocketJourney();
+      return;
     }
 
     entry.current = Math.min(1, entry.current + delta / ENTRY_SECONDS);
@@ -89,10 +197,10 @@ export default function JourneyCruise() {
     // (the same feel as the rides' warp; the streak field stays put)
     sway
       .set(Math.sin(t * 0.8) * 0.5, Math.sin(t * 1.17) * 0.35, 0)
-      .applyQuaternion(cruiseQuat);
+      .applyQuaternion(CRUISE_QUAT);
     swayedPos.copy(CRUISE_POS).add(sway);
     rollQuat.setFromAxisAngle(Z_AXIS, Math.sin(t * 0.6) * 0.03);
-    targetQuat.copy(cruiseQuat).multiply(rollQuat);
+    targetQuat.copy(CRUISE_QUAT).multiply(rollQuat);
 
     camera.position.lerpVectors(fromPos.current, swayedPos, e);
     camera.quaternion.slerpQuaternions(fromQuat.current, targetQuat, e);
@@ -105,15 +213,54 @@ export default function JourneyCruise() {
     intensity.current +=
       (target * e - intensity.current) * Math.min(1, delta * 3);
 
-    journeyState.starDim = STAR_DIM_CRUISE * e;
+    // Chase the cruise's star dim rather than assigning it: a rocket
+    // arrival comes in fully dimmed (boarding drove starDim to 1) and
+    // the points ease back in instead of popping
+    journeyState.starDim +=
+      (STAR_DIM_CRUISE * e - journeyState.starDim) * Math.min(1, delta * 2);
+
+    // Flyby cameos, glued to the crawl: p is this artifact's own 0..1
+    // pass through the windshield, derived purely from crawl progress
+    const slotPx =
+      artifacts.length > 0 ? cruiseState.totalPx / artifacts.length : 0;
+    for (const artifact of artifacts) {
+      const p =
+        slotPx > 0
+          ? (cruiseState.progressPx -
+              (artifact.slot + ARTIFACT_LEAD) * slotPx) /
+            (slotPx * ARTIFACT_SPAN)
+          : -1;
+      if (p < 0 || p > 1) {
+        artifact.group.visible = false;
+        continue;
+      }
+      artifact.group.visible = true;
+      const z = ARTIFACT_Z_START + p * (ARTIFACT_Z_EXIT - ARTIFACT_Z_START);
+      // Drifts outward as it nears, exiting past the windshield's shoulder
+      artifact.group.position.set(artifact.side * (9 + p * 14), artifact.y, z);
+      // The tumble stays on the clock — a parked cameo still feels alive
+      artifact.group.rotation.set(
+        artifact.tilt,
+        artifact.baseYaw + t * artifact.spin,
+        0,
+      );
+    }
   });
 
   return (
     <group ref={rig}>
+      {/* The cruise brings its own light for the cameos (the scene's
+          ambient is starlight-dim); parented here, it lives only while
+          the cruise does */}
+      <ambientLight intensity={0.55} />
+      <pointLight position={[6, 14, 18]} intensity={2.2} decay={0} />
       <WarpStreaks
         getIntensity={() => intensity.current}
         speedScale={CRUISE_SPEED_SCALE}
       />
+      {artifacts.map((artifact, i) => (
+        <primitive key={i} object={artifact.group} />
+      ))}
     </group>
   );
 }

--- a/src/space3d/solar/RocketJourney.tsx
+++ b/src/space3d/solar/RocketJourney.tsx
@@ -1,35 +1,38 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 import { planetPosition, ROCKET, SYNTH_PAD } from "./constants";
 import { rocketNoseDirection } from "./Rocket";
 import { viewGoal, type SolarView } from "./CameraRig";
-import { ARTIFACT_BUILDERS, disposeArtifact } from "./warpArtifacts";
+import { CRUISE_POS, CRUISE_QUAT } from "./JourneyCruise";
 import WarpStreaks from "./WarpStreaks";
 import { endRocketJourney, flashWarp, journeyState } from "../../rocketJourney";
 import { SYNTH_ORIGIN } from "../../synthSpec";
 
 /**
- * Drives every lightspeed journey: the rocket joyride (the /home
- * "So u wanna be astronaut?" easter egg) and the 808-pad transits to
- * the synth solar system and back. While journeyState is active this
- * component owns the camera — CameraRig stands down — and plays three
- * beats:
+ * Drives the lightspeed journeys' boarding beats and the 808-pad
+ * transits to the synth solar system and back. While journeyState is
+ * active this component owns the camera (CameraRig stands down) — with
+ * one handoff: the rocket ride's warp is the /journey cruise, owned by
+ * JourneyCruise, so once that ride reaches warp this driver goes quiet.
+ *
+ * The beats:
  *
  * 1. Boarding: the camera swoops toward the journey's vehicle (behind
  *    the rocket's nose, or down over the 808 pad; the synth return just
  *    swings the nose around toward home) while the stars fade and the
  *    DOM windshield frame fades in (App.scss, `body.rocket-journey`).
- * 2. Warp: a flash covers a teleport to a "warp zone" hundreds of units
- *    along the travel heading — far enough that no solar system is more
- *    than a speck. The rig (this component's group) is parked there
- *    carrying the Star Wars streak field — plus the flyby artifact
- *    cameos on the joyride — and the camera sways gently inside it.
- * 3. Re-entry: a second flash covers a teleport onto the destination
- *    view's approach line (navigating to its route if needed), then the
- *    journey ends and CameraRig's ordinary resume swoop glides the last
- *    stretch onto the perch — the landing.
+ * 2. Warp: a flash covers a teleport along the travel heading. For the
+ *    rocket ride the teleport is straight to the /journey cruise pose —
+ *    the route flips under the flash and JourneyCruise takes the camera
+ *    (the story crawl decides when that warp ends). The synth transits
+ *    stay here: parked in a "warp zone" far from every system, inside
+ *    the Star Wars streak field, while the camera sways gently.
+ * 3. Re-entry (synth transits only): a second flash covers a teleport
+ *    onto the destination view's approach line (navigating to its route
+ *    if needed), then the journey ends and CameraRig's ordinary resume
+ *    swoop glides the last stretch onto the perch — the landing.
  *
  * The streaks are one LineSegments whose head vertices march toward the
  * camera and wrap; line length and material opacity ride the warp
@@ -42,8 +45,6 @@ const BOARD_CAM_BEHIND = 1.5;
 const BOARD_PAD_BEHIND = 2.2;
 const BOARD_LOOK_AHEAD = 10;
 
-/** Joyride warp zone: this far from the origin along the rocket's nose */
-const WARP_DISTANCE = 900;
 /** Transit warp zone: this far past the boarding spot along the heading
  *  (roughly a quarter of the way to the other system) */
 const TRANSIT_WARP_AHEAD = 450;
@@ -52,12 +53,6 @@ const WARP_RAMP_IN_SECONDS = 0.9;
 const WARP_RAMP_OUT_SECONDS = 1;
 /** Stars fade back in over the last stretch of warp (decelerating) */
 const STAR_RETURN_SECONDS = 1.2;
-
-const ARTIFACT_Z_START = -170;
-const ARTIFACT_Z_EXIT = 25;
-const ARTIFACT_SPEED = 115;
-const ARTIFACT_FIRST_SPAWN = 1;
-const ARTIFACT_SPAWN_INTERVAL = 1.25;
 
 /** How far out on the destination's approach line re-entry drops the
  *  camera (the synth view sits closer, so its approach is shorter) */
@@ -89,30 +84,15 @@ const goalPos = new THREE.Vector3();
 const goalLook = new THREE.Vector3();
 const forward = new THREE.Vector3();
 
-interface FlybyArtifact {
-  group: THREE.Group;
-  spawnAt: number;
-  /** -1 flies past on the left, +1 on the right */
-  side: number;
-  y: number;
-  baseYaw: number;
-  tilt: number;
-  spin: number;
-}
-
-/** Lateral flyby heights, hand-varied so consecutive cameos don't trace
- *  the same line across the window */
-const ARTIFACT_HEIGHTS = [-2, 3, -3.5, 2.5, 4.5, -2.5, 3.5, -3];
-const ARTIFACT_SCALES = [4.5, 3.8, 3.6, 3.4, 3.6, 3.8, 3.8, 3.2];
-
 export default function RocketJourney({
   view,
   navigate,
 }: {
   view: SolarView;
   /** Router navigation, threaded in from outside the canvas (context
-   *  doesn't cross the R3F reconciler boundary) — re-entry uses it when
-   *  the destination lives on another route */
+   *  doesn't cross the R3F reconciler boundary) — the rocket ride hops
+   *  to /journey at its warp flash; re-entry uses it when the
+   *  destination lives on another route */
   navigate: (to: string) => void;
 }) {
   const rig = useRef<THREE.Group>(null);
@@ -129,29 +109,6 @@ export default function RocketJourney({
   const sawDestView = useRef(false);
   const warpPos = useRef(new THREE.Vector3());
   const warpQuat = useRef(new THREE.Quaternion());
-
-  const artifacts: FlybyArtifact[] = useMemo(
-    () =>
-      ARTIFACT_BUILDERS.map((build, i) => {
-        const group = build();
-        group.scale.setScalar(ARTIFACT_SCALES[i]);
-        group.visible = false;
-        return {
-          group,
-          spawnAt: ARTIFACT_FIRST_SPAWN + i * ARTIFACT_SPAWN_INTERVAL,
-          side: i % 2 === 0 ? -1 : 1,
-          y: ARTIFACT_HEIGHTS[i],
-          baseYaw: (i * Math.PI) / 3,
-          tilt: (i % 2 === 0 ? 1 : -1) * (0.15 + (i % 3) * 0.12),
-          spin: 0.6 + (i % 3) * 0.35,
-        };
-      }),
-    [],
-  );
-  useEffect(
-    () => () => artifacts.forEach((a) => disposeArtifact(a.group)),
-    [artifacts],
-  );
 
   // The overlay button only launches while this driver is mounted, and
   // an abandoned ride (unmount mid-journey) must not leave the page UI
@@ -172,6 +129,14 @@ export default function RocketJourney({
       warpIntensity.current = 0;
       return;
     }
+    // The rocket ride's warp lives on /journey — JourneyCruise owns the
+    // camera (and the show) from the flash on; this driver stands down
+    if (state.destination === "journey" && state.phase === "warp") {
+      if (rig.current?.visible) rig.current.visible = false;
+      startCaptured.current = false;
+      warpIntensity.current = 0;
+      return;
+    }
     // Route change mid-ride (browser back): abort and let CameraRig
     // swoop to the new view from wherever the camera is. The journey's
     // own routes don't count: the origin view is where it boarded, and
@@ -179,7 +144,11 @@ export default function RocketJourney({
     // flips the URL at boarding). Once the destination view has been
     // seen, leaving it again (back mid-warp) is a real abort.
     const rideDestView: SolarView =
-      state.destination === "synth" ? "synth" : "home";
+      state.destination === "synth"
+        ? "synth"
+        : state.destination === "journey"
+          ? "journey"
+          : "home";
     if (startCaptured.current) {
       if (view === rideDestView) sawDestView.current = true;
       const foreign = sawDestView.current
@@ -228,7 +197,12 @@ export default function RocketJourney({
       lookMatrix.lookAt(targetPos, lookTarget, UP);
       targetQuat.setFromRotationMatrix(lookMatrix);
 
-      const p = clamp01(state.phaseElapsed / state.boardSeconds);
+      // Boarding for /journey while already ON /journey (a mid-boarding
+      // manual navigation) has no rocket to chase — jump straight to warp
+      const p =
+        state.destination === "journey" && view === "journey"
+          ? 1
+          : clamp01(state.phaseElapsed / state.boardSeconds);
       const e = easeInOutCubic(p);
       camera.position.lerpVectors(startPos.current, targetPos, e);
       camera.quaternion.slerpQuaternions(startQuat.current, targetQuat, e);
@@ -239,16 +213,22 @@ export default function RocketJourney({
         state.phase = "warp";
         state.phaseElapsed = 0;
         flashWarp();
+        if (state.destination === "journey") {
+          // The rocket ride: teleport straight to the /journey cruise
+          // pose and flip the route — both cuts hide under the flash,
+          // and JourneyCruise picks the camera up from exactly here
+          camera.position.copy(CRUISE_POS);
+          camera.quaternion.copy(CRUISE_QUAT);
+          startCaptured.current = false;
+          if (view !== "journey") navigate("/journey");
+          return;
+        }
         // Jump along the current heading: same orientation, new spot —
         // the flash covers the position cut, the view direction doesn't
         // change, and every solar system ends up a speck
-        if (state.vehicle === "rocket") {
-          warpPos.current.copy(travelDir).multiplyScalar(WARP_DISTANCE);
-        } else {
-          warpPos.current
-            .copy(targetPos)
-            .addScaledVector(travelDir, TRANSIT_WARP_AHEAD);
-        }
+        warpPos.current
+          .copy(targetPos)
+          .addScaledVector(travelDir, TRANSIT_WARP_AHEAD);
         warpQuat.current.copy(targetQuat);
         camera.position.copy(warpPos.current);
         camera.quaternion.copy(warpQuat.current);
@@ -257,15 +237,11 @@ export default function RocketJourney({
           rig.current.quaternion.copy(warpQuat.current);
           rig.current.visible = true;
         }
-        // A transit must not inherit a frozen cameo from an aborted joyride
-        if (!state.cameos) {
-          artifacts.forEach((artifact) => (artifact.group.visible = false));
-        }
       }
       return;
     }
 
-    // ── warp ──
+    // ── warp (synth transits only) ──
     const elapsed = state.phaseElapsed;
     const intensity = THREE.MathUtils.smoothstep(
       Math.min(
@@ -288,32 +264,6 @@ export default function RocketJourney({
     camera.position.copy(warpPos.current).add(sway);
     rollQuat.setFromAxisAngle(Z_AXIS, Math.sin(t * 0.7) * 0.035);
     camera.quaternion.copy(warpQuat.current).multiply(rollQuat);
-
-    // Flyby cameos (joyride only): each pops in far ahead, drifts
-    // outward as it nears, and exits past the shoulder of the windshield
-    if (state.cameos) {
-      for (const artifact of artifacts) {
-        const local = elapsed - artifact.spawnAt;
-        const z = ARTIFACT_Z_START + local * ARTIFACT_SPEED;
-        if (local < 0 || z > ARTIFACT_Z_EXIT) {
-          artifact.group.visible = false;
-          continue;
-        }
-        artifact.group.visible = true;
-        const progress =
-          (z - ARTIFACT_Z_START) / (ARTIFACT_Z_EXIT - ARTIFACT_Z_START);
-        artifact.group.position.set(
-          artifact.side * (9 + progress * 14),
-          artifact.y,
-          z,
-        );
-        artifact.group.rotation.set(
-          artifact.tilt,
-          artifact.baseYaw + t * artifact.spin,
-          0,
-        );
-      }
-    }
 
     if (elapsed >= state.warpSeconds) {
       // Drop out of lightspeed onto the destination's approach line
@@ -351,9 +301,6 @@ export default function RocketJourney({
       <ambientLight intensity={0.55} />
       <pointLight position={[6, 14, 18]} intensity={2.2} decay={0} />
       <WarpStreaks getIntensity={() => warpIntensity.current} />
-      {artifacts.map((artifact, i) => (
-        <primitive key={i} object={artifact.group} />
-      ))}
     </group>
   );
 }

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -165,8 +165,9 @@ const SolarScene = ({
       {/* The second solar system, far below this one: six knob-planets
           around a beat-pulsing sun (the space synth) */}
       {view === "synth" && <SynthSystem isNightMode={isNightMode} />}
-      {/* The /journey cruise: open-space flight behind the story crawl */}
-      {view === "journey" && <JourneyCruise />}
+      {/* The /journey cruise: the rocket ride's warp — open-space flight
+          behind the story crawl, ended by the cockpit's "End trip" */}
+      {view === "journey" && <JourneyCruise navigate={onNavigate} />}
       {/* Mounted before CameraRig: while a journey is active it must
           pose the camera first each frame (CameraRig stands down) */}
       <RocketJourney view={view} navigate={onNavigate} />

--- a/src/space3d/solar/WarpStreaks.tsx
+++ b/src/space3d/solar/WarpStreaks.tsx
@@ -27,11 +27,17 @@ const STREAK_LENGTH = 30;
 
 export default function WarpStreaks({
   getIntensity,
+  getFlow = () => 1,
   speedScale = 1,
 }: {
   /** Read per frame (a ref accessor, not React state): 0 = no streaks,
    *  1 = full lightspeed */
   getIntensity: () => number;
+  /** Signed march direction, -1..1 (default full ahead): the /journey
+   *  cruise eases it negative while the crawl is scrubbed backwards, so
+   *  the field streams the other way. Passing through 0 the streaks
+   *  collapse to points and regrow reversed — no pop. */
+  getFlow?: () => number;
   /** Scales the march speed and stretch — the cruise ambles, the warp
    *  sprints */
   speedScale?: number;
@@ -96,22 +102,25 @@ export default function WarpStreaks({
     // flight, not fast-forward it on the first frame back
     const delta = Math.min(rawDelta, 0.1);
     const intensity = THREE.MathUtils.clamp(getIntensity(), 0, 1);
+    const flow = THREE.MathUtils.clamp(getFlow(), -1, 1);
 
-    // March the streak heads toward the camera and wrap; tails trail
-    // "ahead" (where the streak came from) by the stretched length
+    // March the streak heads toward the camera (or away, on a reversed
+    // flow) and wrap; tails trail where the streak came from, so the
+    // signed flow flips them along with the motion
     const positions = streaks.positionAttr.array as Float32Array;
     const length = STREAK_LENGTH * speedScale * intensity + 0.2;
     for (let i = 0; i < STREAK_COUNT; i++) {
       let zHead =
-        streaks.z[i] + streaks.speed[i] * speedScale * intensity * delta;
+        streaks.z[i] + streaks.speed[i] * speedScale * intensity * flow * delta;
       if (zHead > STREAK_BEHIND_PAD) zHead -= STREAK_DEPTH + STREAK_BEHIND_PAD;
+      else if (zHead < -STREAK_DEPTH) zHead += STREAK_DEPTH + STREAK_BEHIND_PAD;
       streaks.z[i] = zHead;
       positions[i * 6] = streaks.x[i];
       positions[i * 6 + 1] = streaks.y[i];
       positions[i * 6 + 2] = zHead;
       positions[i * 6 + 3] = streaks.x[i];
       positions[i * 6 + 4] = streaks.y[i];
-      positions[i * 6 + 5] = zHead - length;
+      positions[i * 6 + 5] = zHead - length * flow;
     }
     streaks.positionAttr.needsUpdate = true;
     streaks.material.opacity = intensity;


### PR DESCRIPTION
Merges the rocket easter egg with the /journey page: clicking the rocket on /home plays the boarding swoop as before, but the warp flash now drops you into the cockpit on /journey with the story crawl rolling in front of the lightspeed stars. The ride lasts as long as the story does — an "End trip" button on the dashboard console plays the re-entry flash and lands you back home.

- the rocket click boards toward `/journey`; `RocketJourney` flips the route under the warp flash and hands the camera to `JourneyCruise` (the 808 synth transits are untouched)
- `JourneyCruise` starts the ride state itself on its first frame, so deep links and the résumé link get the cockpit + windshield too
- the flyby cameos (cheeseburger et al) moved from the old timed joyride into the cruise and are glued to crawl progress via `cruiseState.progressPx` — each one owns its own stretch of the story, parks when the reader parks, and rewinds on a scroll back (eventually they'll be objects matched to the chapters they pass)
- scrolling the crawl backwards streams the star field backwards too: `cruiseState.boost` went signed, and `WarpStreaks` grew a `getFlow` input that flips the march and the tails — easing through zero so a reversal reads as collapse-and-regrow, not a pop
- "End trip" raises `journeyState.landingRequested`; the 3D loop does the flash → home-approach-line drop → CameraRig landing swoop; with a dead 3D canvas it falls back to a plain navigate
- `RocketCockpit` now mounts once at App level — the rides hop routes mid-flight, and the per-page mounts were cutting the covering flash short at each hop
- the journey hint and post-credits chips sit above the cockpit frame now (z 6002), reading as dashboard chrome; the crawl itself stays behind the glass
- filled in the crawl's `[to fill in]` placeholders with the real story (born in Rochester, raised in Oregon; Lego robotics → HS robotics captain; "Andy and David: A place for fun"; Princeton CS '13–'17; the sabbatical 3D-printing addiction) and trimmed the Zip chapter's tool laundry list down to crawl pacing