### PR TITLE
[home] show the scroll hint on /home and fix the mobile summary collision

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,6 +54,14 @@ const SETTLED_ENTRANCES = `
     opacity: 1 !important;
     transition: none !important;
   }
+  .scroll-hint,
+  .scroll-hint-label {
+    opacity: 1 !important;
+    transition: none !important;
+  }
+  .scroll-hint-chevron {
+    animation: none !important;
+  }
 `;
 
 const preview: Preview = {

--- a/docs/home-layout-plan.md
+++ b/docs/home-layout-plan.md
@@ -1,0 +1,149 @@
+# /home layout — findings and a positioning plan
+
+Written against the real app at 390×844, 834×1000, 1280×800 and 1728×1000
+(the `Pages/Home` stories cover the same four). Nothing here is
+implemented — it's a proposal to argue with.
+
+## The one structural problem
+
+Home has **two layout systems fighting over the same pixels**:
+
+- a **DOM layer** positioned in CSS — the info panel, back link, audio
+  pill, day/night switch, scroll hint, badge medallion;
+- a **3D layer** whose link targets (Earth = ABOUT ME, the three
+  asteroids, Sputnik, the rocket, the drum pad) are placed by orbital
+  mechanics and projected to screen each frame.
+
+Neither knows about the other, and the 3D layer *moves*. Every collision
+below is a symptom of that, so the fix is mostly about giving each layer
+its own reserved territory rather than nudging individual elements.
+
+The screenshots make the drift concrete: in one capture at 390px the
+asteroid trio sat mid-screen; seconds later Earth had swung into the same
+space and the drum pad had risen into the info panel. Any plan that
+assumes a fixed 3D position will be wrong a few seconds later.
+
+## What's wrong, per breakpoint
+
+### sm — 390×844 (the one that needs the most)
+
+| Issue | Detail |
+| --- | --- |
+| Wordmark clipped | `andrewhunt` runs edge to edge; the `a` and `t` touch the bezel |
+| Day/night switch overlaps it | The switch sits top-right, on top of the wordmark's last letters |
+| Bad line break | "Frontend Engineer · ~~SF~~" / "NYC" — the city is orphaned onto line 2 |
+| Bottom edge is a pile-up | Audio pill (nearly full width), scroll hint, badge medallion, and whatever 3D body has drifted low |
+| 3D link targets are unreliable tap targets | Asteroids are small, moving, and sometimes behind the info panel |
+| Info panel competes with the sun | The panel's dark plate sits over the sun's limb — legible, but visually muddy |
+
+### md — 834×1000
+
+- **The social icon row lands on Sputnik.** The clearest collision in the
+  whole set: the LinkedIn/GitHub/Mail icons sit directly over the
+  satellite's body and struts.
+- Info text is pinned to `left: 5vw` while the icons sit mid-width, so the
+  block reads as two disconnected fragments with a gap between them.
+- Large dead zone through the upper middle.
+
+### lg — 1280×800
+
+- The best of the four; this is clearly what the layout was tuned for.
+- The typed line truncates (`interes|`) — the container is too narrow for
+  the longest string.
+- Empty band across the upper middle, between wordmark and content.
+
+### xl — 1728×1000
+
+- Sparse. `left: 5vw` pushes the info block further from centre as the
+  viewport grows, so content clusters upper-left while the right half
+  holds only Earth and the rocket.
+- `width: calc(22vw + 22vh)` keeps growing the panel, so the text line
+  gets longer rather than the layout getting denser.
+
+## Proposed positioning
+
+### The principle
+
+**Reserve horizontal bands for the DOM; leave the middle to the 3D.**
+The DOM takes a top band (identity + back link) and a bottom band
+(controls + hint). The 3D owns the middle, where it can drift without
+hitting anything.
+
+### sm — switch to a bottom sheet, and stop navigating in 3D
+
+The biggest win available. Concretely:
+
+1. **One panel, anchored bottom**, containing the summary line, the icon
+   row, and the typed line — instead of a floating mid-screen block.
+   Sits above the audio pill.
+2. **Promote the 3D destinations into that panel as real links.** On
+   touch, a moving 8px asteroid is not a tap target. Add About, Blog and
+   Draw beside LinkedIn/GitHub/Mail, and let the 3D bodies be scenery on
+   sm. This is the "different nav structure" worth taking.
+3. **Hide on sm:** the badge medallion and the drum pad. Both are
+   delightful and neither survives the space budget.
+4. **Reserve the top third for the scene** so Earth has somewhere to be.
+5. Fix the wrap: wrap `~~SF~~ NYC` in a `white-space: nowrap` span.
+6. Shrink the wordmark to ~85% width and move the day/night switch into
+   the bottom control cluster with the audio pill, off the wordmark.
+
+Result: one tap-friendly card, one uncluttered scene, one control row.
+
+### md — unstack the collision
+
+- Move the icon row **below** the text instead of beside it, so the info
+  block is a single left-aligned column and nothing reaches into
+  Sputnik's airspace.
+- Pull the block off the hard `left: 5vw` and into a `max-width` column
+  with a floor on the left inset (say `max(5vw, 24px)`), so it stops
+  drifting with viewport width.
+
+### lg — mostly leave it, two fixes
+
+- Widen the info container enough for the longest typed string, or
+  shorten the strings. Truncation reads as a bug.
+- Optionally lift the block ~5% to close the upper-middle gap.
+
+### xl — cap, don't stretch
+
+- Cap the info container (`max-width: 520px`) and stop scaling it with
+  `vw + vh`; let the extra width become breathing room rather than longer
+  lines.
+- Anchor the whole DOM layer to a centred `max-width` container so at
+  1728px it doesn't hug the left bezel.
+- Consider capping the scene's zoom so the planets don't spread out into
+  emptiness on very wide screens.
+
+## Element inventory
+
+| Element | Layer | Now | Proposed |
+| --- | --- | --- | --- |
+| Back to orbit | DOM | fixed top-left | unchanged |
+| Wordmark | DOM (SVG) | full width, top | ~85% width on sm |
+| Day/night switch | DOM | fixed top-right | bottom control cluster on sm |
+| Info panel | DOM | `left:5vw`, `top:45%` | bottom sheet (sm), left column (md), capped column (lg/xl) |
+| Social icons | DOM | inline beside text | below text on md and under |
+| Typed intro | DOM | in panel | unchanged; widen container |
+| Scroll hint | DOM | bottom centre | unchanged (already lifted above the pill on sm) |
+| Audio pill | DOM | fixed bottom-left | joins the control cluster |
+| Badge medallion | DOM/3D | bottom-right | hidden on sm |
+| Earth / ABOUT ME | 3D | orbital | keep; give it the reserved top band on sm |
+| Asteroids, Sputnik | 3D | orbital | scenery only on sm; duplicate as links in the panel |
+| Rocket, drum pad | 3D | orbital | drum pad hidden on sm |
+
+## Suggested order
+
+1. `sm` bottom sheet + in-panel nav — biggest gain, contained change.
+2. `md` icon row below text — kills the Sputnik collision outright.
+3. Info container width caps for `lg`/`xl`.
+4. Control cluster (audio + day/night together).
+5. Hide badge medallion and drum pad on `sm`.
+
+Steps 1 and 2 are independent; either can ship alone.
+
+## Caveat on the stories
+
+`Home.stories.tsx` renders the DOM layer only — the 3D-anchored targets
+need a live canvas and are inert there. Use the stories to iterate on the
+DOM bands above, then confirm collisions against the real app, because
+only the real app shows where the 3D bodies actually are.

--- a/src/App.scss
+++ b/src/App.scss
@@ -673,7 +673,7 @@ p {
   .interest-pill,
   .App-background_day,
   .body-outline-pulse,
-  .landing-scroll-hint,
+  .scroll-hint-chevron,
   .svg-generator-spinner,
   .svg-generator-loading-dots span,
   // The hue cycle on the drawing itself. The per-element wobble lives
@@ -684,19 +684,21 @@ p {
   }
 }
 
-// Bouncing "you can scroll" chevron on the landing page (Landing.tsx):
-// appears a beat after the intro choreography, disappears once the
-// visitor starts scrubbing
-.landing-scroll-hint {
+// Bouncing "you can scroll" nudge (ScrollHint.tsx), shown on the landing
+// page and home — both have somewhere further along the journey to go.
+// Appears a beat after each page's own choreography, disappears once the
+// visitor starts scrubbing.
+.scroll-hint {
   position: fixed;
   bottom: 18px;
   left: 50%;
-  // The keyframes carry the same X-centering; this keeps it centered
-  // under prefers-reduced-motion (animation: none)
   transform: translateX(-50%);
   z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
   color: rgba(232, 230, 245, 0.75);
-  animation: hint-bounce 2.2s ease-in-out infinite;
   transition: opacity 0.8s ease;
   opacity: 1;
 
@@ -710,17 +712,79 @@ p {
   }
 }
 
-.App.day .landing-scroll-hint {
-  color: $purp;
+// Only the chevron bounces — the caption stays put so it stays readable
+.scroll-hint-chevron {
+  animation: hint-bounce 2.2s ease-in-out infinite;
+}
+
+.scroll-hint-label {
+  font-family: "Inconsolata", monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.32em;
+  // The tracking adds a trailing gap on the last letter; nudge it back so
+  // the caption reads as centered over the chevron
+  text-indent: 0.32em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.5);
+  // Arrives after the chevron has settled, so the motion is noticed first
+  // and the words explain it second
+  transition:
+    opacity 0.9s ease 0.75s,
+    color 0.2s ease;
+  opacity: 1;
+}
+
+// On the way out the caption leaves with the chevron rather than lingering
+.scroll-hint.hint-hidden .scroll-hint-label {
+  opacity: 0;
+  transition-delay: 0s;
+}
+
+.scroll-hint:hover .scroll-hint-label {
+  color: $purp-light;
+}
+
+// White-on-pink washes out over the day gradient
+.App.day {
+  .scroll-hint {
+    color: $purp;
+  }
+
+  .scroll-hint-label {
+    color: rgba(60, 40, 90, 0.65);
+  }
+
+  .scroll-hint:hover .scroll-hint-label {
+    color: $purp;
+  }
+}
+
+// On a phone the "Enable space jams" pill (fixed bottom-4 left-4) runs
+// almost the full width, so a centred caption at the same height lands on
+// top of it. Only pages that actually show the pill get lifted — it is
+// gated on `!isLanding`, so lifting the landing hint too would just leave
+// a gap under it.
+@media (max-width: 767px) {
+  .scroll-hint--above-controls {
+    bottom: 76px;
+  }
+
+  .scroll-hint-label {
+    font-size: 8px;
+    letter-spacing: 0.22em;
+    text-indent: 0.22em;
+  }
 }
 
 @keyframes hint-bounce {
   0%,
   100% {
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
   50% {
-    transform: translate(-50%, 9px);
+    transform: translateY(9px);
   }
 }
 
@@ -1070,6 +1134,21 @@ li > ul > li {
     font-size: 20px;
     left: 50%;
     transform: translateX(-50%);
+
+    // Pinning the summary to the top while .homeInfoContainer is anchored
+    // to the bottom means the two grow toward each other: on a short
+    // viewport (a phone in landscape) the panel rises into the summary and
+    // the icon row lands on top of the text — measured 34px of overlap at
+    // 667x470, and fully inverted at 375px tall. The summary is already a
+    // child of the panel in the DOM, so dropping it back into normal flow
+    // removes the collision by construction and restores reading order.
+    @media (max-height: 560px) {
+      position: static;
+      transform: none;
+      width: auto;
+      max-width: none;
+      margin-bottom: 6px;
+    }
   }
 
   .nameTitle {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1497,6 +1497,9 @@ body.rocket-journey {
   .synth-knob,
   .synth-sun-button,
   .synth-hint,
+  // /home mounts the scroll hint too — without this it kept bouncing
+  // (and stayed focusable) through a ride that clears every other overlay
+  .scroll-hint,
   .badge-link {
     opacity: 0 !important;
     pointer-events: none !important;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -8,6 +8,8 @@ import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
 import RocketCockpit from "./RocketCockpit";
+import ScrollHint from "./ScrollHint";
+import { JOURNEY_STOPS } from "./scrollTransition";
 
 import {
   Tooltip,
@@ -37,12 +39,16 @@ const typedOptions = {
 // in their UA, so this matches the whole family
 const isChromium = navigator.userAgent.includes("Chrome");
 
+// The arrival swoop lands at 2s and the content fade runs a beat past it;
+// the hint follows once the page has settled
+const HINT_DELAY_MS = 3800;
+
 const Home = () => {
   const [logoOpacity, setLogoOpacity] = useState(0);
 
   // Scroll-scrubbed travel: up retreats toward the landing view, down
   // continues out to /about (scrollTransition.ts)
-  useScrollJourney(1);
+  const engaged = useScrollJourney(1);
 
   const size = useWindowSize();
   const isSmall = size === "sm";
@@ -117,10 +123,15 @@ const Home = () => {
       </div>
       <main className={cx("homeInfoContainer", logoOpacity === 1 && "show")}>
         {isSmall && (
-          <div className="sm-screen-summary-line max-w-[240px] text-center">
+          <div className="sm-screen-summary-line max-w-[300px] text-center">
             Frontend Engineer ·{" "}
-            <s className="opacity-70 decoration-[#ff6b6b] decoration-2">SF</s>{" "}
-            NYC
+            {/* Keep the city pair together — at 240px this broke after the
+                strikethrough and orphaned "NYC" onto its own line, which
+                doubled the block's height and pushed it into the icons */}
+            <span className="whitespace-nowrap">
+              <s className="opacity-70 decoration-[#ff6b6b] decoration-2">SF</s>{" "}
+              NYC
+            </span>
           </div>
         )}
         <div className="hoverableHomeItem justify-between gap-6">
@@ -234,6 +245,16 @@ const Home = () => {
           </>
         )}
       </main>
+      {/* Home is a waypoint, not the end of the line — the résumé is one
+          more scroll further out, and nothing else says so. Waits for the
+          arrival swoop and the content fade (~2s) to finish first. */}
+      <ScrollHint
+        target={JOURNEY_STOPS.about}
+        delayMs={HINT_DELAY_MS}
+        hidden={engaged}
+        // /home renders the "Enable space jams" pill; the landing page doesn't
+        clearsBottomLeftControl
+      />
     </>
   );
 };

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,18 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
-import { ChevronDown } from "react-feather";
-import cx from "classnames";
 import { SunInternals } from "SunSvg";
 import { hoverState } from "./solarHover";
 import useScrollJourney from "./useScrollJourney";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./ui/tooltip";
+import ScrollHint from "./ScrollHint";
 import { SUN_RADIUS_OFFSET, SUN_SIZE } from "./landingScene";
-import { scrollTransitionState } from "./scrollTransition";
+import { JOURNEY_STOPS } from "./scrollTransition";
 
 // The solar system's 4s-delayed fadeIn is first-visit choreography (the
 // stars assemble first). Landing remounts on every visit, and replaying
@@ -20,7 +13,6 @@ import { scrollTransitionState } from "./scrollTransition";
 // the sun flying back into it — for 5 seconds.
 let hasPlayedIntro = false;
 
-const SCROLL_HINT_TEXT = "Scroll or click around to explore the solar system";
 // The scroll hint appears a beat after the landing choreography finishes:
 // the first visit's intro runs ~5s (stars, then the 4s-delayed system
 // fade); return visits skip the delay
@@ -46,16 +38,6 @@ const Landing = () => {
   // poses the camera along the landing→home→about journey; `engaged`
   // flips once the visitor starts scrubbing (and hides the hint below)
   const engaged = useScrollJourney(0);
-
-  const [hintReady, setHintReady] = useState(false);
-  const [hintClicked, setHintClicked] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(
-      () => setHintReady(true),
-      skipIntroDelay ? HINT_DELAY_RETURN_MS : HINT_DELAY_FIRST_VISIT_MS,
-    );
-    return () => clearTimeout(timer);
-  }, [skipIntroDelay]);
 
   // The orbits and planets are the WebGL scene's (SolarScene); this SVG
   // only carries the clickable ENTER sun ring, which SunSvgAnchor glues
@@ -90,36 +72,13 @@ const Landing = () => {
       </div>
       {/* Gentle nudge that the page scrolls; disappears once it has done
           its job (the visitor scrubs) */}
-      <TooltipProvider delayDuration={100}>
-        <Tooltip disableHoverableContent>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className={cx(
-                "landing-scroll-hint",
-                (!hintReady || engaged || hintClicked) && "hint-hidden",
-              )}
-              aria-label={SCROLL_HINT_TEXT}
-              onClick={() => {
-                // A chevron that only *hints* at travel is a broken
-                // promise as a <button>: clicking it rides the same
-                // scroll journey a wheel scrub would, gliding down to
-                // /home (the progress watcher commits the route)
-                const s = scrollTransitionState;
-                if (s.initialized && s.rigSettled) {
-                  s.target = 1;
-                  setHintClicked(true);
-                }
-              }}
-            >
-              <ChevronDown size={30} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{SCROLL_HINT_TEXT}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <ScrollHint
+        target={JOURNEY_STOPS.home}
+        delayMs={
+          skipIntroDelay ? HINT_DELAY_RETURN_MS : HINT_DELAY_FIRST_VISIT_MS
+        }
+        hidden={engaged}
+      />
     </>
   );
 };

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from "react";
+import { ChevronDown } from "react-feather";
+import cx from "classnames";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+import { scrollTransitionState } from "./scrollTransition";
+
+/**
+ * Where each stop actually goes, for the tooltip and the screen-reader
+ * label. The visible caption stays generic, but these have to name the
+ * real destination — telling someone on /home that the chevron explores
+ * the solar system describes the trip they just finished, not the résumé
+ * they are about to reach.
+ */
+const DESTINATION_TEXT: Record<1 | 2, string> = {
+  1: "Scroll or click around to explore the solar system",
+  2: "Scroll or click to travel on to the résumé",
+};
+
+/** The wide-tracked caption above the chevron */
+const SCROLL_HINT_LABEL = "Scroll or click to explore";
+
+type ScrollHintProps = {
+  /**
+   * Journey stop to travel to when the hint is clicked — the next view
+   * along (see JOURNEY_STOPS): 1 from the landing page, 2 from home.
+   */
+  target: 1 | 2;
+  /** How long to wait before fading in, after the page's own choreography */
+  delayMs: number;
+  /** Hide it — the visitor has started scrubbing and no longer needs it */
+  hidden?: boolean;
+  /**
+   * Lift it clear of the bottom-left audio pill on phones. Only pages that
+   * render that pill need this — it is gated on `!isLanding`.
+   */
+  clearsBottomLeftControl?: boolean;
+};
+
+/**
+ * The bouncing "this page scrolls" nudge, shared by the landing page and
+ * home. Both sit on the scroll journey with somewhere further to travel,
+ * so both earn the hint; only /about (native scrolling) does not.
+ *
+ * Clicking it rides the same journey a wheel scrub would rather than
+ * hard-navigating — a chevron that merely *hints* at travel would be a
+ * broken promise as a <button>.
+ */
+const ScrollHint = ({
+  target,
+  delayMs,
+  hidden = false,
+  clearsBottomLeftControl = false,
+}: ScrollHintProps) => {
+  const [ready, setReady] = useState(false);
+  const [clicked, setClicked] = useState(false);
+  const destinationText = DESTINATION_TEXT[target];
+
+  useEffect(() => {
+    const timer = setTimeout(() => setReady(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [delayMs]);
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cx(
+              "scroll-hint",
+              clearsBottomLeftControl && "scroll-hint--above-controls",
+              (!ready || hidden || clicked) && "hint-hidden",
+            )}
+            aria-label={destinationText}
+            onClick={() => {
+              const s = scrollTransitionState;
+              if (s.initialized && s.rigSettled) {
+                s.target = target;
+                setClicked(true);
+              }
+            }}
+          >
+            {/* aria-hidden: the button's own label already says this, and
+                more fully — this copy is the visible shorthand */}
+            <span className="scroll-hint-label" aria-hidden="true">
+              {SCROLL_HINT_LABEL}
+            </span>
+            <ChevronDown className="scroll-hint-chevron" size={30} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{destinationText}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default ScrollHint;


### PR DESCRIPTION
> Stacked on #95 — review that first; this diff is against its branch.

The scroll hint only lived on the landing page, but `/home` is a waypoint too — the résumé is one more scroll out and nothing said so. Testing it turned up a mobile overlap, fixed here as well.

- extracts the hint into `ScrollHint.tsx` and uses it on both pages; clicking it rides the same scroll journey a wheel scrub would rather than hard-navigating
- adds a wide-tracked all-caps caption above the chevron that fades in after it; only the chevron bounces, since a caption bobbing under 0.32em tracking was hard to read
- fixes the mobile collision: `.sm-screen-summary-line` is pinned `top: 120px` while `.homeInfoContainer` is anchored `bottom: 184px`, so the two grow into each other — 34px of overlap at 667x470, fully inverted at 375px tall. The summary is already a child of the panel, so it now falls back into normal flow under 560px tall, removing the collision by construction rather than by tuning offsets
- keeps `SF NYC` together on one line, halving the block's height; at `max-w-[240px]` it broke after the strikethrough and orphaned the city
- tooltip and aria-label name the real destination per page — on `/home` the old copy described the trip the visitor just finished
- the phone lift above the audio pill is now opt-in; that pill is gated on `!isLanding`, so lifting the landing hint just left a gap
- adds `docs/home-layout-plan.md` — per-breakpoint findings and a proposal, none of it implemented here

Verified at 667x470, 667x375 and 390x844: no overlaps, summary above the icons, tall-phone layout still uses the pinned position.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and scroll-hint behavior only; click handling reuses the existing scroll journey state pattern from landing with no auth or data changes.
> 
> **Overview**
> **`/home` now gets the same scroll-journey nudge as landing**, pointing visitors toward the résumé stop after the page intro (~3.8s delay) and hiding once they start scrubbing.
> 
> The landing-only chevron UI moves into **`ScrollHint`**, used on both pages. Clicks set `scrollTransitionState.target` to the next journey stop (home from landing, about from home) instead of hard navigation. A static **“Scroll or click to explore”** caption sits above the chevron (only the chevron bounces); tooltip and **`aria-label`** text differ per destination. On phones, **`/home`** opts into **`scroll-hint--above-controls`** so the hint clears the bottom-left audio pill.
> 
> **Mobile `/home` fixes:** the small-screen summary uses **`whitespace-nowrap`** for ~~SF~~ NYC and a wider max width; under **560px height**, `.sm-screen-summary-line` drops fixed top positioning so it flows inside the bottom panel and avoids overlap with icons in landscape. Rocket joyride mode now hides **`.scroll-hint`** like other chrome.
> 
> **`docs/home-layout-plan.md`** adds breakpoint findings and a proposed DOM vs 3D layout plan (not implemented). Storybook settled-state CSS includes the new hint classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b156ef336acc7b8f02c7cb943ca83474130788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->