### PR TITLE
[site] declutter the small-screen home view and polish the journey chrome

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -921,7 +921,9 @@ p {
 }
 
 .highlightedChar_night {
-  fill: #6cfc9e;
+  // Halfway between the old green (#6cfc9e) and the white base letters,
+  // so the roving highlight reads as a shimmer rather than a blink
+  fill: #b6fdcf;
   z-index: 100;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -340,8 +340,8 @@ body.journey-mode {
   }
 }
 
-// z above the cockpit frame: the hint sits right on the dashboard
-// console, doubling as a cockpit readout
+// z above the cockpit frame: during a ride the hint floats just inside
+// the windshield glass; without the cockpit it rests near the bottom edge
 .journey-hint {
   position: fixed;
   left: 50%;
@@ -358,6 +358,13 @@ body.journey-mode {
   }
 }
 
+// The windshield opening's bottom edge sits at 86% of the viewport
+// (cockpit SVG y=86 with preserveAspectRatio="none"), so 14vh up from
+// the bottom puts the hint just inside the glass
+body.rocket-journey .journey-hint {
+  bottom: calc(14vh + 10px);
+}
+
 // The cockpit's dashboard controls (soundtrack mute + "End trip"),
 // parked on the right of the console. Only tangible while the ride is
 // actually flying (body.rocket-journey) — with a dead 3D canvas the
@@ -366,7 +373,10 @@ body.journey-mode {
 .cockpit-controls {
   position: fixed;
   right: 5vw;
-  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  // Center on the dashboard's fake buttons: the console's controls all
+  // sit at y=94 in the cockpit SVG, i.e. 6vh up from the viewport bottom
+  bottom: 6vh;
+  transform: translateY(50%);
   z-index: 6002;
   display: flex;
   gap: 10px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -308,10 +308,10 @@ body.journey-mode {
 .journey-credits {
   position: fixed;
   left: 50%;
-  bottom: calc(72px + env(safe-area-inset-bottom, 0px));
-  transform: translateX(-50%) translateY(12px);
+  top: 50%;
+  transform: translate(-50%, calc(-50% + 12px));
   display: flex;
-  gap: 28px;
+  gap: 16px;
   align-items: center;
   opacity: 0;
   pointer-events: none;
@@ -322,16 +322,23 @@ body.journey-mode {
 
   button,
   a {
-    color: $purp-light;
-    background: none;
+    color: #fff;
+    background: rgba($purp-light, 0.5);
     border: none;
+    border-radius: 8px;
+    padding: 10px 18px;
     font-size: 15px;
+    transition: background-color 150ms ease;
+
+    &:hover {
+      background: rgba($purp-light, 0.7);
+    }
   }
 
   &.shown {
     opacity: 1;
     pointer-events: auto;
-    transform: translateX(-50%);
+    transform: translate(-50%, -50%);
   }
 
   @media (max-width: $breakpoint-sm) {

--- a/src/App.scss
+++ b/src/App.scss
@@ -927,6 +927,18 @@ p {
   z-index: 100;
 }
 
+// Circular icon buttons in the home link row. Plain CSS rather than
+// Tailwind bg-* utilities: the global unlayered `button` reset further
+// down beats utility-layer backgrounds on the copy-email <button>
+.icon-pill {
+  background: rgba(94, 255, 252, 0.1);
+  transition: background-color 150ms ease;
+
+  &:hover {
+    background: rgba(94, 255, 252, 0.34);
+  }
+}
+
 .hoverableHomeItem {
   display: flex;
   min-height: 16px;

--- a/src/DayNightSwitch.tsx
+++ b/src/DayNightSwitch.tsx
@@ -3,6 +3,8 @@ import * as Switch from "@radix-ui/react-switch";
 import { useLocation } from "react-router-dom";
 import cx from "classnames";
 
+import useWindowSize from "useWindowSize";
+
 // Sun/moon mode switch, after the classic light/dark toggle design
 // (dribbble.com/shots/14431115): a sky pill with drifting clouds and a
 // glowing sun thumb by day; a starry navy pill with a cratered moon
@@ -17,12 +19,16 @@ const DayNightSwitch = ({
   onCheckedChange: (isNight: boolean) => void;
 }) => {
   const { pathname } = useLocation();
+  const size = useWindowSize();
   const onLanding = pathname === "/";
+  // /home below lg gives its corner back to the scene (part of the
+  // small-screen declutter alongside the moon and link-trio bodies)
+  const onNarrowHome = pathname === "/home" && size !== "lg";
   return (
     <Switch.Root
       className={cx(
         "day-night-switch fixed right-12 top-4 z-[5000]",
-        onLanding && "dns-hidden",
+        (onLanding || onNarrowHome) && "dns-hidden",
       )}
       checked={isNightMode}
       onCheckedChange={onCheckedChange}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -146,18 +146,18 @@ const Home = () => {
               target="_blank"
               rel="noopener noreferrer"
               href="https://www.linkedin.com/in/andrewmhunt/"
-              className="flex size-11 items-center justify-center rounded-full p-1 transition-colors hover:bg-[#5efffc57]"
+              className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
             >
-              <Linkedin size={20} />
+              <Linkedin size={22} />
             </a>
             <a
               aria-label="GitHub"
               target="_blank"
               rel="noopener noreferrer"
               href="https://www.github.com/amhunt"
-              className="flex size-11 items-center justify-center rounded-full p-1 transition-colors hover:bg-[#5efffc57]"
+              className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
             >
-              <GitHub size={20} />
+              <GitHub size={22} />
             </a>
             {/* <TooltipProvider>
               <Tooltip disableHoverableContent>
@@ -165,7 +165,7 @@ const Home = () => {
                   <Link
                     aria-label="SVG Studio"
                     to="/draw"
-                    className="flex size-11 items-center justify-center rounded-full p-1 transition-colors hover:bg-[#5efffc57]"
+                    className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
                   >
                     <Wand2 size={20} />
                   </Link>
@@ -192,9 +192,9 @@ const Home = () => {
                     aria-label="Copy email address andrew+in@hunt.codes"
                     onPointerDown={() => pinCopyTooltip()}
                     onClick={() => void handleCopy()}
-                    className="flex size-11 items-center justify-center rounded-full p-1 transition-colors hover:bg-[#5efffc57]"
+                    className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
                   >
-                    <Mail size={20} />
+                    <Mail size={22} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent

--- a/src/Journey.tsx
+++ b/src/Journey.tsx
@@ -49,6 +49,9 @@ const VELOCITY_DECAY = 3.2;
 const MAX_VELOCITY = 2600;
 /** Scrub speed that reads as "full burn" to the cruise (px/s) */
 const FULL_BURN_VELOCITY = 1000;
+/** Backward scrub accumulated while parked at the start before the ride
+ *  gives up and flies home — a firm flick, not a stray tick */
+const BACK_EXIT_PX = 300;
 
 const prefersReducedMotion = () =>
   typeof window !== "undefined" &&
@@ -64,6 +67,9 @@ const Journey = () => {
   const [muted, setMuted] = useState(false);
   const progress = useRef(0);
   const velocity = useRef(0);
+  // Backward scrub piled up against the start (see BACK_EXIT_PX)
+  const backOverscroll = useRef(0);
+  const exiting = useRef(false);
   const [ended, setEnded] = useState(false);
   const endedRef = useRef(false);
   // Reduced motion skips the intro sequence and lands straight on the
@@ -137,6 +143,24 @@ const Journey = () => {
         endedRef.current = atEnd;
         setEnded(atEnd);
       }
+
+      // Scrubbing back past the start flies the ship home: keep pulling
+      // against the parked crawl and the ride lands (same exit as the
+      // cockpit's "End trip" — or a plain route change if the 3D driver
+      // is dead)
+      if (progress.current <= 0 && velocity.current < 0) {
+        backOverscroll.current += -velocity.current * dt;
+        if (backOverscroll.current > BACK_EXIT_PX && !exiting.current) {
+          exiting.current = true;
+          if (journeyState.phase !== "idle") {
+            requestJourneyLanding();
+          } else {
+            void navigate("/home");
+          }
+        }
+      } else {
+        backOverscroll.current = 0;
+      }
     };
     raf = requestAnimationFrame(tick);
 
@@ -185,7 +209,7 @@ const Journey = () => {
       window.removeEventListener("touchmove", onTouchMove);
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [reduced]);
+  }, [reduced, navigate]);
 
   // The soundtrack fades up a beat after arrival. Autoplay is allowed
   // when the visitor rode the rocket here (the click was the gesture);

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -65,7 +65,12 @@ const SolarOverlays = () => {
   const navigate = useNavigate();
   // The 808 pad sits out on phones (SolarScene hides the 3D pad; this
   // hides its click target so no invisible button floats in the sky)
-  const isPhone = useWindowSize() === "sm";
+  const size = useWindowSize();
+  const isPhone = size === "sm";
+  // Below lg the link trio (blog rock, GitHub Sputnik, LinkedIn rock)
+  // sits out too — the icon buttons cover those links, and SolarScene
+  // hides the 3D bodies to match
+  const isNarrow = size !== "lg";
   // Navigating away doesn't fire pointerleave — don't leave a hover
   // glow stuck on
   React.useEffect(
@@ -97,35 +102,36 @@ const SolarOverlays = () => {
       >
         <BodyOutline outlineId={EARTH_ABOUT_OUTLINE_ID} />
       </Link>
-      {ASTEROID_LINKS.map((link) => (
-        <TooltipProvider key={link.name} delayDuration={100}>
-          <Tooltip disableHoverableContent>
-            <TooltipTrigger asChild>
-              <a
-                id={asteroidAnchorId(link.name)}
-                className="asteroid-link"
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={link.label}
-                onPointerEnter={() => {
-                  hoverState.asteroid = link.name;
-                }}
-                onPointerLeave={() => {
-                  if (hoverState.asteroid === link.name) {
-                    hoverState.asteroid = null;
-                  }
-                }}
-              >
-                <BodyOutline outlineId={asteroidOutlineId(link.name)} />
-              </a>
-            </TooltipTrigger>
-            <TooltipContent updatePositionStrategy="always">
-              <p>{link.label}</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ))}
+      {!isNarrow &&
+        ASTEROID_LINKS.map((link) => (
+          <TooltipProvider key={link.name} delayDuration={100}>
+            <Tooltip disableHoverableContent>
+              <TooltipTrigger asChild>
+                <a
+                  id={asteroidAnchorId(link.name)}
+                  className="asteroid-link"
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={link.label}
+                  onPointerEnter={() => {
+                    hoverState.asteroid = link.name;
+                  }}
+                  onPointerLeave={() => {
+                    if (hoverState.asteroid === link.name) {
+                      hoverState.asteroid = null;
+                    }
+                  }}
+                >
+                  <BodyOutline outlineId={asteroidOutlineId(link.name)} />
+                </a>
+              </TooltipTrigger>
+              <TooltipContent updatePositionStrategy="always">
+                <p>{link.label}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ))}
       {/* The rocket easter egg: clicking it boards the ship and warps to
           the /journey story crawl (rocketJourney.ts flips the route under
           the warp flash). Same anchor plumbing as the asteroid links. */}

--- a/src/journeyContent.ts
+++ b/src/journeyContent.ts
@@ -44,7 +44,7 @@ export const JOURNEY_CHAPTERS: JourneyChapter[] = [
     era: "2016 – 2020 · San Francisco",
     title: "Airbnb",
     lines: [
-      "A summer internship, a first taste of San Francisco and of shipping real code.",
+      "A summer internship, a taste of San Francisco and of shipping real code.",
       "Came for a summer, stayed for four more years.",
       "Four years on Experiences, building pricing tools for hosts and faster pages for guests. Led the TypeScript migration and never looked back.",
     ],

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -54,6 +54,12 @@ const SolarScene = ({
   const { width } = useWindowWidth();
   const isCompact = width < 1280;
   const isPhone = width < 768;
+  // Below the lg breakpoint (useWindowSize's 1000px) the home view drops
+  // its redundant chrome — the link trio duplicates the icon buttons and
+  // the moon crowds Earth — so the perch keeps some breathing room.
+  // SolarOverlays hides the trio's click targets to match.
+  const isNarrow = width < 1000;
+  const hideHomeExtras = view === "home" && isNarrow;
   useEffect(() => {
     layoutState.compact = isCompact;
   }, [isCompact]);
@@ -125,7 +131,7 @@ const SolarScene = ({
       <Moon
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.28 : 0.2}
-        revealed={planetsRevealed}
+        revealed={planetsRevealed && !hideHomeExtras}
         linkActive={view === "about"}
       />
       {/* Link bodies — home view only: on landing they'd read as clutter
@@ -138,7 +144,7 @@ const SolarScene = ({
           <Satellite
             key={asteroid.name}
             config={asteroid}
-            visible={view === "home"}
+            visible={view === "home" && !isNarrow}
           />
         ) : asteroid.name === "rocket" ? (
           <Rocket
@@ -158,7 +164,7 @@ const SolarScene = ({
           <Asteroid
             key={asteroid.name}
             config={asteroid}
-            visible={view === "home"}
+            visible={view === "home" && !isNarrow}
           />
         ),
       )}


### PR DESCRIPTION
Tidies up the home page on smaller screens and lines up the /journey cockpit chrome with the ship's geometry. (An earlier revision swapped NovaMono for Kode Mono — reverted, we're keeping NovaMono.)

- below the 1000px `lg` breakpoint, /home hides the moon + its orbit, the blog/LinkedIn rocks, the GitHub Sputnik (their DOM click targets too), and the day/night switch — the icon buttons already cover those links. The journey rocket and 808 pad stay
- the LinkedIn/GitHub/email icon buttons grew to 48px and got a translucent cyan fill so they read as buttons, not ghosts. Moved the styling to an `.icon-pill` class: the unlayered global `button` reset beats Tailwind's utility layer, which had also been silently eating the copy-email button's hover tint
- the home headline's roving highlight is now `#b6fdcf` in night mode — halfway between the old green and the white base letters, so it reads as a shimmer instead of a blink
- the ride hint now floats just inside the windshield glass (the opening's bottom edge is at 86% of the viewport in the cockpit SVG), and the cockpit controls center on the dashboard's fake-button line at y=94
- the post-credits chips ("Roll again" / "Back to resume") were misaligned at the bottom on wide screens — now centered mid-screen as proper buttons: white text on 50% `$purp-light`
- scrubbing back past the start of the crawl (~300px of pull against the parked text) lands the ship back on /home, same exit as "End trip"
- "a first taste of San Francisco" → "a taste of San Francisco"