### PR TITLE
[a11y] labels, landmarks, and sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -20,4 +20,14 @@
     <lastmod>2026-07-09</lastmod>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://www.hunt.codes/journey</loc>
+    <lastmod>2026-08-05</lastmod>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.hunt.codes/synth</loc>
+    <lastmod>2026-08-05</lastmod>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/src/DayNightSwitch.tsx
+++ b/src/DayNightSwitch.tsx
@@ -32,7 +32,7 @@ const DayNightSwitch = ({
       )}
       checked={isNightMode}
       onCheckedChange={onCheckedChange}
-      aria-label={isNightMode ? "Switch to day mode" : "Switch to night mode"}
+      aria-label="Night mode"
     >
       <span aria-hidden className="dns-scene dns-scene-day">
         <span className="dns-cloud dns-cloud-1" />

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -120,6 +120,7 @@ const Home = () => {
         </Link>
       </div>
       <main className={cx("homeInfoContainer", logoOpacity === 1 && "show")}>
+        <h1 className="sr-only">Andrew Hunt — home</h1>
         {isSmall && (
           <div className="sm-screen-summary-line max-w-[300px] text-center">
             Frontend Engineer ·{" "}

--- a/src/SvgGenerator.tsx
+++ b/src/SvgGenerator.tsx
@@ -463,11 +463,12 @@ const SvgGenerator = () => {
             onClick={() => void generateSvg()}
             disabled={loading || !prompt.trim()}
             type="button"
+            aria-label={loading ? "Generating…" : "Generate drawing"}
           >
             {loading ? (
-              <span className="svg-generator-spinner" />
+              <span className="svg-generator-spinner" aria-hidden="true" />
             ) : (
-              <Wand2 size={20} />
+              <Wand2 size={20} aria-hidden="true" />
             )}
           </button>
         </div>

--- a/src/Synth.tsx
+++ b/src/Synth.tsx
@@ -154,7 +154,8 @@ const Synth = () => {
   );
 
   return (
-    <>
+    <div role="main" aria-label="Space jam studio">
+      <h1 className="sr-only">Space jam studio</h1>
       <div className="synthBackLink">
         <button type="button" onClick={() => startSynthReturn()}>
           <ArrowLeftCircleIcon className="starIcon" size={16} />
@@ -298,7 +299,7 @@ const Synth = () => {
         drag a planet to shape the sound · A–L plays notes · the sun runs the
         beat
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Small accessibility and crawlability fixes from the design audit.

- the /draw generate button had no accessible name — screen readers announced it as just `button`
- the day/night switch gets a stable `Night mode` label; the old action-phrased label contradicted `aria-checked` ("Switch to day mode, switch, on")
- sr-only `h1` on /home and a main landmark + sr-only `h1` on /synth — /home had no heading at all and /synth had neither a landmark nor a heading
- `sitemap.xml` gains `/journey` and `/synth`