### PR TITLE
[about] make the résumé scannable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1002,6 +1002,14 @@ li > ul > li {
   padding: 24px 32px 64px;
   background: rgba(8, 6, 28, 0.82);
   border-radius: 16px;
+
+  // Cap the measure of running text — the monospace body ran 92–114
+  // characters per line at full panel width. Headings, pill rows, and the
+  // .hor-list card grid keep the full width.
+  p,
+  > ul:not(.hor-list) {
+    max-width: 72ch;
+  }
 }
 
 .App.day .resume-panel {
@@ -1017,10 +1025,17 @@ li > ul > li {
   align-items: center;
 }
 
+// Dates in the experience/education rows: metadata, not headings
+.resume-date {
+  font-size: 14px;
+  font-weight: 400;
+  opacity: 0.75;
+}
+
 .pill {
   border-radius: 16px;
-  padding: 3px 8px;
-  font-size: 10px;
+  padding: 3px 10px;
+  font-size: 12px;
   color: white;
   font-weight: 500;
   text-transform: uppercase;

--- a/src/App.scss
+++ b/src/App.scss
@@ -1023,6 +1023,10 @@ li > ul > li {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  // The longest titles wrap at the 20px step on narrow panels; keep the date
+  // clear of them and let it drop to its own line instead of colliding
+  flex-wrap: wrap;
+  gap: 4px 16px;
 }
 
 // Dates in the experience/education rows: metadata, not headings
@@ -1030,6 +1034,8 @@ li > ul > li {
   font-size: 14px;
   font-weight: 400;
   opacity: 0.75;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .pill {

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -195,14 +195,14 @@ const Resume = () => {
           {experienceItems.map((item) => (
             <React.Fragment key={item.title}>
               <div className="splitRow">
-                <h4 className="flex items-center">
+                <h3 className="flex items-center">
                   {item.title}{" "}
                   <span className="pill location-pill">{item.location}</span>
-                </h4>
-                <h4 className="flex items-center gap-2">
+                </h3>
+                <span className="resume-date flex items-center gap-2">
                   {item.date}
                   <Calendar size={12} />
-                </h4>
+                </span>
               </div>
               <ul>
                 {item.description.map((d, idx) => (
@@ -227,12 +227,12 @@ const Resume = () => {
           <div className="resume-divider" />
           <h2>Education</h2>
           <div className="splitRow">
-            <h4 className="flex items-center">
+            <h3 className="flex items-center">
               Princeton University
               <span className="pill location-pill">BSE</span>
               <span className="pill location-pill">Computer Science</span>
-            </h4>
-            <h4>September 2013 — June 2017</h4>
+            </h3>
+            <span className="resume-date">September 2013 — June 2017</span>
           </div>
           <div className="resume-divider" />
           <h2>Other interests</h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,9 +52,9 @@ module.exports = {
     // Animation utilities now come from tw-animate-css, imported in index.css.
     plugin(function ({ addBase, theme }) {
       addBase({
-        h1: { fontSize: theme("fontSize.3xl") },
-        h2: { fontSize: theme("fontSize.2xl") },
-        h3: { fontSize: theme("fontSize.xl") },
+        h1: { "font-size": theme("fontSize.3xl") },
+        h2: { "font-size": theme("fontSize.2xl") },
+        h3: { "font-size": theme("fontSize.xl") },
       });
     }),
   ],


### PR DESCRIPTION
Typography pass on the résumé panel, from the design audit.

- job titles were `h4`s with no defined size in the type scale — they rendered at 16px, identical to bullet copy; they're now `h3`s (20px) and the dates demote to muted spans (this also fixes the h2→h4 heading-level jump)
- turns out the whole scale was dead, not just `h4`: the tailwind plugin's `addBase` used camelCase `fontSize`, which v4 emits literally into the CSS and browsers ignore, so `h1`/`h2`/`h3` all rendered at 16px too — fixed to `"font-size"`, restoring About Me to 30px and the section headings to 24px
- running text capped at ~72ch — it ran 92–114 monospace characters per line on desktop widths
- `.pill` bumped 10px→12px; skills, locations, and credentials are content people scan for, not decoration

- `.splitRow` gets a gap and a wrap guard so the longest title no longer collides with its date now that titles are taller

### Experience

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/before-resume-exp.png" width="430"> | <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/after-resume-exp.png" width="430"> |

Title, date, and bullets were all 16px and differed only by weight; now the title leads, the date recedes, and the measure is capped.

### Panel top

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/before-resume-top.png" width="430"> | <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/after-resume-top.png" width="430"> |
