### PR TITLE
[nav] make the site graph learnable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1615,12 +1615,26 @@ a:hover {
 // While the video plays, `video-mode` on <body> hides everything except
 // the stars: the solar canvas, the name letters, the mode toggle, and
 // the music player/toggle. The résumé panel hides itself (.video-hidden).
+//
+// The moon is a video link on /home as well as /about, so the home chrome
+// joins the list — including the body overlays (.asteroid-link,
+// .earth-about-ring), which BodyAnchors keeps glued to projections that
+// are no longer drawn once .solar-canvas fades. Left visible they'd be
+// invisible-but-hoverable rings floating over the video. The backdrop is
+// deliberately transparent (the stars stay), so anything not listed here
+// really does show through.
 body.video-mode {
   .solar-canvas,
   .nameTitle,
   .day-night-switch,
   audio,
-  .music-toggle {
+  .music-toggle,
+  .homeInfoContainer,
+  .homePageBackLink,
+  .asteroid-link,
+  .earth-about-ring,
+  .scroll-hint,
+  .badge-link {
     opacity: 0 !important;
     pointer-events: none !important;
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1929,12 +1929,31 @@ body.rocket-journey #rocket-cockpit {
   video {
     display: block;
     width: 100%;
-    max-height: 82vh;
+    // Was 82vh before the caption existed; the popover is centred in the
+    // viewport and the close button sits 44px above it, so the video gives
+    // back enough height for two caption lines to stay on screen
+    max-height: 72vh;
     object-fit: contain;
     background: #000;
     border-radius: 12px;
     box-shadow: 0 12px 48px rgba(0, 0, 0, 0.65);
   }
+}
+
+// What the reel actually is. Sits over the bare starfield (video-mode
+// cleared everything else), so it takes the same day/night treatment as
+// the close button rather than assuming a dark backdrop.
+.zip-video-caption {
+  margin: 14px auto 0;
+  max-width: 62ch;
+  text-align: center;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #cfcbe4;
+}
+
+.App.day .zip-video-caption {
+  color: #3a3454;
 }
 
 .zip-video-close {

--- a/src/App.scss
+++ b/src/App.scss
@@ -2438,8 +2438,8 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
 
   > a {
     color: $purp-light;
-    padding: 4px;
-    border-radius: 50%;
+    padding: 4px 10px 4px 4px;
+    border-radius: 999px;
 
     &:hover {
       background: $purp-light-transparent-25;
@@ -2837,4 +2837,55 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+// The catch-all 404 (NotFound.tsx) — a lone beacon in the starfield
+.not-found-page {
+  position: fixed;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 24px;
+  text-align: center;
+  font-family: "Inconsolata", monospace;
+  color: #e8e6f5;
+
+  h1 {
+    margin: 0;
+    font-size: 32px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    text-shadow: 0 0 24px $purp-light-transparent;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    letter-spacing: 0.5px;
+    opacity: 0.8;
+  }
+
+  a {
+    margin-top: 20px;
+    color: $purp-light;
+    letter-spacing: 1px;
+    padding: 6px 14px;
+    border-radius: 999px;
+
+    &:hover {
+      background: $purp-light-transparent-25;
+    }
+  }
+}
+
+.App.day .not-found-page {
+  color: #24203a;
+
+  a {
+    color: $purp;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import "./App.scss";
 
 import Home from "./Home";
 import Journey from "./Journey";
+import NotFound from "./NotFound";
 import Resume from "./Resume";
 import RocketCockpit from "./RocketCockpit";
 import Synth from "./Synth";
@@ -58,6 +59,8 @@ const ROUTE_TITLES: Record<string, string> = {
   "/journey": "The Journey | Andrew Hunt",
   "/draw": "SVG Studio | Andrew Hunt",
 };
+// Anything else lands on the catch-all 404 route
+const NOT_FOUND_TITLE = "Lost in space | Andrew Hunt";
 
 // The static index.html head serves every route of the SPA; keep the tab
 // title and canonical URL in sync as the visitor navigates
@@ -67,7 +70,7 @@ const RouteMeta = () => {
     document.title =
       ROUTE_TITLES[pathname] ??
       // Drawing permalinks (/draw/:id) share the studio's title
-      (pathname.startsWith("/draw/") ? ROUTE_TITLES["/draw"] : DEFAULT_TITLE);
+      (pathname.startsWith("/draw/") ? ROUTE_TITLES["/draw"] : NOT_FOUND_TITLE);
     document
       .querySelector('link[rel="canonical"]')
       ?.setAttribute(
@@ -120,6 +123,7 @@ const App = () => {
           <Route path="/journey" element={<Journey />} />
           <Route path="/draw" element={<SvgGenerator />} />
           <Route path="/draw/:id" element={<SvgGenerator />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
         {/* App-level so the windshield frame and warp flash survive the
             rides' mid-flight route hops (/home → /journey → /home) —

--- a/src/BadgeLink.tsx
+++ b/src/BadgeLink.tsx
@@ -13,14 +13,15 @@ import { badgeHoverState } from "./badgeState";
  */
 const BadgeLink = ({ isNightMode }: { isNightMode: boolean }) => {
   const { pathname } = useLocation();
-  // Landing: decorative only (you're already home). /about and /draw:
-  // page content flows over the corner. Day-mode /home: the Golden Gate
-  // Bridge owns the corner. The coin hides in the same cases
+  // Landing: decorative only (you're already home). Day-mode /home: the
+  // Golden Gate Bridge owns the corner. The coin hides in the same cases
   // (Space3DBackground) — an invisible link over other content would
   // hijack clicks.
   const visible =
     pathname === "/synth" ||
     pathname === "/journey" ||
+    pathname === "/about" ||
+    pathname.startsWith("/draw") ||
     (pathname === "/home" && isNightMode);
   if (!visible) return null;
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,7 +3,7 @@ import Typed from "typed.js";
 import cx from "classnames";
 
 import { GitHub, Linkedin, Mail } from "react-feather";
-import { ArrowLeftCircleIcon, PenLine } from "lucide-react";
+import { ArrowLeftCircleIcon, PenLine, Wand2 } from "lucide-react";
 import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
@@ -184,7 +184,7 @@ const Home = () => {
                 <PenLine size={20} />
               </a>
             )}
-            {/* <TooltipProvider>
+            <TooltipProvider>
               <Tooltip disableHoverableContent>
                 <TooltipTrigger asChild>
                   <Link
@@ -199,7 +199,7 @@ const Home = () => {
                   <p>SVG Studio</p>
                 </TooltipContent>
               </Tooltip>
-            </TooltipProvider> */}
+            </TooltipProvider>
             <TooltipProvider
               skipDelayDuration={0}
               delayDuration={0}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -8,6 +8,7 @@ import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
 import ScrollHint from "./ScrollHint";
+import ZipVideoMoon from "./ZipVideoMoon";
 import { JOURNEY_STOPS } from "./scrollTransition";
 
 import {
@@ -51,6 +52,11 @@ const Home = () => {
 
   const size = useWindowSize();
   const isSmall = size === "sm";
+  // The moon's video popover (ZipVideoMoon), same as /about. Below lg the
+  // moon sits out of the home view entirely (SolarScene's hideHomeExtras),
+  // so there'd be nothing for the overlay to glue itself to.
+  const [videoOpen, setVideoOpen] = useState(false);
+  const moonLinkActive = size === "lg";
 
   const typedEl = useRef<HTMLSpanElement>(null);
 
@@ -110,6 +116,11 @@ const Home = () => {
   return (
     <>
       <SolarOverlays />
+      {/* The moon doubles as the Zip brand-video link here too (overlay +
+          popover); `video-mode` on <body> hides the rest of the page */}
+      {moonLinkActive && (
+        <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
+      )}
       <div className="homePageBackLink">
         <Link
           className={cx("mt-4 flex items-center gap-1 transition-transform")}

--- a/src/Journey.tsx
+++ b/src/Journey.tsx
@@ -250,7 +250,7 @@ const Journey = () => {
           to="/home"
         >
           <ArrowLeftCircleIcon className="starIcon" size={16} />
-          <span>Back to orbit</span>
+          <span>Home</span>
         </Link>
       </div>
       {/* Star Wars-style opener: the intro line fades up flat on the

--- a/src/NotFound.tsx
+++ b/src/NotFound.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from "react";
+import { Link } from "react-router-dom";
+
+/**
+ * The catch-all for paths that aren't on the map. The SPA answers every
+ * URL with a 200, so this page tells crawlers not to index it (soft-404
+ * mitigation) and hands lost visitors a way back to the solar system.
+ */
+const NotFound = () => {
+  useEffect(() => {
+    // index.html ships an "index, follow" robots meta — flip it rather
+    // than appending a second, conflicting tag
+    const existing = document.querySelector<HTMLMetaElement>(
+      'meta[name="robots"]',
+    );
+    if (existing) {
+      const previous = existing.content;
+      existing.content = "noindex";
+      return () => {
+        existing.content = previous;
+      };
+    }
+    const meta = document.createElement("meta");
+    meta.name = "robots";
+    meta.content = "noindex";
+    document.head.appendChild(meta);
+    return () => {
+      meta.remove();
+    };
+  }, []);
+
+  return (
+    <main className="not-found-page">
+      <h1>lost in space?</h1>
+      <p>you’ve drifted off the map.</p>
+      <Link to="/home">take me home</Link>
+    </main>
+  );
+};
+
+export default NotFound;

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -12,18 +12,24 @@ import { scrollTransitionState } from "./scrollTransition";
 
 /**
  * Where each stop actually goes, for the tooltip and the screen-reader
- * label. The visible caption stays generic, but these have to name the
- * real destination — telling someone on /home that the chevron explores
- * the solar system describes the trip they just finished, not the résumé
- * they are about to reach.
+ * label. These have to name the real destination — telling someone on
+ * /home that the chevron explores the solar system describes the trip
+ * they just finished, not the résumé they are about to reach.
  */
 const DESTINATION_TEXT: Record<1 | 2, string> = {
   1: "Scroll or click around to explore the solar system",
-  2: "Scroll or click to travel on to the résumé",
+  2: "Scroll on to the résumé — or click to travel there",
 };
 
-/** The wide-tracked caption above the chevron */
-const SCROLL_HINT_LABEL = "Scroll or click to explore";
+/**
+ * The wide-tracked caption above the chevron. Generic on the landing page
+ * (the whole solar system is next); on /home it names the résumé, the one
+ * stop left on the journey.
+ */
+const CAPTION_TEXT: Record<1 | 2, string> = {
+  1: "Scroll or click to explore",
+  2: "Scroll on to the résumé",
+};
 
 type ScrollHintProps = {
   /**
@@ -89,7 +95,7 @@ const ScrollHint = ({
             {/* aria-hidden: the button's own label already says this, and
                 more fully — this copy is the visible shorthand */}
             <span className="scroll-hint-label" aria-hidden="true">
-              {SCROLL_HINT_LABEL}
+              {CAPTION_TEXT[target]}
             </span>
             <ChevronDown className="scroll-hint-chevron" size={30} />
           </button>

--- a/src/SvgGenerator.tsx
+++ b/src/SvgGenerator.tsx
@@ -411,11 +411,11 @@ const SvgGenerator = () => {
     <div className="svg-generator-page">
       <div className="svg-generator-back-link">
         <Link
-          aria-label="Back to landing page"
           className="mt-4 flex items-center gap-1 transition-transform"
           to="/"
         >
-          <Star className="starIcon" size={16} />
+          <Star aria-hidden="true" className="starIcon" size={16} />
+          <span>back to orbit</span>
         </Link>
       </div>
 

--- a/src/ZipVideoMoon.tsx
+++ b/src/ZipVideoMoon.tsx
@@ -73,6 +73,11 @@ const ZipVideoMoon = ({
           {/* The click that opened the popover is the user gesture that
               allows autoplay with sound */}
           <video src="/zip-brand-launch.mp4" controls autoPlay playsInline />
+          <p className="zip-video-caption">
+            A promo video I made for the UI changes we shipped as part of
+            Zip&rsquo;s brand redesign in 2023 — built in After Effects and
+            Premiere.
+          </p>
         </div>
       </div>
     );

--- a/src/ZipVideoMoon.tsx
+++ b/src/ZipVideoMoon.tsx
@@ -15,12 +15,14 @@ import { BodyOutline } from "./SolarOverlays";
 import { hoverState } from "./solarHover";
 
 /**
- * The /about moon as a video link: an invisible overlay that BodyAnchors
- * glues to the moon's projection (same plumbing as the asteroid links),
- * with a tooltip and the shared pulsing hover outline. Clicking it opens
- * the Zip brand-redesign launch reel in a ~80vw popover; `video-mode` on
- * <body> hides everything but the stars behind it (App.scss), and Resume
- * hides its own panel via the lifted `open` state.
+ * The moon as a video link, on /about and /home: an invisible overlay that
+ * BodyAnchors glues to the moon's projection (same plumbing as the
+ * asteroid links), with a tooltip and the shared pulsing hover outline.
+ * Clicking it opens the Zip brand-redesign launch reel in a ~80vw popover;
+ * `video-mode` on <body> hides everything but the stars behind it
+ * (App.scss), and Resume additionally hides its own panel via the lifted
+ * `open` state. Both routes own that state, so neither can mount this
+ * twice — and only one route is mounted at a time anyway.
  *
  * While the popover is open the overlay itself is unmounted — BodyAnchors
  * skips absent elements, so there's nothing left hovering over the video.

--- a/src/solarAnchorIds.ts
+++ b/src/solarAnchorIds.ts
@@ -8,8 +8,9 @@ export const EARTH_ABOUT_RING_ID = "earth-about-ring";
 /** Group inside the /about ring holding Earth's hover-outline paths;
  *  Planet writes Earth's projected silhouette into every path under it. */
 export const EARTH_ABOUT_OUTLINE_ID = "earth-about-outline";
-/** The moon's video-link overlay on /about (rendered by Resume) and the
- *  group holding its hover-outline paths (written by Moon). */
+/** The moon's video-link overlay on /about and /home (rendered by Resume
+ *  and Home) and the group holding its hover-outline paths (written by
+ *  Moon). Only one route mounts at a time, so the id stays unique. */
 export const MOON_VIDEO_LINK_ID = "moon-video-link";
 export const MOON_VIDEO_OUTLINE_ID = "moon-video-outline";
 export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -8,7 +8,7 @@
 export const hoverState = {
   sun: false,
   earth: false,
-  /** The moon's video-link overlay on /about */
+  /** The moon's video-link overlay on /about and /home */
   moon: false,
   /** Name of the hovered link asteroid (constants.ts ASTEROIDS), or null */
   asteroid: null as string | null,

--- a/src/space3d/Space3DBackground.tsx
+++ b/src/space3d/Space3DBackground.tsx
@@ -65,10 +65,10 @@ const Space3DBackground = ({
         <StarField isLanding={isLanding} opacityTarget={isNightMode ? 1 : 0} />
         {/* The corner "hunt.codes" medallion rides the star canvas rather
             than bringing its own WebGL context (three contexts tripped
-            Chrome's per-domain cap and strobed the stars). Hidden where
-            something else owns the corner: /about + /draw (page content)
-            and day-mode /home (the Golden Gate Bridge). */}
-        {!isAboutPage && !(isHomePage && !isNightMode) && (
+            Chrome's per-domain cap and strobed the stars). Hidden only
+            where something else owns the corner: day-mode /home (the
+            Golden Gate Bridge). */}
+        {!(isHomePage && !isNightMode) && (
           <BadgeBoundary>
             <Suspense fallback={null}>
               <BadgeMedallion />

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -67,7 +67,7 @@ const ANCHORS: BodyAnchorConfig[] = [
     fadeInOnArrival: true,
   },
   {
-    // The moon's video link (the overlay only exists on /about)
+    // The moon's video link (the overlay exists on /about and /home)
     domId: MOON_VIDEO_LINK_ID,
     position: (t, out) => moonPosition(t, out),
     radius: MOON.radius,

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -23,17 +23,17 @@ import moonMapUrl from "../../assets/moon.jpg";
  * — still reads it when that face is turned away from the sun.
  *
  * On /about and /home the moon doubles as a video link (the Zip
- * brand-launch reel — see ZipVideoMoon): play-icon badges are decaled onto
- * the surface, and hovering the DOM overlay brightens the moon and pulses
- * its silhouette outline, matching the other link bodies. It is absent
- * from the landing view entirely (SolarScene gates `revealed`).
+ * brand-launch reel — see ZipVideoMoon): movie-camera badges are decaled
+ * onto the surface, and hovering the DOM overlay brightens the moon and
+ * pulses its silhouette outline, matching the other link bodies. It is
+ * absent from the landing view entirely (SolarScene gates `revealed`).
  */
 /** Fade duration for the landing-intro reveal */
 const REVEAL_SECONDS = 0.8;
 
-/** Play badges around the equator: 3 at 120° apart, so from any camera
- *  angle at least one is within 60° of facing the viewer (the moon's
- *  self-spin is glacial — a single badge could hide for minutes). */
+/** Movie-camera badges around the equator: 3 at 120° apart, so from any
+ *  camera angle at least one is within 60° of facing the viewer (the
+ *  moon's self-spin is glacial — a single badge could hide for minutes). */
 const BADGE_YAWS = [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3];
 
 const moonWorldPos = new THREE.Vector3();
@@ -78,12 +78,12 @@ export default function Moon({
   );
   useEffect(() => () => geometry.dispose(), [geometry]);
 
-  // Play-icon stickers on the surface (same decal treatment as the
+  // Movie-camera stickers on the surface (same decal treatment as the
   // asteroid badges), riding the moon's slow self-spin
   const badgeMaterial = useMemo(
     () =>
       new THREE.MeshBasicMaterial({
-        map: createLogoBadgeTexture("play"),
+        map: createLogoBadgeTexture("video"),
         transparent: true,
         depthWrite: false,
         polygonOffset: true,
@@ -208,7 +208,7 @@ export default function Moon({
         />
       </lineLoop>
       <group ref={moonGroup}>
-        {/* clickable-body affordance halo (video link, /about only) */}
+        {/* clickable-body affordance halo (video link, /about and /home) */}
         <InteractiveGlow
           radius={MOON.radius}
           opacityRef={revealOpacity}
@@ -227,7 +227,7 @@ export default function Moon({
                 emissiveIntensity={0.22}
                 transparent
               />
-              {/* Play-icon stickers, riding the spin with the surface */}
+              {/* Movie-camera stickers, riding the spin with the surface */}
               {badgeGeometries.map((badgeGeometry, i) => (
                 <mesh
                   key={i}

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -22,10 +22,11 @@ import moonMapUrl from "../../assets/moon.jpg";
  * emissive) so the /about camera — which perches over the moon's far side
  * — still reads it when that face is turned away from the sun.
  *
- * On /about the moon doubles as a video link (the Zip brand-launch reel —
- * see ZipVideoMoon): play-icon badges are decaled onto the surface, and
- * hovering the DOM overlay brightens the moon and pulses its silhouette
- * outline, matching the other link bodies.
+ * On /about and /home the moon doubles as a video link (the Zip
+ * brand-launch reel — see ZipVideoMoon): play-icon badges are decaled onto
+ * the surface, and hovering the DOM overlay brightens the moon and pulses
+ * its silhouette outline, matching the other link bodies. It is absent
+ * from the landing view entirely (SolarScene gates `revealed`).
  */
 /** Fade duration for the landing-intro reveal */
 const REVEAL_SECONDS = 0.8;
@@ -47,7 +48,8 @@ export default function Moon({
   orbitOpacity: number;
   /** Fades the moon + its orbit ring in (landing intro) */
   revealed?: boolean;
-  /** The video link only exists on /about — gate the clickable halo */
+  /** The video link only exists on /about and /home — gate the clickable
+   *  halo to the views whose overlay is mounted */
   linkActive?: boolean;
 }) {
   const earthGroup = useRef<THREE.Group>(null);
@@ -181,8 +183,8 @@ export default function Moon({
       orbitMaterial.current.opacity = orbitOpacity * revealOpacity.current;
     }
 
-    // Video-link hover (the /about overlay): brighten the moonshine and
-    // hand the silhouette to the overlay's pulsing outline paths
+    // Video-link hover (the /about and /home overlay): brighten the
+    // moonshine and hand the silhouette to the overlay's pulsing outline
     const hovered = hoverState.moon;
     if (surfaceMaterial.current) {
       const ease = Math.min(delta * 6, 1);

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -128,11 +128,17 @@ const SolarScene = ({
           closeUp={view === "about"}
         />
       ))}
+      {/* No moon on the landing view: from the top-down framing it reads as
+          a stray speck beside Earth rather than a body, and its orbit ring
+          crosses Earth's. It fades in on the way to the home perch, where
+          there's room to read it — and where it becomes the video link. */}
       <Moon
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.28 : 0.2}
-        revealed={planetsRevealed && !hideHomeExtras}
-        linkActive={view === "about"}
+        revealed={planetsRevealed && !hideHomeExtras && !isLanding}
+        // The video link needs the moon actually on screen: /about always,
+        // /home only at the widths where hideHomeExtras keeps it
+        linkActive={view === "about" || (view === "home" && !hideHomeExtras)}
       />
       {/* Link bodies — home view only: on landing they'd read as clutter
           around the sun, and on /about their DOM overlays don't exist, so

--- a/src/space3d/textures.ts
+++ b/src/space3d/textures.ts
@@ -219,11 +219,17 @@ const RSS_MARK_PATH =
   "909 24h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727 0 15.909 " +
   "7.184 15.909 15.91z";
 
-/** A simple play triangle (Material Design play arrow), in a 24x24
- *  viewBox — the moon's "watch the video" badge. */
-const PLAY_MARK_PATH = "M8 5v14l11-7z";
+/** A movie camera (Material Design videocam), in a 24x24 viewBox — the
+ *  moon's "watch the video" badge. Chosen over a bare play triangle
+ *  because the moon links a film someone made, not a generic media
+ *  control; it also survives the decal better than a clapperboard or film
+ *  strip, whose sprocket holes and stripes mud together at moon scale.
+ *  Body and lens wedge are both solid, so it needs no even-odd fill. */
+const VIDEO_MARK_PATH =
+  "M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 " +
+  "0 1-.45 1-1v-3.5l4 4v-11l-4 4z";
 
-export type AsteroidLogo = "github" | "linkedin" | "blog" | "play";
+export type AsteroidLogo = "github" | "linkedin" | "blog" | "video";
 
 const LOGO_MARKS: Record<
   AsteroidLogo,
@@ -233,7 +239,10 @@ const LOGO_MARKS: Record<
   // The square marks are scaled down so they don't overwhelm the asteroid
   linkedin: { path: LINKEDIN_MARK_PATH, color: "#0a66c2", scale: 0.6 },
   blog: { path: RSS_MARK_PATH, color: "#f26522", scale: 0.6 },
-  play: { path: PLAY_MARK_PATH, color: "#412596", scale: 0.85 },
+  // Wider than the play triangle it replaced (18 viewBox units vs 11), so
+  // it steps down a notch to keep the same visual weight on the moon and
+  // to stop the decal wrapping further around the limb
+  video: { path: VIDEO_MARK_PATH, color: "#412596", scale: 0.8 },
 };
 
 /** Brand mark on a transparent canvas — a "sticker" decal for the link


### PR DESCRIPTION
Navigation and findability fixes from the design audit.

- restore the commented-out wand pill on /home — `/draw` had zero inbound links anywhere on the site
- /home's scroll hint now reads `scroll on to the résumé` — the destination copy already existed but only fed the tooltip and aria-label
- back-nav consistency: /draw's unlabeled 16px star gets a visible `back to orbit` label (it goes to the landing, same as /home's link), and /journey's back link becomes `Home` (it goes to /home) so "orbit" always means one place; the wordmark coin now also shows on /about and /draw
- on-brand 404 for unmatched paths — they currently return 200 and render an empty starfield with no way home


### /home — wand pill and destination-aware hint

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/before-home-full.png" width="430"> | <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/after-home-full.png" width="430"> |

### Unmatched path (`/lost-in-space`)

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/before-404.png" width="430"> | <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/after-404.png" width="430"> |

### /draw back-nav

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/before-draw.png" width="430"> | <img src="https://raw.githubusercontent.com/amhunt/hunt-codes/assets/pr-screenshots/after-draw-nav.png" width="430"> |
