### PR TITLE
[about] move the moon out from behind the résumé panel

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1012,6 +1012,18 @@ li > ul > li {
   color: #eeeeee;
   transition-delay: 500ms;
 
+  // Left gutter for the moon (the Zip-video link): without it the panel
+  // runs under the moon and the link reads as a dead spot over the text.
+  // Below lg the gutter shrinks with the viewport but keeps the panel at
+  // the same 680px the lg rule below yields at 1280 — so the layout is
+  // continuous across the breakpoint — and never drops under 200px, which
+  // is the moon's widest projection on a portrait tablet. Paired with
+  // aboutMoonNdcX() in CameraRig, which parks the moon at this gutter's
+  // center: change one, change the other.
+  @media (min-width: $breakpoint-sm) {
+    padding-left: max(200px, calc(100vw - 680px));
+  }
+
   @media (min-width: 1280px) {
     padding-left: 600px;
   }

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -62,15 +62,36 @@ const ABOUT_CAM_ABOVE = 2.6;
 const ABOUT_CAM_SIDE = 0.5;
 const ABOUT_LOOK_HEIGHT = 0.45; // aim slightly above the moon's plane
 /** Moon's horizontal screen spot on wide screens: NDC -0.5 = 25vw from
- *  the left edge. Below the lg breakpoint the camera drops its side
- *  offset instead, putting itself on the Earth-moon line so the moon
- *  reads dead-center, directly above Earth. */
+ *  the left edge, well inside the 600px gutter .resume-container reserves
+ *  there. */
 const ABOUT_MOON_NDC_X = -0.5;
+/** Below lg the résumé panel keeps its 680px width and the gutter takes
+ *  whatever is left (min 200px) — .resume-container's `padding-left`. The
+ *  moon rides the center of that gutter, so these two numbers must match
+ *  the stylesheet's. */
+const ABOUT_PANEL_PX = 680;
+const ABOUT_GUTTER_MIN_PX = 200;
+const SM_BREAKPOINT_PX = 768;
 /** Extra downward aim, as an NDC fraction at the moon's distance: rotating
  *  the view down lifts the whole scene — the moon rides ~20vh higher and
  *  more of Earth's limb clears the bottom edge. */
 const ABOUT_MOON_NDC_Y_LIFT = 0.4;
 const LG_BREAKPOINT_PX = 1280;
+
+/**
+ * Where the moon should sit horizontally (NDC) for a viewport width —
+ * always the middle of the gutter the résumé panel leaves it. Returns
+ * null on phone widths, where the panel is full-bleed: there's no gutter
+ * to aim for, so the camera sits on the Earth-moon line instead and the
+ * moon reads dead-center, directly above Earth.
+ */
+function aboutMoonNdcX(width: number): number | null {
+  if (width < SM_BREAKPOINT_PX) return null;
+  if (width >= LG_BREAKPOINT_PX) return ABOUT_MOON_NDC_X;
+  const gutter = Math.max(ABOUT_GUTTER_MIN_PX, width - ABOUT_PANEL_PX);
+  // gutter center in px -> NDC: 2 * (gutter / 2) / width - 1
+  return gutter / width - 1;
+}
 
 // scratch values, reused every frame
 const goalPos = new THREE.Vector3();
@@ -132,13 +153,13 @@ function computeGoal(
     moonPosition(t, moonPos);
     moonDir.copy(moonPos).sub(earthPos).normalize();
     side.crossVectors(moonDir, UP).normalize();
-    const centered = viewport.width < LG_BREAKPOINT_PX;
+    const moonNdcX = aboutMoonNdcX(viewport.width);
     goalPos
       .copy(earthPos)
       .addScaledVector(moonDir, -ABOUT_CAM_BEHIND)
-      // Centered (sm/md): sit right on the Earth-moon line so the moon
-      // reads directly above Earth
-      .addScaledVector(side, centered ? 0 : ABOUT_CAM_SIDE);
+      // Phone widths: sit right on the Earth-moon line so the moon reads
+      // directly above Earth
+      .addScaledVector(side, moonNdcX === null ? 0 : ABOUT_CAM_SIDE);
     goalPos.y += ABOUT_CAM_ABOVE;
     const persp = camera as THREE.PerspectiveCamera;
     const tanHalfV = Math.tan((persp.fov * Math.PI) / 360);
@@ -147,11 +168,11 @@ function computeGoal(
       moonPos.y +
       ABOUT_LOOK_HEIGHT -
       goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_Y_LIFT * tanHalfV;
-    if (!centered) {
-      // Aim sideways of the moon by the angle that lands it at
-      // ABOUT_MOON_NDC_X for the current aspect (~25vw from the left)
+    if (moonNdcX !== null) {
+      // Aim sideways of the moon by the angle that lands it at moonNdcX
+      // for the current aspect (the middle of the panel's left gutter)
       const tanHalfH = tanHalfV * (persp.aspect || 1);
-      const lateral = goalPos.distanceTo(moonPos) * ABOUT_MOON_NDC_X * tanHalfH;
+      const lateral = goalPos.distanceTo(moonPos) * moonNdcX * tanHalfH;
       goalLook.addScaledVector(side, -lateral);
     }
   } else {


### PR DESCRIPTION
Below the lg breakpoint `/about` reserved no space for the moon: the résumé panel sat centered at up to 800px wide while the camera parked the moon dead-center, so the Zip-video link hid behind the intro text. And since `.moon-link` is `z-index: 5` — above the panel at z 4 — its invisible hit circle was quietly swallowing clicks over the paragraph. The panel now keeps a left gutter down to 768px and the camera aims the moon at the middle of it.

- `.resume-container` gets `padding-left: max(200px, calc(100vw - 680px))` from `$breakpoint-sm` up; 680px is exactly what the existing `min-width: 1280px` rule yields at 1280, so panel width is continuous across the breakpoint
- `aboutMoonNdcX(width)` in `CameraRig` replaces the binary `centered` flag — the existing `-0.5` at ≥1280, the gutter's center below that, `null` on phone widths (camera stays on the Earth-moon line there)
- the 200px floor is sized for the moon's widest realistic projection: its diameter is ~0.145 × viewport *height*, so ~161px on an 834×1112 iPad portrait
- the moon stays on the left instead of moving right of the text — ≥1280 already puts it there, and flipping sides mid-resize would read worse
- phones (<768) are unchanged: the panel is full-bleed, so there's no gutter to move into and the link still overlaps the intro copy. Worth a follow-up — either drop the overlay below 768 or find the video another home
