### PR TITLE
Give bunfig's preload the array form knip expects

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-preload = "./happydom.ts"
+preload = ["./happydom.ts"]


### PR DESCRIPTION
One-line fix for the last loose end from the dependency audit.

## The problem

`knip` has been bailing out on `bunfig.toml` before analysing anything:

```
ERROR: Error loading bunfig.toml (preload.map is not a function)
ERROR: Please fix or visit https://knip.dev/reference/known-issues
```

Bun accepts `preload` as either a string or an array, so the scalar form was never wrong for the test runner — but knip only handles the array and calls `.map` on whatever it finds. Wrapping the single entry satisfies both.

```diff
 [test]
-preload = "./happydom.ts"
+preload = ["./happydom.ts"]
```

## Verification

The preload is load-bearing, so I checked it still *works* rather than merely parses: the smoke test calls `document.createElement`, which only exists because `happydom.ts` registers happy-dom's globals. It still passes — a broken preload would fail the test, not skip it.

`knip`, `tsc --noEmit`, `lint` and a production build are all clean too.

## One follow-up, not done here

Now that knip can read the file, it gets further and reports a new configuration hint:

```
happydom.ts    knip.json    Remove redundant entry pattern
```

`entry: ["happydom.ts"]` in `knip.json` is redundant once knip discovers that entry from the preload itself. Left alone to keep this to the parse fix — happy to follow up if you want it tidied.

The unused-dependency list is unchanged either way: `postcss`, `tw-animate-css` and `serve` remain the known false positives `CLAUDE.md` documents, so no doc update is needed.

Also adds the missing trailing newline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01By4C8WtwuhW55oUJEEZumc)_