### PR TITLE
Upgrade eslint-plugin-unicorn to v73

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-tailwindcss": "^4.2.0",
-    "eslint-plugin-unicorn": "^71.1.0",
+    "eslint-plugin-unicorn": "^73.0.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.9.0",
     "knip": "^6.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,6 +612,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/css-tree@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "@eslint/css-tree@npm:4.0.5"
+  dependencies:
+    mdn-data: "npm:2.29.0"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/7fbcb169c98dc8172503b3b1f4bd58b65959e611387f936aa0df193b4c3111f02a79597b7363a5120dddac491117d448e02216379f675070fad7ab1256d8da3b
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:^10.0.1":
   version: 10.0.1
   resolution: "@eslint/js@npm:10.0.1"
@@ -4794,7 +4804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -5184,16 +5194,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:^71.1.0":
-  version: 71.1.0
-  resolution: "eslint-plugin-unicorn@npm:71.1.0"
+"eslint-plugin-unicorn@npm:^73.0.0":
+  version: 73.0.0
+  resolution: "eslint-plugin-unicorn@npm:73.0.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@eslint/css-tree": "npm:^4.0.4"
     browserslist: "npm:^4.28.4"
     change-case: "npm:^5.4.4"
     ci-info: "npm:^4.4.0"
     core-js-compat: "npm:^3.49.0"
     detect-indent: "npm:^7.0.2"
+    entities: "npm:^4.5.0"
     find-up-simple: "npm:^1.0.1"
     globals: "npm:^17.7.0"
     indent-string: "npm:^5.0.0"
@@ -5205,9 +5217,10 @@ __metadata:
     reserved-identifiers: "npm:^1.2.0"
     semver: "npm:^7.8.5"
     strip-indent: "npm:^4.1.1"
+    yaml: "npm:^2.9.0"
   peerDependencies:
     eslint: ">=10.4"
-  checksum: 10c0/389cc27c8e64093abd4260c22817391775748bdfc5b23f047fe65ab48d5d2bae6c491afae9beb7578064c3862e9aca8c3f3aac151110f207c63119a84ac48d38
+  checksum: 10c0/50b13b9d4a22e90daa2e1273ee4ace755bb2a2b7415c321bc257b4710e193099b975fd934988aa3f8589b87707f8c6cdda7505e4415b1380c9fd71dea6925ec7
   languageName: node
   linkType: hard
 
@@ -5897,7 +5910,7 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.17.1"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-tailwindcss: "npm:^4.2.0"
-    eslint-plugin-unicorn: "npm:^71.1.0"
+    eslint-plugin-unicorn: "npm:^73.0.0"
     eslint-plugin-unused-imports: "npm:^4.4.1"
     globals: "npm:^17.9.0"
     husky: "npm:^9.1.7"
@@ -6856,6 +6869,13 @@ __metadata:
   version: 2.0.30
   resolution: "mdn-data@npm:2.0.30"
   checksum: 10c0/a2c472ea16cee3911ae742593715aa4c634eb3d4b9f1e6ada0902aa90df13dcbb7285d19435f3ff213ebaa3b2e0c0265c1eb0e3fb278fda7f8919f046a410cd9
+  languageName: node
+  linkType: hard
+
+"mdn-data@npm:2.29.0":
+  version: 2.29.0
+  resolution: "mdn-data@npm:2.29.0"
+  checksum: 10c0/b973a82d0764ebe611014e3be1c174cbcd235f3d5f1f943530be03b2d2ec74e9db0b0018b2940e8f1f41ca887d1298dcd1d49738e6982f484dbbebccc0250652
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Two majors, 71.1.0 → 73.0.0. **No source changes were needed** — no autofixes to apply, no `eslint-disable` comments required.

## Why a two-major jump is a no-op here

`eslint.config.mjs` enables 19 named unicorn rules rather than extending the plugin's `recommended` preset. New majors of this plugin mostly add rules and reshuffle what `recommended` contains — an explicit allowlist sees none of that. The same 19 rules apply before and after.

## I checked rather than assumed

"No output" and "nothing was linted" look identical from the outside, so I verified coverage directly:

```
files linted:                            73
files with messages:                      0
deep-nested linted (src/space3d/solar):  24
```

Worth confirming because `yarn lint` passes an **unquoted** `src/**/*.{js,jsx,ts,tsx}`, and `sh` has no brace expansion — so the pattern reaches eslint verbatim and eslint does its own globbing. That works correctly, but a zero-match glob would also have exited 0 silently, which is exactly the failure mode that would make a clean run meaningless.

All 19 configured rules still resolve, too. A rule removed or renamed across v72/v73 would surface as `Definition for rule '...' was not found` on every file — and there are no messages at all.

## Verification

`tsc --noEmit`, `lint`, `bun test` (1 pass), a production build, and `yarn install --immutable` — all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01By4C8WtwuhW55oUJEEZumc)_