### PR TITLE
[about] stop the moon overlay and Home link from stealing clicks

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1599,7 +1599,9 @@ a:hover {
 
 // The moon's video link on /about (ZipVideoMoon), glued to the moon by
 // BodyAnchors like the rest; z 5 lifts it above the résumé scroll
-// container (z 4) so it stays hoverable
+// container (z 4) so it stays hoverable. That only works because the
+// panel leaves the moon a gutter — on phones there is no gutter, so
+// Resume doesn't mount the overlay at all (it would sit over the text).
 .moon-link {
   position: fixed;
   visibility: hidden;

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -96,16 +96,27 @@ const Resume = () => {
 
   return (
     <main className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
-      {/* The moon doubles as the Zip brand-video link (overlay + popover) */}
-      <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
+      {/* The moon doubles as the Zip brand-video link (overlay + popover).
+          Not on phones: the panel is full-bleed there and the moon sits
+          behind it (CameraRig's aboutMoonNdcX returns null), so the
+          invisible overlay would just be a 165px tap trap over the intro
+          paragraph and whatever scrolls under it. Home gates it the same
+          way (moonLinkActive); SolarScene drops the moon's link halo to
+          match. */}
+      {size !== "sm" && (
+        <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
+      )}
       {/* The link lives outside .resume-panel so the frosted background
-          starts above the "About Me" heading, not around the link */}
+          starts above the "About Me" heading, not around the link.
+          w-fit: as a flex row it would otherwise stretch to the panel's
+          full width, and once it goes sticky (xl) that invisible strip
+          rides over the résumé and steals clicks from the text under it. */}
       <div
         className={cx("resume-inner-container", videoOpen && "video-hidden")}
       >
         <Link
           className={cx(
-            "back-to-home-link flex transition-transform items-center gap-4 mb-6 inverse ml-8 xl:sticky xl:top-[200px] xl:-ml-8",
+            "back-to-home-link flex w-fit transition-transform items-center gap-4 mb-6 inverse ml-8 xl:sticky xl:top-[200px] xl:-ml-8",
             !inView && isLarge && "-translate-x-32",
           )}
           to="/home"

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -136,9 +136,14 @@ const SolarScene = ({
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.28 : 0.2}
         revealed={planetsRevealed && !hideHomeExtras && !isLanding}
-        // The video link needs the moon actually on screen: /about always,
-        // /home only at the widths where hideHomeExtras keeps it
-        linkActive={view === "about" || (view === "home" && !hideHomeExtras)}
+        // The video link needs the moon actually on screen AND clickable:
+        // /about above phone widths (on phones the panel is full-bleed
+        // and Resume doesn't mount the overlay — the moon hides behind
+        // the résumé), /home only at the widths where hideHomeExtras
+        // keeps it
+        linkActive={
+          (view === "about" && !isPhone) || (view === "home" && !hideHomeExtras)
+        }
       />
       {/* Link bodies — home view only: on landing they'd read as clutter
           around the sun, and on /about their DOM overlays don't exist, so


### PR DESCRIPTION
Two hit-target fixes on /about that fell out of a headless overlap/offscreen audit across sm/md/lg/xl.

- On phone widths the résumé panel is full-bleed and the moon sits behind it (CameraRig's `aboutMoonNdcX` returns null there), but the invisible `.moon-link` overlay was still mounted at `z 5` above the panel — a 165px square that swallowed taps on the intro paragraph and on whatever scrolled under it (pills, dates, headings). `Resume` now skips `<ZipVideoMoon>` on `sm`, mirroring `Home`'s `moonLinkActive`, and `SolarScene` drops the moon's link halo on phones so it doesn't advertise a click that isn't there.
- The "Home" back link is a flex row, so above 768px it stretched to the panel's width (712px at lg, 1012px at xl); once it goes `xl:sticky` that strip rides at y≈200 over the résumé and intercepts clicks on the text scrolling past it. `w-fit` shrinks it to the arrow + label; the slide-out into the gutter is unchanged.

Re-ran the audit after: the moon-related hits on sm went from 40 to 0 and the Home link's box is 88px wide at xl. Not touched here (from the same audit, lower priority): the Earth ring / moon / rocket hit boxes overlapping on /home, and the journey hint + cockpit buttons crossing the crawl text.