### PR TITLE
[nav] uniform tooltip delays and a mac-shaped pointer cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-feather": "^2.0.10",
-    "react-intersection-observer": "^11.0.0",
     "react-router-dom": "^7.18.2",
     "sass": "^1.102.0",
     "tailwind-merge": "^3.6.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -1334,23 +1334,9 @@ li > ul > li {
     }
   }
 
-  .back-to-home-link {
-    // A slight background behind the link so that it's always legible.
-    border-radius: 16px;
-    padding: 8px;
-    // The link sits outside the padded .resume-panel now, so it needs its
-    // own left inset (this unlayered margin overrides the Tailwind ml-8)
-    margin: -8px;
-    margin-left: 24px;
-    width: min-content;
-    background: linear-gradient(
-      to bottom,
-      transparent,
-      #002d19a6 30%,
-      #002d19a6 70%,
-      transparent
-    );
-  }
+  // (No .back-to-home-link rules here: on phones the /about Home link
+  // renders in the .homePageBackLink corner slot instead, like /home's
+  // "Back to orbit")
 }
 
 button {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1430,7 +1430,7 @@ a:hover {
   // interactive palette (cyan→purple, same family as the hover halos);
   // `pointer` stays as the fallback keyword. Hotspot = the fingertip.
   cursor:
-    url(./cursor_pointer.svg) 6 1,
+    url(./cursor_pointer.svg) 7 1,
     pointer;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1426,11 +1426,11 @@ button {
 button:hover,
 a:hover {
   text-decoration: underline;
-  // Hover keeps the space cursor, recolored to the interactive palette
-  // (cyan→purple, same family as the hover halos) instead of dropping to
-  // the stock OS pointer; `pointer` stays as the fallback keyword
+  // Hover swaps to the mac-style pointing hand, recolored to the
+  // interactive palette (cyan→purple, same family as the hover halos);
+  // `pointer` stays as the fallback keyword. Hotspot = the fingertip.
   cursor:
-    url(./cursor_pointer.svg) 0 6,
+    url(./cursor_pointer.svg) 6 1,
     pointer;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -320,7 +320,7 @@ body.journey-mode {
   margin-bottom: 20vh;
 }
 
-// The résumé page's pointer to the cinematic version
+// The resume page's pointer to the cinematic version
 .journey-plug {
   margin-top: 8px;
   font-size: 15px;
@@ -501,7 +501,7 @@ audio {
   left: calc(1rem + env(safe-area-inset-left, 0px));
 }
 
-// On narrow screens the résumé panel scrolls right under the toggle, so
+// On narrow screens the resume panel scrolls right under the toggle, so
 // it needs its own scrim to stay legible (no backdrop-filter — same rule
 // as everything else over the canvases). Over the plain backgrounds the
 // pill all but disappears; padding + negative margin also grow the tap
@@ -1598,7 +1598,7 @@ a:hover {
 }
 
 // The moon's video link on /about (ZipVideoMoon), glued to the moon by
-// BodyAnchors like the rest; z 5 lifts it above the résumé scroll
+// BodyAnchors like the rest; z 5 lifts it above the resume scroll
 // container (z 4) so it stays hoverable. That only works because the
 // panel leaves the moon a gutter — on phones there is no gutter, so
 // Resume doesn't mount the overlay at all (it would sit over the text).
@@ -1616,7 +1616,7 @@ a:hover {
 // ─── Zip brand-video popover (ZipVideoMoon) ────────────────
 // While the video plays, `video-mode` on <body> hides everything except
 // the stars: the solar canvas, the name letters, the mode toggle, and
-// the music player/toggle. The résumé panel hides itself (.video-hidden).
+// the music player/toggle. The resume panel hides itself (.video-hidden).
 //
 // The moon is a video link on /home as well as /about, so the home chrome
 // joins the list — including the body overlays (.asteroid-link,

--- a/src/App.scss
+++ b/src/App.scss
@@ -1119,8 +1119,8 @@ li > ul > li {
 
 // Lead paragraph on the About page (was an <h4> used as body copy)
 .resume-intro {
-  font-size: 1.15rem;
-  line-height: 1.7;
+  font-size: 1rem;
+  line-height: 1.55;
   margin: 0;
 }
 
@@ -1360,15 +1360,8 @@ button {
   transition: color 50ms ease-in-out;
   font-weight: 600;
 
-  // The about page's Home link slides in/out on scroll (Tailwind toggles
-  // -translate-x-32). Tailwind's transition-transform utility lives in a
-  // cascade layer, so the unlayered `transition: color` above would
-  // clobber it and make the slide jump — re-declare both here instead.
-  &.back-to-home-link {
-    transition:
-      color 50ms ease-in-out,
-      translate 300ms ease;
-  }
+  // (The about page's Home link scrubs its `translate` directly from
+  // scroll position — no transition on it, or it would lag the scroll.)
 
   &:hover {
     color: #010c73;

--- a/src/App.scss
+++ b/src/App.scss
@@ -1419,7 +1419,7 @@ li {
 a,
 button {
   cursor:
-    url(./cursor.svg) 0 6,
+    url(./cursor.svg) 0 5,
     auto;
 }
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -16,6 +16,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  TOOLTIP_DELAY_MS,
 } from "./ui/tooltip";
 import { Link } from "react-router-dom";
 
@@ -162,40 +163,64 @@ const Home = () => {
               </div>
             </div>
           )}
-          <div className="flex items-center gap-1">
-            <a
-              aria-label="LinkedIn"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://www.linkedin.com/in/andrewmhunt/"
-              className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
-            >
-              <Linkedin size={22} />
-            </a>
-            <a
-              aria-label="GitHub"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://www.github.com/amhunt"
-              className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
-            >
-              <GitHub size={22} />
-            </a>
-            {/* Below lg the blog-post asteroid sits out (SolarOverlays hides
-                the link trio), so the site's one work sample needs a home in
-                the icon row instead */}
-            {size !== "lg" && (
-              <a
-                aria-label="A blog post I wrote at Zip"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://engineering.ziphq.com/material-ui/"
-                className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
-              >
-                <PenLine size={20} />
-              </a>
-            )}
-            <TooltipProvider>
+          {/* One provider for the whole row: every icon opens with the same
+              slight hover delay, and sliding along the row skips it (Radix's
+              default skip grace), like native toolbar tooltips */}
+          <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
+            <div className="flex items-center gap-1">
+              <Tooltip disableHoverableContent>
+                <TooltipTrigger asChild>
+                  <a
+                    aria-label="LinkedIn"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://www.linkedin.com/in/andrewmhunt/"
+                    className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
+                  >
+                    <Linkedin size={22} />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>LinkedIn</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip disableHoverableContent>
+                <TooltipTrigger asChild>
+                  <a
+                    aria-label="GitHub"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://www.github.com/amhunt"
+                    className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
+                  >
+                    <GitHub size={22} />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>GitHub</p>
+                </TooltipContent>
+              </Tooltip>
+              {/* Below lg the blog-post asteroid sits out (SolarOverlays hides
+                  the link trio), so the site's one work sample needs a home in
+                  the icon row instead */}
+              {size !== "lg" && (
+                <Tooltip disableHoverableContent>
+                  <TooltipTrigger asChild>
+                    <a
+                      aria-label="A blog post I wrote at Zip"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href="https://engineering.ziphq.com/material-ui/"
+                      className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
+                    >
+                      <PenLine size={20} />
+                    </a>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>A blog post I wrote at Zip</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <Tooltip disableHoverableContent>
                 <TooltipTrigger asChild>
                   <Link
@@ -210,12 +235,6 @@ const Home = () => {
                   <p>SVG Studio</p>
                 </TooltipContent>
               </Tooltip>
-            </TooltipProvider>
-            <TooltipProvider
-              skipDelayDuration={0}
-              delayDuration={0}
-              disableHoverableContent
-            >
               <Tooltip
                 disableHoverableContent
                 open={copyTooltipOpen}
@@ -243,8 +262,8 @@ const Home = () => {
                   </p>
                 </TooltipContent>
               </Tooltip>
-            </TooltipProvider>
-          </div>
+            </div>
+          </TooltipProvider>
         </div>
         {/* Moved to computer for large screens */}
         {/* {isMdOrLess && ( */}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -297,7 +297,7 @@ const Home = () => {
           </>
         )}
       </main>
-      {/* Home is a waypoint, not the end of the line — the résumé is one
+      {/* Home is a waypoint, not the end of the line — the resume is one
           more scroll further out, and nothing else says so. Waits for the
           arrival swoop and the content fade (~2s) to finish first. */}
       <ScrollHint

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import cx from "classnames";
 import { ArrowLeftCircle, Calendar } from "react-feather";
+import { ArrowLeftCircleIcon } from "lucide-react";
 import { useInView } from "react-intersection-observer";
 import { Link } from "react-router-dom";
 import useWindowSize from "./useWindowSize";
@@ -75,16 +76,30 @@ const Resume = () => {
   // The moon's video popover (ZipVideoMoon); while it plays, the resume
   // panel hides so only the stars remain behind the video
   const [videoOpen, setVideoOpen] = useState(false);
+  const size = useWindowSize();
+  const isSmall = size === "sm";
+
+  // Tailwind's xl (1280px) is where .resume-inner-container's top margin
+  // jumps 80px → 200px, moving the Home link's rest position — track it
+  // so the slide trigger below fires after the same ~30px of scroll at
+  // every width
+  const [isXl, setIsXl] = useState(
+    () => window.matchMedia("(min-width: 1280px)").matches,
+  );
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 1280px)");
+    const onChange = (e: MediaQueryListEvent) => setIsXl(e.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
   // Drives the Home link's slide: at rest the heading sits ~288px from
-  // the viewport top on xl, so the -260px margin keeps it "in view" until
-  // the user scrolls a few dozen px, then the link slides away
+  // the viewport top on xl (~150px below it), so the margin keeps it "in
+  // view" until the user scrolls a few dozen px, then the link slides away
   const { ref, inView } = useInView({
-    rootMargin: "-260px",
+    rootMargin: isXl ? "-260px" : "-124px",
     threshold: 0,
   });
-
-  const size = useWindowSize();
-  const isLarge = size === "lg";
   useEffect(() => {
     // Overlap the tail of the 2s arrival swoop (the translucent panel
     // tolerates it) and cut half a second of dead time on direct loads
@@ -95,168 +110,192 @@ const Resume = () => {
   }, []);
 
   return (
-    <main className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
-      {/* The moon doubles as the Zip brand-video link (overlay + popover).
-          Not on phones: the panel is full-bleed there and the moon sits
-          behind it (CameraRig's aboutMoonNdcX returns null), so the
-          invisible overlay would just be a 165px tap trap over the intro
-          paragraph and whatever scrolls under it. Home gates it the same
-          way (moonLinkActive); SolarScene drops the moon's link halo to
-          match. */}
-      {size !== "sm" && (
-        <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
+    <>
+      {/* On phones the Home link takes the same corner slot and sizing as
+          /home's "Back to orbit" link, outside the scroller so it stays
+          put (body.video-mode hides .homePageBackLink, same as on /home) */}
+      {isSmall && (
+        <div
+          className="homePageBackLink"
+          style={{ opacity: opacity ? 1 : 0, transition: "opacity 1s ease" }}
+        >
+          <Link className="mt-4 flex items-center gap-1" to="/home">
+            <ArrowLeftCircleIcon className="starIcon" size={16} />
+            <span>Home</span>
+          </Link>
+        </div>
       )}
-      {/* The link lives outside .resume-panel so the frosted background
+      <main className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
+        {/* The moon doubles as the Zip brand-video link (overlay + popover).
+            Not on phones: the panel is full-bleed there and the moon sits
+            behind it (CameraRig's aboutMoonNdcX returns null), so the
+            invisible overlay would just be a 165px tap trap over the intro
+            paragraph and whatever scrolls under it. Home gates it the same
+            way (moonLinkActive); SolarScene drops the moon's link halo to
+            match. */}
+        {!isSmall && (
+          <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
+        )}
+        {/* The link lives outside .resume-panel so the frosted background
           starts above the "About Me" heading, not around the link.
           w-fit: as a flex row it would otherwise stretch to the panel's
-          full width, and once it goes sticky (xl) that invisible strip
-          rides over the résumé and steals clicks from the text under it. */}
-      <div
-        className={cx("resume-inner-container", videoOpen && "video-hidden")}
-      >
-        <Link
-          className={cx(
-            "back-to-home-link flex w-fit transition-transform items-center gap-4 mb-6 inverse ml-8 xl:sticky xl:top-[200px] xl:-ml-8",
-            !inView && isLarge && "-translate-x-32",
-          )}
-          to="/home"
+          full width, and once it goes sticky that invisible strip rides
+          over the resume and steals clicks from the text under it. */}
+        <div
+          className={cx("resume-inner-container", videoOpen && "video-hidden")}
         >
-          <ArrowLeftCircle size={40} />
-          Home
-        </Link>
-        <div className="resume-panel">
-          <h1 ref={ref} className="mt-0 mb-6">
-            About Me
-          </h1>
-          <p className="resume-intro">
-            Hey! I’m a frontend engineer based in New York. I spent ~4 years at{" "}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              className="inverse"
-              href="https://ziphq.com"
+          {/* md and up: pinned at its rest height (sticky top matches each
+              breakpoint's .resume-inner-container top margin, so it never
+              moves vertically) and slides left once the heading scrolls
+              under it */}
+          {!isSmall && (
+            <Link
+              className={cx(
+                "back-to-home-link flex w-fit transition-transform items-center gap-4 mb-6 inverse -ml-8 md:sticky md:top-20 xl:top-[200px]",
+                !inView && "-translate-x-32",
+              )}
+              to="/home"
             >
-              Zip
-            </a>{" "}
-            — most recently as a staff engineer — before stepping away in 2025
-            for a proper sabbatical. A few months of recharging later, I eased
-            back in through consulting, helping teams ship polished, AI-powered
-            web products. Come fall 2026 I’m looking to go full-time again —
-            reach out to{" "}
-            <a
-              className="inverse"
-              href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"
-            >
-              andrew@hunt.codes
-            </a>
-            .
-          </p>
-          <p className="journey-plug">
-            Prefer the cinematic cut?{" "}
-            <Link className="inverse" to="/journey">
-              Watch the journey
-            </Link>{" "}
-            🚀
-          </p>
-          <div className="resume-divider" />
-          <h2>How I like to work</h2>
-          <ul className="hor-list">
-            <li>
-              <div className="card-title">Dev infrastructure</div>I believe it’s
-              difficult to overstate the importance of investing in the
-              development process. Great DevX is a prerequisite to quality UX
-              and efficient product development — this includes strong linters,
-              fast and thorough CI checks, and leaning on AI (LLMs and coding
-              agents) to automate repetitive work and free engineers for
-              higher-leverage problems.
-            </li>
-            <li>
-              <div className="card-title">Component systems</div>Investing in a
-              well-structured and robust component system will accelerate design
-              and engineering work, reduce bugs, and create a more consistent
-              user experience.
-            </li>
-            <li>
-              <div className="card-title">Product collaboration</div>
-              The best products come from designers, researchers, and engineers
-              building in the same room — tight feedback loops, shared taste,
-              and a bias toward shipping the delightful details.
-            </li>
-            <li>
-              <div className="card-title">Performance</div>
-              I’m passionate about delivering a lightning-fast, responsive user
-              experience. Performance can be a complex problem, and often needs
-              to be approached with both a data-driven and user-centric lens.
-            </li>
-          </ul>
-          <div>
-            <div className="card-title">Tools & Frameworks in my orbit</div>
-            <div className="flex flex-wrap gap-2 mt-2">
-              {tools.map((t) => (
-                <span className="pill tool-pill" key={t}>
-                  {t}
+              <ArrowLeftCircle size={40} />
+              Home
+            </Link>
+          )}
+          <div className="resume-panel">
+            <h1 ref={ref} className="mt-0 mb-6">
+              About Me
+            </h1>
+            <p className="resume-intro">
+              Hey! I’m a frontend engineer based in New York. I spent ~4 years
+              at{" "}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                className="inverse"
+                href="https://ziphq.com"
+              >
+                Zip
+              </a>{" "}
+              — most recently as a staff engineer — before stepping away in 2025
+              for a proper sabbatical. A few months of recharging later, I eased
+              back in through consulting, helping teams ship polished,
+              AI-powered web products. Come fall 2026 I’m looking to go
+              full-time again — reach out to{" "}
+              <a
+                className="inverse"
+                href="mailto:andrew@hunt.codes?Subject=Hey%20Andrew"
+              >
+                andrew@hunt.codes
+              </a>
+              .
+            </p>
+            <p className="journey-plug">
+              Prefer the cinematic cut?{" "}
+              <Link className="inverse" to="/journey">
+                Watch the journey
+              </Link>{" "}
+              🚀
+            </p>
+            <div className="resume-divider" />
+            <h2>How I like to work</h2>
+            <ul className="hor-list">
+              <li>
+                <div className="card-title">Dev infrastructure</div>I believe
+                it’s difficult to overstate the importance of investing in the
+                development process. Great DevX is a prerequisite to quality UX
+                and efficient product development — this includes strong
+                linters, fast and thorough CI checks, and leaning on AI (LLMs
+                and coding agents) to automate repetitive work and free
+                engineers for higher-leverage problems.
+              </li>
+              <li>
+                <div className="card-title">Component systems</div>Investing in
+                a well-structured and robust component system will accelerate
+                design and engineering work, reduce bugs, and create a more
+                consistent user experience.
+              </li>
+              <li>
+                <div className="card-title">Product collaboration</div>
+                The best products come from designers, researchers, and
+                engineers building in the same room — tight feedback loops,
+                shared taste, and a bias toward shipping the delightful details.
+              </li>
+              <li>
+                <div className="card-title">Performance</div>
+                I’m passionate about delivering a lightning-fast, responsive
+                user experience. Performance can be a complex problem, and often
+                needs to be approached with both a data-driven and user-centric
+                lens.
+              </li>
+            </ul>
+            <div>
+              <div className="card-title">Tools & Frameworks in my orbit</div>
+              <div className="flex flex-wrap gap-2 mt-2">
+                {tools.map((t) => (
+                  <span className="pill tool-pill" key={t}>
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="resume-divider" />
+
+            <h2>Experience</h2>
+            {experienceItems.map((item) => (
+              <React.Fragment key={item.title}>
+                <div className="splitRow">
+                  <h3 className="flex items-center">
+                    {item.title}{" "}
+                    <span className="pill location-pill">{item.location}</span>
+                  </h3>
+                  <span className="resume-date flex items-center gap-2">
+                    {item.date}
+                    <Calendar size={12} />
+                  </span>
+                </div>
+                <ul>
+                  {item.description.map((d, idx) => (
+                    <li key={idx}>
+                      {typeof d === "string" ? (
+                        d
+                      ) : (
+                        <>
+                          {d.item}
+                          <ul>
+                            {d.subbullets?.map((s) => (
+                              <li key={s}>{s}</li>
+                            ))}
+                          </ul>
+                        </>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </React.Fragment>
+            ))}
+            <div className="resume-divider" />
+            <h2>Education</h2>
+            <div className="splitRow">
+              <h3 className="flex items-center">
+                Princeton University
+                <span className="pill location-pill">BSE</span>
+                <span className="pill location-pill">Computer Science</span>
+              </h3>
+              <span className="resume-date">September 2013 — June 2017</span>
+            </div>
+            <div className="resume-divider" />
+            <h2>Other interests</h2>
+            <div className="flex flex-wrap gap-2">
+              {interests.map((i) => (
+                <span className="pill interest-pill" key={i}>
+                  {i}
                 </span>
               ))}
             </div>
           </div>
-
-          <div className="resume-divider" />
-
-          <h2>Experience</h2>
-          {experienceItems.map((item) => (
-            <React.Fragment key={item.title}>
-              <div className="splitRow">
-                <h3 className="flex items-center">
-                  {item.title}{" "}
-                  <span className="pill location-pill">{item.location}</span>
-                </h3>
-                <span className="resume-date flex items-center gap-2">
-                  {item.date}
-                  <Calendar size={12} />
-                </span>
-              </div>
-              <ul>
-                {item.description.map((d, idx) => (
-                  <li key={idx}>
-                    {typeof d === "string" ? (
-                      d
-                    ) : (
-                      <>
-                        {d.item}
-                        <ul>
-                          {d.subbullets?.map((s) => (
-                            <li key={s}>{s}</li>
-                          ))}
-                        </ul>
-                      </>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </React.Fragment>
-          ))}
-          <div className="resume-divider" />
-          <h2>Education</h2>
-          <div className="splitRow">
-            <h3 className="flex items-center">
-              Princeton University
-              <span className="pill location-pill">BSE</span>
-              <span className="pill location-pill">Computer Science</span>
-            </h3>
-            <span className="resume-date">September 2013 — June 2017</span>
-          </div>
-          <div className="resume-divider" />
-          <h2>Other interests</h2>
-          <div className="flex flex-wrap gap-2">
-            {interests.map((i) => (
-              <span className="pill interest-pill" key={i}>
-                {i}
-              </span>
-            ))}
-          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </>
   );
 };
 

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -72,7 +72,7 @@ const experienceItems = [
 
 const Resume = () => {
   const [opacity, setOpacity] = useState(false);
-  // The moon's video popover (ZipVideoMoon); while it plays, the résumé
+  // The moon's video popover (ZipVideoMoon); while it plays, the resume
   // panel hides so only the stars remain behind the video
   const [videoOpen, setVideoOpen] = useState(false);
   // Drives the Home link's slide: at rest the heading sits ~288px from

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import cx from "classnames";
 import { ArrowLeftCircle, Calendar } from "react-feather";
 import { ArrowLeftCircleIcon } from "lucide-react";
-import { useInView } from "react-intersection-observer";
 import { Link } from "react-router-dom";
 import useWindowSize from "./useWindowSize";
 import ZipVideoMoon from "./ZipVideoMoon";
@@ -71,6 +70,11 @@ const experienceItems = [
   },
 ];
 
+// The Home link's scroll-scrubbed slide: it travels SLIDE_DISTANCE_PX
+// leftward over the first SLIDE_RANGE_PX of the container's scroll
+const SLIDE_RANGE_PX = 100;
+const SLIDE_DISTANCE_PX = 128; // the old Tailwind -translate-x-32
+
 const Resume = () => {
   const [opacity, setOpacity] = useState(false);
   // The moon's video popover (ZipVideoMoon); while it plays, the resume
@@ -79,27 +83,17 @@ const Resume = () => {
   const size = useWindowSize();
   const isSmall = size === "sm";
 
-  // Tailwind's xl (1280px) is where .resume-inner-container's top margin
-  // jumps 80px → 200px, moving the Home link's rest position — track it
-  // so the slide trigger below fires after the same ~30px of scroll at
-  // every width
-  const [isXl, setIsXl] = useState(
-    () => window.matchMedia("(min-width: 1280px)").matches,
-  );
-  useEffect(() => {
-    const query = window.matchMedia("(min-width: 1280px)");
-    const onChange = (e: MediaQueryListEvent) => setIsXl(e.matches);
-    query.addEventListener("change", onChange);
-    return () => query.removeEventListener("change", onChange);
+  // The Home link's leftward slide is scrubbed by scroll, not animated:
+  // it tracks the first SLIDE_RANGE_PX of scrollTop directly, so stopping
+  // mid-range parks the link mid-slide. Written straight to the element's
+  // style (no React state) — scroll fires every frame.
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const handleScroll = useCallback((e: React.UIEvent<HTMLElement>) => {
+    const progress = Math.min(1, e.currentTarget.scrollTop / SLIDE_RANGE_PX);
+    if (linkRef.current) {
+      linkRef.current.style.translate = `${-SLIDE_DISTANCE_PX * progress}px 0`;
+    }
   }, []);
-
-  // Drives the Home link's slide: at rest the heading sits ~288px from
-  // the viewport top on xl (~150px below it), so the margin keeps it "in
-  // view" until the user scrolls a few dozen px, then the link slides away
-  const { ref, inView } = useInView({
-    rootMargin: isXl ? "-260px" : "-124px",
-    threshold: 0,
-  });
   useEffect(() => {
     // Overlap the tail of the 2s arrival swoop (the translucent panel
     // tolerates it) and cut half a second of dead time on direct loads
@@ -125,7 +119,11 @@ const Resume = () => {
           </Link>
         </div>
       )}
-      <main className="resume-container" style={{ opacity: opacity ? 1 : 0 }}>
+      <main
+        className="resume-container"
+        style={{ opacity: opacity ? 1 : 0 }}
+        onScroll={handleScroll}
+      >
         {/* The moon doubles as the Zip brand-video link (overlay + popover).
             Not on phones: the panel is full-bleed there and the moon sits
             behind it (CameraRig's aboutMoonNdcX returns null), so the
@@ -146,14 +144,12 @@ const Resume = () => {
         >
           {/* md and up: pinned at its rest height (sticky top matches each
               breakpoint's .resume-inner-container top margin, so it never
-              moves vertically) and slides left once the heading scrolls
-              under it */}
+              moves vertically) while handleScroll scrubs it leftward over
+              the first stretch of scroll */}
           {!isSmall && (
             <Link
-              className={cx(
-                "back-to-home-link flex w-fit transition-transform items-center gap-4 mb-6 inverse -ml-8 md:sticky md:top-20 xl:top-[200px]",
-                !inView && "-translate-x-32",
-              )}
+              ref={linkRef}
+              className="back-to-home-link flex w-fit items-center gap-4 mb-6 inverse -ml-8 md:sticky md:top-20 xl:top-50"
               to="/home"
             >
               <ArrowLeftCircle size={40} />
@@ -161,9 +157,7 @@ const Resume = () => {
             </Link>
           )}
           <div className="resume-panel">
-            <h1 ref={ref} className="mt-0 mb-6">
-              About Me
-            </h1>
+            <h1 className="mt-0 mb-6">About Me</h1>
             <p className="resume-intro">
               Hey! I’m a frontend engineer based in New York. I spent ~4 years
               at{" "}
@@ -188,13 +182,14 @@ const Resume = () => {
               </a>
               .
             </p>
+            {/* Hidden until /journey gets more polish:
             <p className="journey-plug">
               Prefer the cinematic cut?{" "}
               <Link className="inverse" to="/journey">
                 Watch the journey
               </Link>{" "}
               🚀
-            </p>
+            </p> */}
             <div className="resume-divider" />
             <h2>How I like to work</h2>
             <ul className="hor-list">

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  TOOLTIP_DELAY_MS,
 } from "./ui/tooltip";
 import { scrollTransitionState } from "./scrollTransition";
 
@@ -73,7 +74,7 @@ const ScrollHint = ({
   }, [delayMs]);
 
   return (
-    <TooltipProvider delayDuration={100}>
+    <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
       <Tooltip disableHoverableContent>
         <TooltipTrigger asChild>
           <button

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -15,21 +15,21 @@ import { scrollTransitionState } from "./scrollTransition";
  * Where each stop actually goes, for the tooltip and the screen-reader
  * label. These have to name the real destination — telling someone on
  * /home that the chevron explores the solar system describes the trip
- * they just finished, not the résumé they are about to reach.
+ * they just finished, not the resume they are about to reach.
  */
 const DESTINATION_TEXT: Record<1 | 2, string> = {
   1: "Scroll or click around to explore the solar system",
-  2: "Scroll on to the résumé — or click to travel there",
+  2: "Scroll on to the resume — or click to travel there",
 };
 
 /**
  * The wide-tracked caption above the chevron. Generic on the landing page
- * (the whole solar system is next); on /home it names the résumé, the one
- * stop left on the journey.
+ * (the whole solar system is next); on /home it stays short — the tooltip
+ * and screen-reader label (DESTINATION_TEXT) name the resume destination.
  */
 const CAPTION_TEXT: Record<1 | 2, string> = {
   1: "Scroll or click to explore",
-  2: "Scroll on to the résumé",
+  2: "Scroll on",
 };
 
 type ScrollHintProps = {

--- a/src/cursor.svg
+++ b/src/cursor.svg
@@ -1,4 +1,4 @@
-<svg width="18" height="27" viewBox="0 0 26 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="24" viewBox="0 0 26 39" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M1 35.6179V3L23 24.561H12.55L16.95 35.065L12.55 37L8.15 27.0488L1 35.6179Z" fill="url(#paint0_angular)" stroke="white" stroke-width="2" />
   <defs>
     <radialGradient id="paint0_angular" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1 35.6179) rotate(-34.7306) scale(38.8153 38.6988)">

--- a/src/cursor_pointer.svg
+++ b/src/cursor_pointer.svg
@@ -2,7 +2,7 @@
   <!-- The macOS pointing-hand ("pointer") silhouette — index finger up,
        curled-finger knuckle bumps, thumb at the left — recolored to the
        site's interactive palette -->
-  <path d="M6.8 22 L6.8 5 C6.8 1.6 11.2 1.6 11.2 5 L11.2 12.8 C11.3 11.1 14.5 11.1 14.6 12.9 L14.6 13.5 C14.8 11.9 17.7 12 17.8 13.8 L17.8 14.4 C18 13 20.6 13.1 20.6 14.9 L20.6 23.5 C20.6 29.8 17.2 34 12.4 34 C9.7 34 7.5 33.2 5.9 31.2 L2.4 26.2 C1.1 24.2 1.7 22 3.8 21.6 C5.1 21.4 6 22.1 6.8 23.4 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
+  <path d="M6.8 17.6 L6.8 4.3 C6.8 1.7 11.2 1.7 11.2 4.3 L11.2 10.4 C11.3 9.1 14.5 9.1 14.6 10.5 L14.6 11 C14.8 9.7 17.7 9.8 17.8 11.2 L17.8 11.7 C18 10.6 20.6 10.7 20.6 12.1 L20.6 18.8 C20.6 23.7 17.2 27 12.4 27 C9.7 27 7.5 26.3 5.9 24.8 L2.4 20.9 C1.1 19.3 1.7 17.6 3.8 17.3 C5.1 17.1 6 17.7 6.8 18.7 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
   <defs>
     <radialGradient id="paint0_angular_ptr" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1 35.6179) rotate(-34.7306) scale(38.8153 38.6988)">
       <stop offset="0.0228442" stop-color="#5efffc" stop-opacity="0.8" />

--- a/src/cursor_pointer.svg
+++ b/src/cursor_pointer.svg
@@ -1,5 +1,7 @@
 <svg width="18" height="27" viewBox="0 0 26 39" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M1 35.6179V3L23 24.561H12.55L16.95 35.065L12.55 37L8.15 27.0488L1 35.6179Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" />
+  <!-- The macOS default-arrow silhouette (vertical left edge, ~45° right
+       edge, short click-leg), recolored to the site's interactive palette -->
+  <path d="M1 3 L1 32.6 L8.2 25.9 L13.1 37.7 L18.2 35.6 L13.3 23.8 L23.2 23.8 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
   <defs>
     <radialGradient id="paint0_angular_ptr" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1 35.6179) rotate(-34.7306) scale(38.8153 38.6988)">
       <stop offset="0.0228442" stop-color="#5efffc" stop-opacity="0.8" />

--- a/src/cursor_pointer.svg
+++ b/src/cursor_pointer.svg
@@ -2,7 +2,7 @@
   <!-- The macOS pointing-hand ("pointer") silhouette — index finger up,
        curled-finger knuckle bumps, thumb at the left — recolored to the
        site's interactive palette -->
-  <path d="M6.8 17.6 L6.8 4.3 C6.8 1.7 11.2 1.7 11.2 4.3 L11.2 10.4 C11.3 9.1 14.5 9.1 14.6 10.5 L14.6 11 C14.8 9.7 17.7 9.8 17.8 11.2 L17.8 11.7 C18 10.6 20.6 10.7 20.6 12.1 L20.6 18.8 C20.6 23.7 17.2 27 12.4 27 C9.7 27 7.5 26.3 5.9 24.8 L2.4 20.9 C1.1 19.3 1.7 17.6 3.8 17.3 C5.1 17.1 6 17.7 6.8 18.7 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
+  <path d="M8 20.6 L8 4.2 C8 1 13.4 1 13.4 4.2 L13.4 11.7 C13.5 10.1 17.5 10.1 17.6 11.8 L17.6 12.4 C17.9 10.8 21.4 11 21.5 12.7 L21.5 13.3 C21.8 11.9 25 12.1 25 13.8 L25 22 C25 28.1 20.8 32.1 14.9 32.1 C11.6 32.1 8.9 31.3 6.9 29.4 L2.6 24.6 C1 22.6 1.7 20.6 4.3 20.2 C5.9 19.9 7 20.7 8 21.9 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
   <defs>
     <radialGradient id="paint0_angular_ptr" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1 35.6179) rotate(-34.7306) scale(38.8153 38.6988)">
       <stop offset="0.0228442" stop-color="#5efffc" stop-opacity="0.8" />

--- a/src/cursor_pointer.svg
+++ b/src/cursor_pointer.svg
@@ -1,7 +1,8 @@
 <svg width="18" height="27" viewBox="0 0 26 39" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- The macOS default-arrow silhouette (vertical left edge, ~45° right
-       edge, short click-leg), recolored to the site's interactive palette -->
-  <path d="M1 3 L1 32.6 L8.2 25.9 L13.1 37.7 L18.2 35.6 L13.3 23.8 L23.2 23.8 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
+  <!-- The macOS pointing-hand ("pointer") silhouette — index finger up,
+       curled-finger knuckle bumps, thumb at the left — recolored to the
+       site's interactive palette -->
+  <path d="M6.8 22 L6.8 5 C6.8 1.6 11.2 1.6 11.2 5 L11.2 12.8 C11.3 11.1 14.5 11.1 14.6 12.9 L14.6 13.5 C14.8 11.9 17.7 12 17.8 13.8 L17.8 14.4 C18 13 20.6 13.1 20.6 14.9 L20.6 23.5 C20.6 29.8 17.2 34 12.4 34 C9.7 34 7.5 33.2 5.9 31.2 L2.4 26.2 C1.1 24.2 1.7 22 3.8 21.6 C5.1 21.4 6 22.1 6.8 23.4 Z" fill="url(#paint0_angular_ptr)" stroke="white" stroke-width="2" stroke-linejoin="round" />
   <defs>
     <radialGradient id="paint0_angular_ptr" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1 35.6179) rotate(-34.7306) scale(38.8153 38.6988)">
       <stop offset="0.0228442" stop-color="#5efffc" stop-opacity="0.8" />

--- a/src/rocketJourney.ts
+++ b/src/rocketJourney.ts
@@ -101,7 +101,7 @@ export const startSynthReturn = (): void =>
   beginJourney("none", "home", RETURN_TURN_SECONDS, TRANSIT_WARP_SECONDS);
 
 /** The /journey cruise announcing itself (JourneyCruise's first frame):
- *  a deep link or résumé-link arrival starts the ride mid-warp — cockpit
+ *  a deep link or resume-link arrival starts the ride mid-warp — cockpit
  *  up, no boarding beat. No-op when the rocket boarding already began
  *  the ride (or any other journey is playing). */
 export function startJourneyCruise(): void {

--- a/src/scrollTransition.ts
+++ b/src/scrollTransition.ts
@@ -1,7 +1,7 @@
 /**
  * Scroll-scrubbed camera journey across the site's three views:
  * landing (0) → home (1) → about (2). The pages have no scrollable
- * content (the /about résumé being the exception — it keeps native
+ * content (the /about resume being the exception — it keeps native
  * scroll and no journey handlers), so useScrollJourney accumulates
  * wheel/touch deltas into the `target` stop value; CameraRig eases
  * `progress` toward it each frame and poses the camera along the

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -65,7 +65,7 @@ const ABOUT_LOOK_HEIGHT = 0.45; // aim slightly above the moon's plane
  *  the left edge, well inside the 600px gutter .resume-container reserves
  *  there. */
 const ABOUT_MOON_NDC_X = -0.5;
-/** Below lg the résumé panel keeps its 680px width and the gutter takes
+/** Below lg the resume panel keeps its 680px width and the gutter takes
  *  whatever is left (min 200px) — .resume-container's `padding-left`. The
  *  moon rides the center of that gutter, so these two numbers must match
  *  the stylesheet's. */
@@ -80,7 +80,7 @@ const LG_BREAKPOINT_PX = 1280;
 
 /**
  * Where the moon should sit horizontally (NDC) for a viewport width —
- * always the middle of the gutter the résumé panel leaves it. Returns
+ * always the middle of the gutter the resume panel leaves it. Returns
  * null on phone widths, where the panel is full-bleed: there's no gutter
  * to aim for, so the camera sits on the Earth-moon line instead and the
  * moon reads dead-center, directly above Earth.

--- a/src/space3d/solar/JourneyCruise.tsx
+++ b/src/space3d/solar/JourneyCruise.tsx
@@ -19,7 +19,7 @@ import { cruiseState } from "../../journeyCruise";
  * from both solar systems, flying through the shared streak field
  * (WarpStreaks) from inside the cockpit (RocketCockpit's windshield,
  * revealed by body.rocket-journey). This component starts the ride
- * state itself on its first frame, so a deep link or the résumé link
+ * state itself on its first frame, so a deep link or the resume link
  * gets the cockpit too — not just the rocket easter egg.
  *
  * The crawl's scroll velocity feeds cruiseState.boost (scrub the story

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -139,7 +139,7 @@ const SolarScene = ({
         // The video link needs the moon actually on screen AND clickable:
         // /about above phone widths (on phones the panel is full-bleed
         // and Resume doesn't mount the overlay — the moon hides behind
-        // the résumé), /home only at the widths where hideHomeExtras
+        // the resume), /home only at the widths where hideHomeExtras
         // keeps it
         linkActive={
           (view === "about" && !isPhone) || (view === "home" && !hideHomeExtras)

--- a/src/ui/tooltip.tsx
+++ b/src/ui/tooltip.tsx
@@ -2,6 +2,12 @@ import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "lib/utils";
 
+/**
+ * Shared hover delay so every tooltip on the site opens with the same
+ * slight pause (Radix's default 700ms feels sluggish, 0–100ms twitchy).
+ */
+const TOOLTIP_DELAY_MS = 500;
+
 const TooltipProvider = TooltipPrimitive.Provider;
 
 const Tooltip = TooltipPrimitive.Root;
@@ -26,4 +32,10 @@ const TooltipContent = React.forwardRef<
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+  TOOLTIP_DELAY_MS,
+};

--- a/src/useScrollJourney.ts
+++ b/src/useScrollJourney.ts
@@ -19,7 +19,7 @@ const ROUTES = ["/", "/home", "/about"];
 /**
  * Scroll-scrubbed travel between the site's views (see
  * scrollTransition.ts). Mounted by the landing page (stop 0) and home
- * page (stop 1) — not /about, whose résumé needs native scrolling.
+ * page (stop 1) — not /about, whose resume needs native scrolling.
  * Accumulates wheel/touch deltas into the journey target and commits the
  * matching route when the RENDERED progress reaches a different stop —
  * keyed to the camera, not the wheel, so a fast fling can't navigate

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,7 +5922,6 @@ __metadata:
     react: "npm:^19.2.8"
     react-dom: "npm:^19.2.8"
     react-feather: "npm:^2.0.10"
-    react-intersection-observer: "npm:^11.0.0"
     react-router-dom: "npm:^7.18.2"
     sass: "npm:^1.102.0"
     storybook: "npm:^10.5.6"
@@ -7862,19 +7861,6 @@ __metadata:
   peerDependencies:
     react: ">=16.8.6"
   checksum: 10c0/bcc312ab39a710d8fa6fb611fde2affb38cf183fa5215d46c78577d88950ecb9181b59e4b57d7683f543d25725a39deb0c2ad9a9f29cab1a44bf4cbca46e6b8e
-  languageName: node
-  linkType: hard
-
-"react-intersection-observer@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "react-intersection-observer@npm:11.0.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-  checksum: 10c0/cecfdc1b2d939749d6fbc27ac0957515529bff5d0fbba751bb6b4473961636d9bb7f663e8d7d8afff476e06ac8d6627fd19bc022320916d286aae96017ea57e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Gives every tooltip on /home the same slight hover delay, reshapes the hover cursor to the macOS pointing hand, de-accents "résumé", and reworks the /about Home link and intro.

- new shared `TOOLTIP_DELAY_MS` (500ms) in `ui/tooltip.tsx`; the scroll-hint tooltips move from 100ms to it
- every icon pill (LinkedIn, GitHub, blog pen, wand, mail) now has a tooltip under one shared provider, so sliding along the row opens the next tooltip instantly (Radix's skip grace) like native toolbar tips — the mail pill's copy-to-clipboard pin behavior is unchanged, it just gains the hover delay it previously skipped
- `cursor_pointer.svg` redrawn as the macOS pointing-hand silhouette, keeping the cyan→purple gradient and white outline; hotspot moves to the fingertip, and the arrow cursor shrinks to 16×24 so the hand reads bigger on hover, like the native pair
- "résumé" → "resume" everywhere, and the /home scroll-hint caption shortens from "Scroll on to the resume" to "Scroll on" — the tooltip and screen-reader label still name the destination
- /about Home link: on phones it takes the same corner slot and sizing as /home's "Back to orbit" (outside the scroller, so it stays put); from md up it's sticky at its rest height (`md:top-20` / `xl:top-50`, matching each breakpoint's `.resume-inner-container` top margin so it never moves vertically) and its leftward slide is now scroll-scrubbed — it tracks the first 100px of scrollTop directly (stop mid-range, it parks mid-slide) via a direct style write, replacing the old IntersectionObserver toggle + 300ms transition. `react-intersection-observer` is now unused and removed
- the "Prefer the cinematic cut? … 🚀" journey plug is commented out until /journey gets more polish, and the About intro drops to 16px with 1.55 line-height