### PR TITLE
[landing] drop the scroll caption, let the chevron tooltip say it

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -53,6 +53,9 @@ const Home = () => {
 
   const size = useWindowSize();
   const isSmall = size === "sm";
+  // 768–999px: the five icon pills squeezed the headline to ~100px, so the
+  // row wraps there — contact links on top, the work samples underneath
+  const isMedium = size === "md";
   // The moon's video popover (ZipVideoMoon), same as /about. Below lg the
   // moon sits out of the home view entirely (SolarScene's hideHomeExtras),
   // so there'd be nothing for the overlay to glue itself to.
@@ -167,7 +170,16 @@ const Home = () => {
               slight hover delay, and sliding along the row skips it (Radix's
               default skip grace), like native toolbar tooltips */}
           <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
-            <div className="flex items-center gap-1">
+            {/* On md the pills wrap into two rows: contact links (LinkedIn,
+                GitHub, mail) on top, the work samples (blog, SVG Studio)
+                pushed underneath via `order`; max-w-38 = three 48px pills +
+                gaps. Everywhere else it's one row in DOM order. */}
+            <div
+              className={cx(
+                "flex items-center justify-end gap-1",
+                isMedium && "flex-wrap max-w-38",
+              )}
+            >
               <Tooltip disableHoverableContent>
                 <TooltipTrigger asChild>
                   <a
@@ -211,7 +223,10 @@ const Home = () => {
                       target="_blank"
                       rel="noopener noreferrer"
                       href="https://engineering.ziphq.com/material-ui/"
-                      className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
+                      className={cx(
+                        "icon-pill flex size-12 items-center justify-center rounded-full p-1",
+                        isMedium && "order-1",
+                      )}
                     >
                       <PenLine size={20} />
                     </a>
@@ -226,7 +241,10 @@ const Home = () => {
                   <Link
                     aria-label="SVG Studio"
                     to="/draw"
-                    className="icon-pill flex size-12 items-center justify-center rounded-full p-1"
+                    className={cx(
+                      "icon-pill flex size-12 items-center justify-center rounded-full p-1",
+                      isMedium && "order-1",
+                    )}
                   >
                     <Wand2 size={20} />
                   </Link>

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -18,17 +18,18 @@ import { scrollTransitionState } from "./scrollTransition";
  * they just finished, not the resume they are about to reach.
  */
 const DESTINATION_TEXT: Record<1 | 2, string> = {
-  1: "Scroll or click around to explore the solar system",
+  1: "Scroll or click to explore",
   2: "Scroll on to the resume — or click to travel there",
 };
 
 /**
- * The wide-tracked caption above the chevron. Generic on the landing page
- * (the whole solar system is next); on /home it stays short — the tooltip
- * and screen-reader label (DESTINATION_TEXT) name the resume destination.
+ * The wide-tracked caption above the chevron. The landing page runs
+ * caption-less — the bouncing chevron carries it, and the tooltip says the
+ * rest on hover; on /home it stays short — the tooltip and screen-reader
+ * label (DESTINATION_TEXT) name the resume destination.
  */
-const CAPTION_TEXT: Record<1 | 2, string> = {
-  1: "Scroll or click to explore",
+const CAPTION_TEXT: Record<1 | 2, string | null> = {
+  1: null,
   2: "Scroll on",
 };
 
@@ -95,9 +96,11 @@ const ScrollHint = ({
           >
             {/* aria-hidden: the button's own label already says this, and
                 more fully — this copy is the visible shorthand */}
-            <span className="scroll-hint-label" aria-hidden="true">
-              {CAPTION_TEXT[target]}
-            </span>
+            {CAPTION_TEXT[target] && (
+              <span className="scroll-hint-label" aria-hidden="true">
+                {CAPTION_TEXT[target]}
+              </span>
+            )}
             <ChevronDown className="scroll-hint-chevron" size={30} />
           </button>
         </TooltipTrigger>

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -14,11 +14,7 @@ import {
   EARTH_ABOUT_RING_ID,
 } from "./solarAnchorIds";
 import { hoverState } from "./solarHover";
-import {
-  journeyState,
-  startRocketJourney,
-  startSynthJourney,
-} from "./rocketJourney";
+import { journeyState, startSynthJourney } from "./rocketJourney";
 import { ensureAudio } from "./synthAudio";
 import useWindowSize from "./useWindowSize";
 
@@ -132,9 +128,12 @@ const SolarOverlays = () => {
             </Tooltip>
           </TooltipProvider>
         ))}
-      {/* The rocket easter egg: clicking it boards the ship and warps to
+      {/* The rocket (spaceship) link is parked until the /journey copy is
+          ready — the ship still flies in the scene, it just isn't clickable.
+          Restore this block (and the startRocketJourney import) to re-arm it.
+         The rocket easter egg: clicking it boards the ship and warps to
           the /journey story crawl (rocketJourney.ts flips the route under
-          the warp flash). Same anchor plumbing as the asteroid links. */}
+          the warp flash). Same anchor plumbing as the asteroid links.
       <TooltipProvider delayDuration={100}>
         <Tooltip disableHoverableContent>
           <TooltipTrigger asChild>
@@ -169,6 +168,7 @@ const SolarOverlays = () => {
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
+      */}
       {/* The floating 808 pad: warps to the synth solar system (/synth).
           Unlocking the AudioContext inside this click is what lets the
           beat start playing the moment you land. */}

--- a/src/space3d/Space3DBackground.tsx
+++ b/src/space3d/Space3DBackground.tsx
@@ -5,6 +5,9 @@ import StarField from "./StarField";
 import BadgeMedallion from "./BadgeMedallion";
 import SolarScene from "./solar/SolarScene";
 
+// Night-mode star opacity on the landing page (home/about run at 1)
+const LANDING_STAR_OPACITY = 0.8;
+
 /**
  * Entry point for the WebGL background (lazy-loaded so three.js ships as
  * its own chunk). Two canvases:
@@ -62,7 +65,14 @@ const Space3DBackground = ({
   return (
     <>
       <SpaceCanvas>
-        <StarField isLanding={isLanding} opacityTarget={isNightMode ? 1 : 0} />
+        {/* The landing page runs its stars 20% dimmer — the glyph field is
+            the whole view there and read a touch loud at full strength */}
+        <StarField
+          isLanding={isLanding}
+          opacityTarget={
+            isNightMode ? (isLanding ? LANDING_STAR_OPACITY : 1) : 0
+          }
+        />
         {/* The corner "hunt.codes" medallion rides the star canvas rather
             than bringing its own WebGL context (three contexts tripped
             Chrome's per-domain cap and strobed the stars). Hidden only


### PR DESCRIPTION
Landing/home polish: the landing scroll caption goes, the chevron tooltip says it; the landing stars run 20% dimmer; the /home icon pills wrap on medium screens so the headline isn't crushed; and the rocket link is parked until /journey's copy is ready.

- `ScrollHint`: `CAPTION_TEXT` becomes nullable and the label span only renders when there's copy — the landing page is caption-less and its chevron tooltip (shared 500ms delay) now reads "Scroll or click to explore"; /home keeps its "Scroll on" caption and resume tooltip unchanged. The landing `aria-label` follows the tooltip copy
- `Space3DBackground`: `StarField` gets `opacityTarget` 0.8 on the landing page (`LANDING_STAR_OPACITY`), 1 elsewhere — the glyph field is the whole view there and read a touch loud at full strength
- `Home`: between 768–999px (`useWindowSize` md) the five icon pills were squeezing the "Frontend Engineer based in…" block to ~100px, one word per line. On md the pill row now wraps into two: contact links (LinkedIn, GitHub, mail) on top, the work samples (blog post, SVG Studio) underneath via `order`, right-aligned; the headline gets ~204px and sits on two lines. Other widths are untouched (lg+ stays one row in DOM order, sm still stacks). Driven off the JS breakpoint rather than Tailwind variants, since `min-[1000px]:` sorts before `md:` and loses the override
- `SolarOverlays`: the rocket (spaceship) overlay link + tooltip are commented out — the ship still flies in the scene, it just isn't clickable; `BodyAnchors` and `writeSilhouette` both skip a missing DOM target, so nothing else changes. The `startRocketJourney` import goes with it; restore both to re-arm