### PR TITLE
[home] park the spaceship, hide the moon until the /about swoop

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1594,14 +1594,9 @@ a:hover {
 
 // ─── Zip brand-video popover (ZipVideoMoon) ────────────────
 // While the video plays, `video-mode` on <body> hides everything except
-// the stars: the solar canvas, the name letters, the mode toggle, and
-// the music player/toggle. The resume panel hides itself (.video-hidden).
-//
-// The moon is a video link on /home as well as /about, so the home chrome
-// joins the list — including the body overlays (.asteroid-link,
-// .earth-about-ring), which BodyAnchors keeps glued to projections that
-// are no longer drawn once .solar-canvas fades. Left visible they'd be
-// invisible-but-hoverable rings floating over the video. The backdrop is
+// the stars: the solar canvas, the name letters, the mode toggle, the
+// music player/toggle, the phone-width Home link and the corner medallion.
+// The resume panel hides itself (.video-hidden). The backdrop is
 // deliberately transparent (the stars stay), so anything not listed here
 // really does show through.
 body.video-mode {
@@ -1610,11 +1605,7 @@ body.video-mode {
   .day-night-switch,
   audio,
   .music-toggle,
-  .homeInfoContainer,
   .homePageBackLink,
-  .asteroid-link,
-  .earth-about-ring,
-  .scroll-hint,
   .badge-link {
     opacity: 0 !important;
     pointer-events: none !important;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -8,7 +8,6 @@ import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
 import ScrollHint from "./ScrollHint";
-import ZipVideoMoon from "./ZipVideoMoon";
 import { JOURNEY_STOPS } from "./scrollTransition";
 
 import {
@@ -56,11 +55,6 @@ const Home = () => {
   // 768–999px: the five icon pills squeezed the headline to ~100px, so the
   // row wraps there — contact links on top, the work samples underneath
   const isMedium = size === "md";
-  // The moon's video popover (ZipVideoMoon), same as /about. Below lg the
-  // moon sits out of the home view entirely (SolarScene's hideHomeExtras),
-  // so there'd be nothing for the overlay to glue itself to.
-  const [videoOpen, setVideoOpen] = useState(false);
-  const moonLinkActive = size === "lg";
 
   const typedEl = useRef<HTMLSpanElement>(null);
 
@@ -120,11 +114,6 @@ const Home = () => {
   return (
     <>
       <SolarOverlays />
-      {/* The moon doubles as the Zip brand-video link here too (overlay +
-          popover); `video-mode` on <body> hides the rest of the page */}
-      {moonLinkActive && (
-        <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
-      )}
       <div className="homePageBackLink">
         <Link
           className={cx("mt-4 flex items-center gap-1 transition-transform")}

--- a/src/Resume.tsx
+++ b/src/Resume.tsx
@@ -107,7 +107,7 @@ const Resume = () => {
     <>
       {/* On phones the Home link takes the same corner slot and sizing as
           /home's "Back to orbit" link, outside the scroller so it stays
-          put (body.video-mode hides .homePageBackLink, same as on /home) */}
+          put (body.video-mode hides .homePageBackLink) */}
       {isSmall && (
         <div
           className="homePageBackLink"
@@ -128,9 +128,8 @@ const Resume = () => {
             Not on phones: the panel is full-bleed there and the moon sits
             behind it (CameraRig's aboutMoonNdcX returns null), so the
             invisible overlay would just be a 165px tap trap over the intro
-            paragraph and whatever scrolls under it. Home gates it the same
-            way (moonLinkActive); SolarScene drops the moon's link halo to
-            match. */}
+            paragraph and whatever scrolls under it. SolarScene drops the
+            moon's link halo to match. */}
         {!isSmall && (
           <ZipVideoMoon open={videoOpen} onOpenChange={setVideoOpen} />
         )}

--- a/src/SolarOverlays.tsx
+++ b/src/SolarOverlays.tsx
@@ -129,8 +129,8 @@ const SolarOverlays = () => {
           </TooltipProvider>
         ))}
       {/* The rocket (spaceship) link is parked until the /journey copy is
-          ready — the ship still flies in the scene, it just isn't clickable.
-          Restore this block (and the startRocketJourney import) to re-arm it.
+          ready — the ship itself is parked too (SolarScene). Restore this
+          block (and the startRocketJourney import) to re-arm it.
          The rocket easter egg: clicking it boards the ship and warps to
           the /journey story crawl (rocketJourney.ts flips the route under
           the warp flash). Same anchor plumbing as the asteroid links.

--- a/src/ZipVideoMoon.tsx
+++ b/src/ZipVideoMoon.tsx
@@ -7,22 +7,18 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./ui/tooltip";
-import {
-  MOON_VIDEO_LINK_ID,
-  MOON_VIDEO_OUTLINE_ID,
-} from "./solarAnchorIds";
+import { MOON_VIDEO_LINK_ID, MOON_VIDEO_OUTLINE_ID } from "./solarAnchorIds";
 import { BodyOutline } from "./SolarOverlays";
 import { hoverState } from "./solarHover";
 
 /**
- * The moon as a video link, on /about and /home: an invisible overlay that
+ * The moon as a video link on /about: an invisible overlay that
  * BodyAnchors glues to the moon's projection (same plumbing as the
  * asteroid links), with a tooltip and the shared pulsing hover outline.
  * Clicking it opens the Zip brand-redesign launch reel in a ~80vw popover;
  * `video-mode` on <body> hides everything but the stars behind it
  * (App.scss), and Resume additionally hides its own panel via the lifted
- * `open` state. Both routes own that state, so neither can mount this
- * twice — and only one route is mounted at a time anyway.
+ * `open` state it owns.
  *
  * While the popover is open the overlay itself is unmounted — BodyAnchors
  * skips absent elements, so there's nothing left hovering over the video.

--- a/src/solarAnchorIds.ts
+++ b/src/solarAnchorIds.ts
@@ -8,9 +8,8 @@ export const EARTH_ABOUT_RING_ID = "earth-about-ring";
 /** Group inside the /about ring holding Earth's hover-outline paths;
  *  Planet writes Earth's projected silhouette into every path under it. */
 export const EARTH_ABOUT_OUTLINE_ID = "earth-about-outline";
-/** The moon's video-link overlay on /about and /home (rendered by Resume
- *  and Home) and the group holding its hover-outline paths (written by
- *  Moon). Only one route mounts at a time, so the id stays unique. */
+/** The moon's video-link overlay on /about (rendered by Resume) and the
+ *  group holding its hover-outline paths (written by Moon). */
 export const MOON_VIDEO_LINK_ID = "moon-video-link";
 export const MOON_VIDEO_OUTLINE_ID = "moon-video-outline";
 export const asteroidAnchorId = (name: string) => `asteroid-link-${name}`;

--- a/src/solarHover.ts
+++ b/src/solarHover.ts
@@ -8,7 +8,7 @@
 export const hoverState = {
   sun: false,
   earth: false,
-  /** The moon's video-link overlay on /about and /home */
+  /** The moon's video-link overlay on /about */
   moon: false,
   /** Name of the hovered link asteroid (constants.ts ASTEROIDS), or null */
   asteroid: null as string | null,

--- a/src/space3d/solar/BodyAnchors.tsx
+++ b/src/space3d/solar/BodyAnchors.tsx
@@ -67,7 +67,7 @@ const ANCHORS: BodyAnchorConfig[] = [
     fadeInOnArrival: true,
   },
   {
-    // The moon's video link (the overlay exists on /about and /home)
+    // The moon's video link (the overlay exists on /about)
     domId: MOON_VIDEO_LINK_ID,
     position: (t, out) => moonPosition(t, out),
     radius: MOON.radius,

--- a/src/space3d/solar/CameraRig.tsx
+++ b/src/space3d/solar/CameraRig.tsx
@@ -13,7 +13,7 @@ import { SYNTH_CAM_HEIGHT, SYNTH_ORIGIN } from "../../synthSpec";
  * above the sun (the system reads as a flat orbital diagram). Home
  * perches just over the SUN's limb looking out toward Earth, so the
  * sun's top curve fills the bottom of the frame with mostly stars above
- * and Earth (moon alongside) hanging small in the middle distance. About
+ * and Earth hanging small in the middle distance. About
  * perches over EARTH's limb opposite the moon and rides the moon's
  * orbit, so Earth's top curve fills the foreground with the moon pinned
  * in view above-right of it. View changes swoop between the views over
@@ -178,7 +178,7 @@ function computeGoal(
   } else {
     // Perch just over the sun's limb on the far side from Earth, looking
     // out at the stars: the sun's top curve fills the bottom of the frame
-    // and Earth (with its moon) hangs small in the middle distance.
+    // and Earth hangs small in the middle distance.
     planetPosition(EARTH, t, earthPos);
     toEarth.copy(earthPos).normalize();
     side.crossVectors(toEarth, UP).normalize();

--- a/src/space3d/solar/Moon.tsx
+++ b/src/space3d/solar/Moon.tsx
@@ -5,6 +5,7 @@ import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 
 import { EARTH, MOON, planetPosition } from "./constants";
 import { applyOffAxisSquash } from "./offAxisSquash";
+import { JOURNEY_STOPS, scrollTransitionState } from "../../scrollTransition";
 import { MOON_VIDEO_OUTLINE_ID } from "../../solarAnchorIds";
 import { writeSilhouette } from "./outline";
 import { createLogoBadgeTexture } from "../textures";
@@ -22,13 +23,17 @@ import moonMapUrl from "../../assets/moon.jpg";
  * emissive) so the /about camera — which perches over the moon's far side
  * — still reads it when that face is turned away from the sun.
  *
- * On /about and /home the moon doubles as a video link (the Zip
- * brand-launch reel — see ZipVideoMoon): movie-camera badges are decaled
- * onto the surface, and hovering the DOM overlay brightens the moon and
- * pulses its silhouette outline, matching the other link bodies. It is
- * absent from the landing view entirely (SolarScene gates `revealed`).
+ * On /about the moon doubles as a video link (the Zip brand-launch reel —
+ * see ZipVideoMoon): movie-camera badges are decaled onto the surface, and
+ * hovering the DOM overlay brightens the moon and pulses its silhouette
+ * outline, matching the other link bodies. It is absent from the landing
+ * and home views (SolarScene gates `revealed` to /about) and fades in on
+ * the way there: a link swoop flips `revealed`, and the scroll scrub is
+ * read straight from the journey progress, so the moon materializes as
+ * the visitor scrolls out from home instead of popping in on arrival.
  */
-/** Fade duration for the landing-intro reveal */
+/** Fade duration for the reveal — the link swoop's fade, and how closely
+ *  the opacity trails a fast scroll scrub */
 const REVEAL_SECONDS = 0.8;
 
 /** Movie-camera badges around the equator: 3 at 120° apart, so from any
@@ -46,10 +51,11 @@ export default function Moon({
 }: {
   orbitColor: string;
   orbitOpacity: number;
-  /** Fades the moon + its orbit ring in (landing intro) */
+  /** Shows the moon + its orbit ring (the about view). While off, the
+   *  moon still follows the home→about scroll scrub (see the useFrame). */
   revealed?: boolean;
-  /** The video link only exists on /about and /home — gate the clickable
-   *  halo to the views whose overlay is mounted */
+  /** The video link only exists on /about — gate the clickable halo to
+   *  the view whose overlay is mounted */
   linkActive?: boolean;
 }) {
   const earthGroup = useRef<THREE.Group>(null);
@@ -169,11 +175,24 @@ export default function Moon({
       mesh.current.rotation.y += delta * MOON.spinSpeed;
     }
 
-    // Landing-intro reveal: fade the moon + its orbit ring in with the planets
-    revealOpacity.current = THREE.MathUtils.clamp(
-      revealOpacity.current + (revealed ? delta : -delta) / REVEAL_SECONDS,
+    // Reveal: the about view shows the moon + its orbit ring; elsewhere it
+    // tracks the home→about scroll scrub (0 at the home stop, 1 on
+    // arrival) so it fades in along the ride — the /about route only
+    // commits once the camera has all but arrived, which would otherwise
+    // pop the moon in at the very end. A link swoop teleports the progress
+    // to the about stop, so that path simply eases in over REVEAL_SECONDS.
+    const scrubReveal = THREE.MathUtils.clamp(
+      (scrollTransitionState.progress - JOURNEY_STOPS.home) /
+        (JOURNEY_STOPS.about - JOURNEY_STOPS.home),
       0,
       1,
+    );
+    const revealTarget = revealed ? 1 : scrubReveal;
+    const maxStep = delta / REVEAL_SECONDS;
+    revealOpacity.current += THREE.MathUtils.clamp(
+      revealTarget - revealOpacity.current,
+      -maxStep,
+      maxStep,
     );
     if (surfaceMaterial.current) {
       surfaceMaterial.current.opacity = revealOpacity.current;

--- a/src/space3d/solar/SolarScene.tsx
+++ b/src/space3d/solar/SolarScene.tsx
@@ -7,7 +7,6 @@ import Moon from "./Moon";
 import Sun from "./Sun";
 import Asteroid from "./Asteroid";
 import Satellite from "./Satellite";
-import Rocket from "./Rocket";
 import DrumPad from "./DrumPad";
 import RocketJourney from "./RocketJourney";
 import JourneyCruise from "./JourneyCruise";
@@ -55,11 +54,10 @@ const SolarScene = ({
   const isCompact = width < 1280;
   const isPhone = width < 768;
   // Below the lg breakpoint (useWindowSize's 1000px) the home view drops
-  // its redundant chrome — the link trio duplicates the icon buttons and
-  // the moon crowds Earth — so the perch keeps some breathing room.
-  // SolarOverlays hides the trio's click targets to match.
+  // its redundant link trio — it duplicates the icon buttons — so the
+  // perch keeps some breathing room. SolarOverlays hides the trio's click
+  // targets to match.
   const isNarrow = width < 1000;
-  const hideHomeExtras = view === "home" && isNarrow;
   useEffect(() => {
     layoutState.compact = isCompact;
   }, [isCompact]);
@@ -128,40 +126,38 @@ const SolarScene = ({
           closeUp={view === "about"}
         />
       ))}
-      {/* No moon on the landing view: from the top-down framing it reads as
-          a stray speck beside Earth rather than a body, and its orbit ring
-          crosses Earth's. It fades in on the way to the home perch, where
-          there's room to read it — and where it becomes the video link. */}
+      {/* The moon is an /about-only body: from the landing's top-down
+          framing it reads as a stray speck beside Earth rather than a body
+          (and its orbit ring crosses Earth's), and from the home perch it
+          only crowds Earth. It fades in on the way to the about perch —
+          along the scroll scrub as well as the timed swoop (Moon reads the
+          journey progress itself) — where it becomes the video link. */}
       <Moon
         orbitColor={isNightMode ? "#ffffff" : "#141428"}
         orbitOpacity={isNightMode ? 0.28 : 0.2}
-        revealed={planetsRevealed && !hideHomeExtras && !isLanding}
+        revealed={view === "about"}
         // The video link needs the moon actually on screen AND clickable:
         // /about above phone widths (on phones the panel is full-bleed
         // and Resume doesn't mount the overlay — the moon hides behind
-        // the resume), /home only at the widths where hideHomeExtras
-        // keeps it
-        linkActive={
-          (view === "about" && !isPhone) || (view === "home" && !hideHomeExtras)
-        }
+        // the resume)
+        linkActive={view === "about" && !isPhone}
       />
       {/* Link bodies — home view only: on landing they'd read as clutter
           around the sun, and on /about their DOM overlays don't exist, so
           the rocks would be dead weight drifting near the sun. They fade
           in on the way to the home perch. GitHub gets the Sputnik
           satellite, the rest are rocks. */}
-      {ASTEROIDS.map((asteroid) =>
-        asteroid.name === "github" ? (
+      {ASTEROIDS.map((asteroid) => {
+        // The rocket (spaceship) is parked along with its overlay link
+        // (SolarOverlays) until the /journey copy is ready. Restore this
+        // (and the Rocket import) to fly it again:
+        //   <Rocket key={asteroid.name} config={asteroid} visible={view === "home"} />
+        if (asteroid.name === "rocket") return null;
+        return asteroid.name === "github" ? (
           <Satellite
             key={asteroid.name}
             config={asteroid}
             visible={view === "home" && !isNarrow}
-          />
-        ) : asteroid.name === "rocket" ? (
-          <Rocket
-            key={asteroid.name}
-            config={asteroid}
-            visible={view === "home"}
           />
         ) : asteroid.name === "synthpad" ? (
           <DrumPad
@@ -177,8 +173,8 @@ const SolarScene = ({
             config={asteroid}
             visible={view === "home" && !isNarrow}
           />
-        ),
-      )}
+        );
+      })}
       {/* The second solar system, far below this one: six knob-planets
           around a beat-pulsing sun (the space synth) */}
       {view === "synth" && <SynthSystem isNightMode={isNightMode} />}


### PR DESCRIPTION
Parks the rocket ship along with its already-commented-out link, and makes the moon an /about-only body — it no longer shows on /home and fades in on the way to the about perch.

- `SolarScene`: the `rocket` asteroid now returns `null` from the link-body map (the restore note and the dropped `Rocket` import are right there); the moon's `revealed` / `linkActive` are gated to `view === "about"`, and `hideHomeExtras` goes away since the moon was its only user
- `Moon`: the reveal target also follows `scrollTransitionState.progress` across the home→about segment, so a scroll-scrubbed trip fades the moon in along the ride instead of popping it in when the route commits on arrival; a link swoop (ABOUT ME) teleports progress to the about stop, so that path just eases in over the existing 0.8s
- `Home` drops its `ZipVideoMoon` mount (it'd be an invisible tap target glued to an invisible moon), and `App.scss` drops the home-only chrome from `body.video-mode` to match
- comment sweeps for "/about and /home" → "/about" in `ZipVideoMoon`, `solarAnchorIds`, `solarHover`, `BodyAnchors`, `Resume`, `CameraRig`
- knip now flags `Rocket`'s default export, same parked-easter-egg bucket as `startRocketJourney`