### PR TITLE
[draw] bigger named gallery cards, Home link with a sun; galaxy icon on /home's back link

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2782,7 +2782,7 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
   }
 }
 
-// Recent transmissions — the gallery of everyone's drawings
+// Past submissions — the gallery of everyone's drawings
 .svg-generator-gallery {
   width: 100%;
   margin-top: 40px;
@@ -2802,10 +2802,21 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
   gap: 10px;
+
+  // From the md breakpoint up the 720px column fits four ~150px previews
+  // instead of six ~95px ones — big enough to actually read a drawing
+  @media (min-width: $breakpoint-md) {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+  }
 }
 
 .svg-generator-gallery-card {
   display: block;
+  // Grid items default to min-width: auto, so a long nowrap prompt would
+  // widen its track instead of truncating — let the card shrink to the
+  // track and the text lines below do the ellipsizing
+  min-width: 0;
   padding: 8px;
   // Stays dark in both palettes — the drawings are composed for a night sky
   background: rgba(0, 0, 0, 0.45);
@@ -2833,15 +2844,31 @@ $dns-ease: cubic-bezier(0.45, 0.05, 0.25, 1.2);
   }
 }
 
+// The drawing's name (its prompt) leads the caption, the artist trails
+.svg-generator-gallery-prompt,
 .svg-generator-gallery-name {
-  margin: 6px 0 0;
   font-family: "Inconsolata", monospace;
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.55);
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.svg-generator-gallery-prompt {
+  margin: 8px 0 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.92);
+
+  @media (min-width: $breakpoint-md) {
+    font-size: 13px;
+  }
+}
+
+.svg-generator-gallery-name {
+  margin: 2px 0 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 // The catch-all 404 (NotFound.tsx) — a lone beacon in the starfield

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,11 +3,12 @@ import Typed from "typed.js";
 import cx from "classnames";
 
 import { GitHub, Linkedin, Mail } from "react-feather";
-import { ArrowLeftCircleIcon, PenLine, Wand2 } from "lucide-react";
+import { PenLine, Wand2 } from "lucide-react";
 import useWindowSize from "./useWindowSize";
 import useScrollJourney from "./useScrollJourney";
 import SolarOverlays from "./SolarOverlays";
 import ScrollHint from "./ScrollHint";
+import GalaxyIcon from "./ui/GalaxyIcon";
 import { JOURNEY_STOPS } from "./scrollTransition";
 
 import {
@@ -119,7 +120,7 @@ const Home = () => {
           className={cx("mt-4 flex items-center gap-1 transition-transform")}
           to="/"
         >
-          <ArrowLeftCircleIcon className="starIcon" size={16} />
+          <GalaxyIcon aria-hidden="true" className="starIcon" size={16} />
           <span>Back to orbit</span>
         </Link>
       </div>

--- a/src/SvgGenerator.tsx
+++ b/src/SvgGenerator.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { Star } from "react-feather";
+import { Sun } from "react-feather";
 import { Check, Link2, Wand2 } from "lucide-react";
 
 const DRAWABLE_SELECTORS =
@@ -291,7 +291,7 @@ const SvgGenerator = () => {
     };
   }, [routeId]);
 
-  // The gallery of recent transmissions — decoration, so it fails quietly
+  // The gallery of past submissions — decoration, so it fails quietly
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -412,10 +412,10 @@ const SvgGenerator = () => {
       <div className="svg-generator-back-link">
         <Link
           className="mt-4 flex items-center gap-1 transition-transform"
-          to="/"
+          to="/home"
         >
-          <Star aria-hidden="true" className="starIcon" size={16} />
-          <span>back to orbit</span>
+          <Sun aria-hidden="true" className="starIcon" size={16} />
+          <span>Home</span>
         </Link>
       </div>
 
@@ -522,12 +522,10 @@ const SvgGenerator = () => {
           )}
         </div>
 
-        {/* Recent transmissions */}
+        {/* Past submissions — everyone's drawings, newest first */}
         {gallery.length > 0 && (
           <div className="svg-generator-gallery">
-            <h2 className="svg-generator-gallery-title">
-              recent transmissions
-            </h2>
+            <h2 className="svg-generator-gallery-title">past submissions</h2>
             <div className="svg-generator-gallery-grid">
               {gallery.map((d) => (
                 <Link
@@ -539,7 +537,15 @@ const SvgGenerator = () => {
                   <div className="svg-generator-gallery-thumb">
                     <img alt={d.prompt} src={toDataUri(d.svg)} loading="lazy" />
                   </div>
-                  <p className="svg-generator-gallery-name">{d.name}</p>
+                  {/* The drawing's name (its prompt) leads, the artist
+                      trails; both are one line with the full text in
+                      `title` for when they're cut short */}
+                  <p className="svg-generator-gallery-prompt" title={d.prompt}>
+                    {d.prompt}
+                  </p>
+                  <p className="svg-generator-gallery-name" title={d.name}>
+                    by {d.name}
+                  </p>
                 </Link>
               ))}
             </div>

--- a/src/ui/GalaxyIcon.tsx
+++ b/src/ui/GalaxyIcon.tsx
@@ -1,0 +1,34 @@
+import { createLucideIcon } from "lucide-react";
+
+/**
+ * A spiral galaxy for the home page's "Back to orbit" link. lucide has no
+ * galaxy, so this one is drawn on lucide's own chassis (24-unit grid, 2px
+ * round strokes) via `createLucideIcon` — it sits flush with the other
+ * back-link icons and takes the same `size` / `className` props. The arms
+ * pin their own `fill="none"` so the link's hover fill (App.scss
+ * `.starIcon`) lights up just the core and the two stars, not the space
+ * between the arms.
+ */
+const GalaxyIcon = createLucideIcon("galaxy", [
+  ["circle", { cx: "12", cy: "12", r: "1.5", key: "core" }],
+  [
+    "path",
+    {
+      d: "M14.6 12.0C14.6 12.3 14.8 13.4 14.5 14.0C14.2 14.6 13.5 15.4 12.8 15.7C12.0 16.0 10.9 16.1 10.0 15.9C9.2 15.6 8.1 14.9 7.5 14.0C7.0 13.1 6.5 11.7 6.7 10.6C6.8 9.4 8.1 7.7 8.4 7.1",
+      fill: "none",
+      key: "arm-1",
+    },
+  ],
+  [
+    "path",
+    {
+      d: "M9.4 12.0C9.4 11.7 9.2 10.6 9.5 10.0C9.8 9.4 10.5 8.6 11.2 8.3C12.0 8.0 13.1 7.9 14.0 8.1C14.8 8.4 15.9 9.1 16.5 10.0C17.0 10.9 17.5 12.3 17.3 13.4C17.2 14.6 15.9 16.3 15.6 16.9",
+      fill: "none",
+      key: "arm-2",
+    },
+  ],
+  ["circle", { cx: "19", cy: "5", r: "1", key: "star-1" }],
+  ["circle", { cx: "5", cy: "19", r: "1", key: "star-2" }],
+]);
+
+export default GalaxyIcon;


### PR DESCRIPTION
Reworks the /draw gallery into "past submissions" with bigger cards that name each drawing, re-points the page's back link at /home, and swaps the home page's "Back to orbit" arrow for a galaxy.

- gallery cards: from the md breakpoint up (1000px, ≈ Tailwind `lg`) the 720px column holds four ~150px previews instead of six ~95px ones; `min-width: 0` on the card so a long prompt truncates instead of widening its grid track
- each card now leads with the drawing's name (its prompt, bold) over "by {artist}" — both single-line ellipsized with the full text in `title`; the card-level title stays for the thumbnail hover
- "recent transmissions" → "past submissions"
- /draw back link: `to="/home"`, says "Home", feather `Sun` instead of the star (the existing hover fill lights the sun's core)
- /home "Back to orbit": new `src/ui/GalaxyIcon.tsx`, a spiral galaxy built with lucide's `createLucideIcon` (lucide has no galaxy icon — checked through 1.33) so it matches the other 16px back-link icons; the arms pin `fill="none"` so the hover fill only lights the core and the two stars